### PR TITLE
Adds profiles to adjust cache sizes/db opts

### DIFF
--- a/config.json
+++ b/config.json
@@ -76,7 +76,6 @@
   "db": {
     "path": "mainnetdb"
   },
-  "light": false,
   "localsnapshots": {
     "path": "latest-export.gz.bin"
   },

--- a/config.json
+++ b/config.json
@@ -1,4 +1,39 @@
 {
+  "useProfile": "default",
+  "profiles": {
+    "custom": {
+      "caches": {
+        "requestQueue": 100000,
+        "approvers": 100000,
+        "bundles": 20000,
+        "milestones": 1000,
+        "spentAddresses": 5000,
+        "transactions": 50000,
+        "incomingTransactionFilter": 5000,
+        "refsInvalidBundle": 10000
+      },
+      "badger": {
+        "levelOneSize": 268435456,
+        "levelSizeMultiplier": 10,
+        "tableLoadingMode": 2,
+        "valueLogLoadingMode": 2,
+        "maxLevels": 7,
+        "maxTableSize": 67108864,
+        "numCompactors": 2,
+        "numLevelZeroTables": 5,
+        "numLevelZeroTablesStall": 10,
+        "numMemtables": 5,
+        "numVersionsToKeep": 1,
+        "syncWrites": true,
+        "compactLevel0OnClose": true,
+        "valueLogFileSize": 1073741823,
+        "valueLogMaxEntries": 1000000,
+        "valueThreshold": 32,
+        "logRotatesToFlush": 2,
+        "maxCacheSize": 50000000
+      }
+    }
+  },
   "api": {
     "auth": {
       "password": "",

--- a/config.json
+++ b/config.json
@@ -7,7 +7,8 @@
           "size": 100000
         },
         "approvers": {
-          "size": 100000
+          "size": 100000,
+          "evictionSize": 1000
         },
         "bundles": {
           "size": 20000,
@@ -18,7 +19,8 @@
           "evictionSize": 100
         },
         "spentAddresses": {
-          "size": 5000
+          "size": 5000,
+          "evictionSize": 1000
         },
         "transactions": {
           "size": 50000,

--- a/config.json
+++ b/config.json
@@ -3,14 +3,33 @@
   "profiles": {
     "custom": {
       "caches": {
-        "requestQueue": 100000,
-        "approvers": 100000,
-        "bundles": 20000,
-        "milestones": 1000,
-        "spentAddresses": 5000,
-        "transactions": 50000,
-        "incomingTransactionFilter": 5000,
-        "refsInvalidBundle": 10000
+        "requestQueue": {
+          "size": 100000
+        },
+        "approvers": {
+          "size": 100000
+        },
+        "bundles": {
+          "size": 20000,
+          "evictionSize": 1000
+        },
+        "milestones": {
+          "size": 1000,
+          "evictionSize": 100
+        },
+        "spentAddresses": {
+          "size": 5000
+        },
+        "transactions": {
+          "size": 50000,
+          "evictionSize": 1000
+        },
+        "incomingTransactionFilter": {
+          "size": 5000
+        },
+        "refsInvalidBundle": {
+          "size": 10000
+        }
       },
       "badger": {
         "levelOneSize": 268435456,

--- a/packages/model/queue/request_queue.go
+++ b/packages/model/queue/request_queue.go
@@ -1,19 +1,18 @@
 package queue
 
 import (
-	"github.com/gohornet/hornet/packages/datastructure"
-	"github.com/gohornet/hornet/packages/model/milestone_index"
-	"github.com/gohornet/hornet/packages/typeutils"
 	"time"
 
-	"github.com/iotaledger/iota.go/trinary"
-
+	"github.com/gohornet/hornet/packages/datastructure"
+	"github.com/gohornet/hornet/packages/model/milestone_index"
+	"github.com/gohornet/hornet/packages/profile"
 	"github.com/gohornet/hornet/packages/syncutils"
+	"github.com/gohornet/hornet/packages/typeutils"
+	"github.com/iotaledger/iota.go/trinary"
 )
 
 const (
-	RequestQueueRequestesCacheSize = 100000
-	RequestQueueTickerInterval     = 2 * time.Second
+	RequestQueueTickerInterval = 2 * time.Second
 )
 
 type RequestQueue struct {
@@ -28,7 +27,7 @@ type RequestQueue struct {
 func NewRequestQueue() *RequestQueue {
 
 	queue := &RequestQueue{
-		requestedCache: datastructure.NewLRUCache(RequestQueueRequestesCacheSize),
+		requestedCache: datastructure.NewLRUCache(profile.GetProfile().Caches.RequestQueue),
 		ticker:         time.NewTicker(RequestQueueTickerInterval),
 		tickerDone:     make(chan bool),
 	}

--- a/packages/model/queue/request_queue.go
+++ b/packages/model/queue/request_queue.go
@@ -27,7 +27,7 @@ type RequestQueue struct {
 func NewRequestQueue() *RequestQueue {
 
 	queue := &RequestQueue{
-		requestedCache: datastructure.NewLRUCache(profile.GetProfile().Caches.RequestQueue),
+		requestedCache: datastructure.NewLRUCache(profile.GetProfile().Caches.RequestQueue.Size),
 		ticker:         time.NewTicker(RequestQueueTickerInterval),
 		tickerDone:     make(chan bool),
 	}

--- a/packages/model/tangle/approvers.go
+++ b/packages/model/tangle/approvers.go
@@ -21,7 +21,7 @@ func NewApprovers(hash trinary.Hash) *Approvers {
 }
 
 func GetApprovers(hash trinary.Hash) (result *Approvers, err error) {
-	if cacheResult := approversCache.ComputeIfAbsent(hash, func() interface{} {
+	if cacheResult := ApproversCache.ComputeIfAbsent(hash, func() interface{} {
 		approvers, dbErr := readApproversForTransactionFromDatabase(hash)
 		if dbErr == nil {
 			return approvers
@@ -35,7 +35,7 @@ func GetApprovers(hash trinary.Hash) (result *Approvers, err error) {
 }
 
 func DiscardApproversFromCache(hash trinary.Hash) {
-	approversCache.DeleteWithoutEviction(hash)
+	ApproversCache.DeleteWithoutEviction(hash)
 }
 
 func (approvers *Approvers) Add(transactionHash trinary.Hash) {

--- a/packages/model/tangle/approvers_cache.go
+++ b/packages/model/tangle/approvers_cache.go
@@ -11,7 +11,7 @@ var (
 )
 
 func InitApproversCache() {
-	approversCache = datastructure.NewLRUCache(profile.GetProfile().Caches.Approvers, &datastructure.LRUCacheOptions{
+	approversCache = datastructure.NewLRUCache(profile.GetProfile().Caches.Approvers.Size, &datastructure.LRUCacheOptions{
 		EvictionCallback:  onEvictApprovers,
 		EvictionBatchSize: 1000,
 	})

--- a/packages/model/tangle/approvers_cache.go
+++ b/packages/model/tangle/approvers_cache.go
@@ -2,6 +2,7 @@ package tangle
 
 import (
 	"github.com/gohornet/hornet/packages/datastructure"
+	"github.com/gohornet/hornet/packages/profile"
 )
 
 var (
@@ -10,7 +11,7 @@ var (
 )
 
 func InitApproversCache() {
-	approversCache = datastructure.NewLRUCache(ApproversCacheSize, &datastructure.LRUCacheOptions{
+	approversCache = datastructure.NewLRUCache(profile.GetProfile().Caches.Approvers, &datastructure.LRUCacheOptions{
 		EvictionCallback:  onEvictApprovers,
 		EvictionBatchSize: 1000,
 	})

--- a/packages/model/tangle/approvers_cache.go
+++ b/packages/model/tangle/approvers_cache.go
@@ -7,13 +7,14 @@ import (
 
 var (
 	// Transactions that approve a certain TxHash
-	approversCache *datastructure.LRUCache
+	ApproversCache *datastructure.LRUCache
 )
 
 func InitApproversCache() {
-	approversCache = datastructure.NewLRUCache(profile.GetProfile().Caches.Approvers.Size, &datastructure.LRUCacheOptions{
+	opts := profile.GetProfile().Caches.Approvers
+	ApproversCache = datastructure.NewLRUCache(opts.Size, &datastructure.LRUCacheOptions{
 		EvictionCallback:  onEvictApprovers,
-		EvictionBatchSize: 1000,
+		EvictionBatchSize: opts.EvictionSize,
 	})
 }
 
@@ -31,5 +32,5 @@ func onEvictApprovers(_ interface{}, values interface{}) {
 }
 
 func FlushApproversCache() {
-	approversCache.DeleteAll()
+	ApproversCache.DeleteAll()
 }

--- a/packages/model/tangle/bundle_bucket_cache.go
+++ b/packages/model/tangle/bundle_bucket_cache.go
@@ -2,6 +2,7 @@ package tangle
 
 import (
 	"github.com/gohornet/hornet/packages/datastructure"
+	"github.com/gohornet/hornet/packages/profile"
 )
 
 var (
@@ -9,7 +10,7 @@ var (
 )
 
 func InitBundleCache() {
-	bundleBucketCache = datastructure.NewLRUCache(BundleCacheSize, &datastructure.LRUCacheOptions{
+	bundleBucketCache = datastructure.NewLRUCache(profile.GetProfile().Caches.Bundles, &datastructure.LRUCacheOptions{
 		EvictionCallback:  onEvictBundles,
 		EvictionBatchSize: 1000,
 	})

--- a/packages/model/tangle/bundle_bucket_cache.go
+++ b/packages/model/tangle/bundle_bucket_cache.go
@@ -10,9 +10,10 @@ var (
 )
 
 func InitBundleCache() {
-	bundleBucketCache = datastructure.NewLRUCache(profile.GetProfile().Caches.Bundles, &datastructure.LRUCacheOptions{
+	opts := profile.GetProfile().Caches.Bundles
+	bundleBucketCache = datastructure.NewLRUCache(opts.Size, &datastructure.LRUCacheOptions{
 		EvictionCallback:  onEvictBundles,
-		EvictionBatchSize: 1000,
+		EvictionBatchSize: opts.EvictionSize,
 	})
 }
 

--- a/packages/model/tangle/milestones_cache.go
+++ b/packages/model/tangle/milestones_cache.go
@@ -11,9 +11,10 @@ var (
 )
 
 func InitMilestoneCache() {
-	milestoneCache = datastructure.NewLRUCache(profile.GetProfile().Caches.Milestones, &datastructure.LRUCacheOptions{
+	opts := profile.GetProfile().Caches.Milestones
+	milestoneCache = datastructure.NewLRUCache(opts.Size, &datastructure.LRUCacheOptions{
 		EvictionCallback:  onEvictMilestones,
-		EvictionBatchSize: 100,
+		EvictionBatchSize: opts.EvictionSize,
 	})
 }
 

--- a/packages/model/tangle/milestones_cache.go
+++ b/packages/model/tangle/milestones_cache.go
@@ -3,6 +3,7 @@ package tangle
 import (
 	"github.com/gohornet/hornet/packages/datastructure"
 	"github.com/gohornet/hornet/packages/model/milestone_index"
+	"github.com/gohornet/hornet/packages/profile"
 )
 
 var (
@@ -10,7 +11,7 @@ var (
 )
 
 func InitMilestoneCache() {
-	milestoneCache = datastructure.NewLRUCache(MilestoneCacheSize, &datastructure.LRUCacheOptions{
+	milestoneCache = datastructure.NewLRUCache(profile.GetProfile().Caches.Milestones, &datastructure.LRUCacheOptions{
 		EvictionCallback:  onEvictMilestones,
 		EvictionBatchSize: 100,
 	})

--- a/packages/model/tangle/spent.go
+++ b/packages/model/tangle/spent.go
@@ -1,8 +1,9 @@
 package tangle
 
 import (
-	"github.com/iotaledger/iota.go/trinary"
 	"github.com/gohornet/hornet/packages/datastructure"
+	"github.com/gohornet/hornet/packages/profile"
+	"github.com/iotaledger/iota.go/trinary"
 )
 
 var (
@@ -23,7 +24,7 @@ func MarkAddressAsSpent(address trinary.Hash) {
 }
 
 func InitSpentAddressesCache() {
-	spentAddressesCache = datastructure.NewLRUCache(SpentAddressesCacheSize, &datastructure.LRUCacheOptions{
+	spentAddressesCache = datastructure.NewLRUCache(profile.GetProfile().Caches.SpentAddresses, &datastructure.LRUCacheOptions{
 		EvictionCallback:  onEvictSpentAddress,
 		EvictionBatchSize: 1000,
 	})

--- a/packages/model/tangle/spent.go
+++ b/packages/model/tangle/spent.go
@@ -24,9 +24,10 @@ func MarkAddressAsSpent(address trinary.Hash) {
 }
 
 func InitSpentAddressesCache() {
-	spentAddressesCache = datastructure.NewLRUCache(profile.GetProfile().Caches.SpentAddresses, &datastructure.LRUCacheOptions{
+	opts := profile.GetProfile().Caches.SpentAddresses
+	spentAddressesCache = datastructure.NewLRUCache(opts.Size, &datastructure.LRUCacheOptions{
 		EvictionCallback:  onEvictSpentAddress,
-		EvictionBatchSize: 1000,
+		EvictionBatchSize: opts.EvictionSize,
 	})
 }
 

--- a/packages/model/tangle/tangle.go
+++ b/packages/model/tangle/tangle.go
@@ -2,16 +2,8 @@ package tangle
 
 import "github.com/gohornet/hornet/packages/database"
 
-const (
-	BundleCacheSize         = 20000
-	MilestoneCacheSize      = 1000
-	TransactionCacheSize    = 50000
-	ApproversCacheSize      = 100000
-	SpentAddressesCacheSize = 5000
-)
-
-func ConfigureDatabases(directory string, light bool) {
-	database.Settings(directory, light)
+func ConfigureDatabases(directory string) {
+	database.Settings(directory)
 	configureHealthDatabase()
 	configureTransactionDatabase()
 	configureBundleDatabase()

--- a/packages/model/tangle/transaction_cache.go
+++ b/packages/model/tangle/transaction_cache.go
@@ -1,9 +1,10 @@
 package tangle
 
 import (
-	"github.com/iotaledger/iota.go/trinary"
 	"github.com/gohornet/hornet/packages/datastructure"
 	"github.com/gohornet/hornet/packages/model/hornet"
+	"github.com/gohornet/hornet/packages/profile"
+	"github.com/iotaledger/iota.go/trinary"
 )
 
 var (
@@ -12,7 +13,7 @@ var (
 )
 
 func InitTransactionCache(notifyCallback func(notifyStoredTx []*hornet.Transaction)) {
-	transactionCache = datastructure.NewLRUCache(TransactionCacheSize, &datastructure.LRUCacheOptions{
+	transactionCache = datastructure.NewLRUCache(profile.GetProfile().Caches.Transactions, &datastructure.LRUCacheOptions{
 		EvictionCallback:  onEvictTransactions,
 		EvictionBatchSize: 1000,
 	})

--- a/packages/model/tangle/transaction_cache.go
+++ b/packages/model/tangle/transaction_cache.go
@@ -13,9 +13,10 @@ var (
 )
 
 func InitTransactionCache(notifyCallback func(notifyStoredTx []*hornet.Transaction)) {
-	transactionCache = datastructure.NewLRUCache(profile.GetProfile().Caches.Transactions, &datastructure.LRUCacheOptions{
+	opts := profile.GetProfile().Caches.Transactions
+	transactionCache = datastructure.NewLRUCache(opts.Size, &datastructure.LRUCacheOptions{
 		EvictionCallback:  onEvictTransactions,
-		EvictionBatchSize: 1000,
+		EvictionBatchSize: opts.EvictionSize,
 	})
 	evictionNotifyCallback = notifyCallback
 }

--- a/packages/profile/parameters.go
+++ b/packages/profile/parameters.go
@@ -1,0 +1,7 @@
+package profile
+
+import flag "github.com/spf13/pflag"
+
+func init() {
+	flag.String("useProfile", "default", "Sets the profile with which the node runs")
+}

--- a/packages/profile/profile.go
+++ b/packages/profile/profile.go
@@ -1,0 +1,142 @@
+package profile
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/dgraph-io/badger/v2/options"
+	"github.com/iotaledger/hive.go/parameter"
+)
+
+var once = sync.Once{}
+var profile *Profile
+
+func GetProfile() *Profile {
+	once.Do(func() {
+		profileName := parameter.NodeConfig.GetString("useProfile")
+		switch profileName {
+		case "default":
+			profile = DefaultProfile
+			profile.Name = "default"
+		case "light":
+			profile = LightProfile
+			profile.Name = "light"
+		default:
+			p := &Profile{}
+			key := fmt.Sprintf("profiles.%s", profileName)
+			if !parameter.NodeConfig.IsSet(key) {
+				panic(fmt.Sprintf("profile '%s' is not defined in the config", profileName))
+			}
+			if err := parameter.NodeConfig.UnmarshalKey(key, p); err != nil {
+				panic(err)
+			}
+			p.Name = profileName
+			profile = p
+		}
+	})
+	return profile
+}
+
+var DefaultProfile = &Profile{
+	Caches: CacheOpts{
+		RequestQueue:              100000,
+		Approvers:                 100000,
+		Bundles:                   20000,
+		Milestones:                1000,
+		SpentAddresses:            5000,
+		Transactions:              50000,
+		IncomingTransactionFilter: 5000,
+		RefsInvalidBundle:         10000,
+	},
+	Badger: BadgerOpts{
+		LevelOneSize:            268435456,
+		LevelSizeMultiplier:     10,
+		TableLoadingMode:        options.MemoryMap,
+		ValueLogLoadingMode:     options.MemoryMap,
+		MaxLevels:               7,
+		MaxTableSize:            67108864,
+		NumCompactors:           2,
+		NumLevelZeroTables:      5,
+		NumLevelZeroTablesStall: 10,
+		NumMemtables:            5,
+		NumVersionsToKeep:       1,
+		SyncWrites:              true,
+		CompactLevel0OnClose:    true,
+		ValueLogFileSize:        1073741823,
+		ValueLogMaxEntries:      1000000,
+		ValueThreshold:          32,
+		LogRotatesToFlush:       2,
+		MaxCacheSize:            50000000,
+	},
+}
+
+var LightProfile = &Profile{
+	Caches: CacheOpts{
+		RequestQueue:              100000,
+		Approvers:                 100000,
+		Bundles:                   20000,
+		Milestones:                1000,
+		SpentAddresses:            5000,
+		Transactions:              50000,
+		IncomingTransactionFilter: 5000,
+		RefsInvalidBundle:         10000,
+	},
+	Badger: BadgerOpts{
+		LevelOneSize:            67108864,
+		LevelSizeMultiplier:     10,
+		TableLoadingMode:        options.FileIO,
+		ValueLogLoadingMode:     options.FileIO,
+		MaxLevels:               5,
+		MaxTableSize:            16777216,
+		NumCompactors:           1,
+		NumLevelZeroTables:      1,
+		NumLevelZeroTablesStall: 2,
+		NumMemtables:            1,
+		NumVersionsToKeep:       1,
+		SyncWrites:              false,
+		CompactLevel0OnClose:    true,
+		ValueLogFileSize:        33554431,
+		ValueLogMaxEntries:      250000,
+		ValueThreshold:          32,
+		LogRotatesToFlush:       2,
+		MaxCacheSize:            50000000,
+	},
+}
+
+type Profile struct {
+	Name   string     `json:"name"`
+	Caches CacheOpts  `json:"caches"`
+	Badger BadgerOpts `json:"badger"`
+}
+
+type CacheOpts struct {
+	RequestQueue              int `json:"request_queue"`
+	Approvers                 int `json:"approvers"`
+	Bundles                   int `json:"bundles"`
+	Milestones                int `json:"milestones"`
+	SpentAddresses            int `json:"spentAddresses"`
+	Transactions              int `json:"transactions"`
+	IncomingTransactionFilter int `json:"incomingTransactionFilter"`
+	RefsInvalidBundle         int `json:""`
+}
+
+type BadgerOpts struct {
+	LevelOneSize            int64                   `json:"levelOneSize"`
+	LevelSizeMultiplier     int                     `json:"levelSizeMultiplier"`
+	TableLoadingMode        options.FileLoadingMode `json:"tableLoadingMode"`
+	ValueLogLoadingMode     options.FileLoadingMode `json:"valueLogLoadingMode"`
+	MaxLevels               int                     `json:"maxLevels"`
+	MaxTableSize            int64                   `json:"maxTableSize"`
+	NumCompactors           int                     `json:"numCompactors"`
+	NumLevelZeroTables      int                     `json:"numLevelZeroTables"`
+	NumLevelZeroTablesStall int                     `json:"numLevelZeroTablesStall"`
+	NumMemtables            int                     `json:"numMemtables"`
+	NumVersionsToKeep       int                     `json:"numVersionsToKeep"`
+	SyncWrites              bool                    `json:"syncWrites"`
+	CompactLevel0OnClose    bool                    `json:"compactLevel0OnClose"`
+	ValueLogFileSize        int64                   `json:"valueLogFileSize"`
+	ValueLogMaxEntries      uint32                  `json:"valueLogMaxEntries"`
+	ValueThreshold          int                     `json:"valueThreshold"`
+	LogRotatesToFlush       int32                   `json:"logRotatesToFlush"`
+	MaxCacheSize            int64                   `json:"maxCacheSize"`
+}

--- a/packages/profile/profile.go
+++ b/packages/profile/profile.go
@@ -38,15 +38,35 @@ func GetProfile() *Profile {
 }
 
 var DefaultProfile = &Profile{
-	Caches: CacheOpts{
-		RequestQueue:              100000,
-		Approvers:                 100000,
-		Bundles:                   20000,
-		Milestones:                1000,
-		SpentAddresses:            5000,
-		Transactions:              50000,
-		IncomingTransactionFilter: 5000,
-		RefsInvalidBundle:         10000,
+	Caches: Caches{
+		RequestQueue: CacheOpts{
+			Size: 100000,
+		},
+		Approvers: CacheOpts{
+			Size:         100000,
+			EvictionSize: 1000,
+		},
+		Bundles: CacheOpts{
+			Size:         20000,
+			EvictionSize: 1000,
+		},
+		Milestones: CacheOpts{
+			Size:         1000,
+			EvictionSize: 100,
+		},
+		SpentAddresses: CacheOpts{
+			Size: 5000,
+		},
+		Transactions: CacheOpts{
+			Size:         50000,
+			EvictionSize: 1000,
+		},
+		IncomingTransactionFilter: CacheOpts{
+			Size: 5000,
+		},
+		RefsInvalidBundle: CacheOpts{
+			Size: 10000,
+		},
 	},
 	Badger: BadgerOpts{
 		LevelOneSize:            268435456,
@@ -71,15 +91,35 @@ var DefaultProfile = &Profile{
 }
 
 var LightProfile = &Profile{
-	Caches: CacheOpts{
-		RequestQueue:              100000,
-		Approvers:                 100000,
-		Bundles:                   20000,
-		Milestones:                1000,
-		SpentAddresses:            5000,
-		Transactions:              50000,
-		IncomingTransactionFilter: 5000,
-		RefsInvalidBundle:         10000,
+	Caches: Caches{
+		RequestQueue: CacheOpts{
+			Size: 100000,
+		},
+		Approvers: CacheOpts{
+			Size:         10000,
+			EvictionSize: 1000,
+		},
+		Bundles: CacheOpts{
+			Size:         5000,
+			EvictionSize: 1000,
+		},
+		Milestones: CacheOpts{
+			Size:         150,
+			EvictionSize: 100,
+		},
+		SpentAddresses: CacheOpts{
+			Size: 2000,
+		},
+		Transactions: CacheOpts{
+			Size:         10000,
+			EvictionSize: 1000,
+		},
+		IncomingTransactionFilter: CacheOpts{
+			Size: 5000,
+		},
+		RefsInvalidBundle: CacheOpts{
+			Size: 10000,
+		},
 	},
 	Badger: BadgerOpts{
 		LevelOneSize:            67108864,
@@ -105,19 +145,24 @@ var LightProfile = &Profile{
 
 type Profile struct {
 	Name   string     `json:"name"`
-	Caches CacheOpts  `json:"caches"`
+	Caches Caches     `json:"caches"`
 	Badger BadgerOpts `json:"badger"`
 }
 
+type Caches struct {
+	RequestQueue              CacheOpts `json:"requestQueue"`
+	Approvers                 CacheOpts `json:"approvers"`
+	Bundles                   CacheOpts `json:"bundles"`
+	Milestones                CacheOpts `json:"milestones"`
+	SpentAddresses            CacheOpts `json:"spentAddresses"`
+	Transactions              CacheOpts `json:"transactions"`
+	IncomingTransactionFilter CacheOpts `json:"incomingTransactionFilter"`
+	RefsInvalidBundle         CacheOpts `json:"refsInvalidBundle"`
+}
+
 type CacheOpts struct {
-	RequestQueue              int `json:"request_queue"`
-	Approvers                 int `json:"approvers"`
-	Bundles                   int `json:"bundles"`
-	Milestones                int `json:"milestones"`
-	SpentAddresses            int `json:"spentAddresses"`
-	Transactions              int `json:"transactions"`
-	IncomingTransactionFilter int `json:"incomingTransactionFilter"`
-	RefsInvalidBundle         int `json:""`
+	Size         int    `json:"size"`
+	EvictionSize uint64 `json:"evictionSize"`
 }
 
 type BadgerOpts struct {

--- a/packages/profile/profile.go
+++ b/packages/profile/profile.go
@@ -55,7 +55,8 @@ var DefaultProfile = &Profile{
 			EvictionSize: 100,
 		},
 		SpentAddresses: CacheOpts{
-			Size: 5000,
+			Size:         5000,
+			EvictionSize: 1000,
 		},
 		Transactions: CacheOpts{
 			Size:         50000,
@@ -108,7 +109,8 @@ var LightProfile = &Profile{
 			EvictionSize: 100,
 		},
 		SpentAddresses: CacheOpts{
-			Size: 2000,
+			Size:         2000,
+			EvictionSize: 1000,
 		},
 		Transactions: CacheOpts{
 			Size:         10000,

--- a/plugins/cli/plugin.go
+++ b/plugins/cli/plugin.go
@@ -6,14 +6,14 @@ import (
 	"strings"
 
 	"github.com/gohornet/hornet/packages/node"
+	"github.com/gohornet/hornet/packages/profile"
 	"github.com/iotaledger/hive.go/events"
 	"github.com/iotaledger/hive.go/parameter"
 )
 
 var (
 	// AppVersion version number
-	AppVersion = "0.2.0"
-
+	AppVersion = "0.1.0"
 	// AppName app code name
 	AppName = "HORNET"
 )
@@ -59,7 +59,7 @@ func configure(ctx *node.Plugin) {
 
 	parameter.FetchConfig(true)
 	parseParameters()
-
+	ctx.Node.Logger.Infof("Using profile '%s'", profile.GetProfile().Name)
 	ctx.Node.Logger.Info("Loading plugins ...")
 }
 

--- a/plugins/cli/plugin.go
+++ b/plugins/cli/plugin.go
@@ -13,7 +13,7 @@ import (
 
 var (
 	// AppVersion version number
-	AppVersion = "0.1.0"
+	AppVersion = "0.2.0"
 	// AppName app code name
 	AppName = "HORNET"
 )

--- a/plugins/gossip/packet_processor.go
+++ b/plugins/gossip/packet_processor.go
@@ -41,7 +41,7 @@ var (
 
 func configurePacketProcessor() {
 	RequestQueue = queue.NewRequestQueue()
-	incomingCache = datastructure.NewLRUCache(profile.GetProfile().Caches.IncomingTransactionFilter)
+	incomingCache = datastructure.NewLRUCache(profile.GetProfile().Caches.IncomingTransactionFilter.Size)
 
 	gossipLogger.Infof("Configuring packetProcessorWorkerPool with %d workers", packetProcessorWorkerCount)
 	packetProcessorWorkerPool = workerpool.New(func(task workerpool.Task) {

--- a/plugins/spa/frontend/src/app/components/Misc.tsx
+++ b/plugins/spa/frontend/src/app/components/Misc.tsx
@@ -95,6 +95,22 @@ export class Debug extends React.Component<Props, any> {
                     <Col>
                         <Card>
                             <Card.Body>
+                                <Card.Title>Cache Sizes</Card.Title>
+                                <small>
+                                    The cache size shrinks whenever an eviction happens.
+                                    Note that the sizes are sampled only every second, so you won't necessarily
+                                    see the cache hitting its capacity.
+                                </small>
+                                <Line height={60} data={this.props.nodeStore.cacheMetricsSeries}
+                                      options={reqLineChartOptions}/>
+                            </Card.Body>
+                        </Card>
+                    </Col>
+                </Row>
+                <Row className={"mb-3"}>
+                    <Col>
+                        <Card>
+                            <Card.Body>
                                 <Card.Title>Requests</Card.Title>
                                 <Line height={60} data={this.props.nodeStore.stingReqs}
                                       options={reqLineChartOptions}/>

--- a/plugins/tangle/consistency.go
+++ b/plugins/tangle/consistency.go
@@ -3,21 +3,17 @@ package tangle
 import (
 	"errors"
 
-	"github.com/iotaledger/iota.go/trinary"
 	"github.com/gohornet/hornet/packages/datastructure"
 	"github.com/gohornet/hornet/packages/model/milestone_index"
 	"github.com/gohornet/hornet/packages/model/tangle"
-)
-
-const (
-	RefsAnInvalidBundleCacheSize = 10000
+	"github.com/iotaledger/iota.go/trinary"
 )
 
 var (
 	ErrRefBundleNotValid    = errors.New("a referenced bundle is invalid")
 	ErrRefBundleNotComplete = errors.New("a referenced bundle is not complete")
 
-	RefsAnInvalidBundleCache = datastructure.NewLRUCache(RefsAnInvalidBundleCacheSize)
+	RefsAnInvalidBundleCache *datastructure.LRUCache
 )
 
 // CheckConsistencyOfConeAndMutateDiff checks whether cone referenced by the given tail transaction is consistent with the current diff.

--- a/plugins/tangle/plugin.go
+++ b/plugins/tangle/plugin.go
@@ -27,7 +27,7 @@ var belowMaxDepthTransactionLimit int
 func configure(plugin *node.Plugin) {
 
 	belowMaxDepthTransactionLimit = parameter.NodeConfig.GetInt("tipsel.belowMaxDepthTransactionLimit")
-	RefsAnInvalidBundleCache = datastructure.NewLRUCache(profile.GetProfile().Caches.RefsInvalidBundle)
+	RefsAnInvalidBundleCache = datastructure.NewLRUCache(profile.GetProfile().Caches.RefsInvalidBundle.Size)
 
 	tangle.InitTransactionCache(onEvictTransactions)
 	tangle.InitBundleCache()
@@ -44,7 +44,7 @@ func configure(plugin *node.Plugin) {
 	if !tangle.IsCorrectDatabaseVersion() {
 		log.Panic("HORNET database version mismatch. The database scheme was updated. Please delete the database folder and start with a new local snapshot.")
 	}
-	
+
 	tangle.MarkDatabaseCorrupted()
 
 	tangle.ConfigureMilestones(

--- a/plugins/tangle/plugin.go
+++ b/plugins/tangle/plugin.go
@@ -40,6 +40,11 @@ func configure(plugin *node.Plugin) {
 	if tangle.IsDatabaseCorrupted() {
 		log.Panic("HORNET was not shut down correctly. Database is corrupted. Please delete the database folder and start with a new local snapshot.")
 	}
+
+	if !tangle.IsCorrectDatabaseVersion() {
+		log.Panic("HORNET database version mismatch. The database scheme was updated. Please delete the database folder and start with a new local snapshot.")
+	}
+	
 	tangle.MarkDatabaseCorrupted()
 
 	tangle.ConfigureMilestones(

--- a/plugins/webapi/spent.go
+++ b/plugins/webapi/spent.go
@@ -5,9 +5,9 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
+	"github.com/gohornet/hornet/packages/model/tangle"
 	"github.com/iotaledger/iota.go/address"
 	"github.com/mitchellh/mapstructure"
-	"github.com/gohornet/hornet/packages/model/tangle"
 )
 
 func init() {


### PR DESCRIPTION
Using profiles, users can now define their cache sizes and database options. Via the new config key `useProfile` a profile can be named to be used. The profile can be defined as a JSON obj under the `profiles` key. A `default` and `light` profile is hardcoded and usable without defining it in the configuration file. A `custom` profile is defined in the config to show the available config keys.

All LRU caches have been adjusted to use the size parameters from the profile.

```
  "useProfile": "default",
  "profiles": {
    "custom": {
      "caches": {
        "requestQueue": 100000,
        "approvers": 100000,
        "bundles": 20000,
        "milestones": 1000,
        "spentAddresses": 5000,
        "transactions": 50000,
        "incomingTransactionFilter": 5000,
        "refsInvalidBundle": 10000
      },
      "badger": {
        "levelOneSize": 268435456,
        "levelSizeMultiplier": 10,
        "tableLoadingMode": 2,
        "valueLogLoadingMode": 2,
        "maxLevels": 7,
        "maxTableSize": 67108864,
        "numCompactors": 2,
        "numLevelZeroTables": 5,
        "numLevelZeroTablesStall": 10,
        "numMemtables": 5,
        "numVersionsToKeep": 1,
        "syncWrites": true,
        "compactLevel0OnClose": true,
        "valueLogFileSize": 1073741823,
        "valueLogMaxEntries": 1000000,
        "valueThreshold": 32,
        "logRotatesToFlush": 2,
        "maxCacheSize": 50000000
      }
    }
  },
```