### PR TITLE
Clean reconnect pool when moving neighbors from sets

### DIFF
--- a/packages/iputils/iputils.go
+++ b/packages/iputils/iputils.go
@@ -2,10 +2,11 @@ package iputils
 
 import (
 	"fmt"
-	"github.com/pkg/errors"
 	"net"
 	"strconv"
 	"strings"
+
+	"github.com/pkg/errors"
 )
 
 type IP struct {
@@ -30,6 +31,21 @@ type NeighborIPAddresses struct {
 
 func NewNeighborIPAddresses() *NeighborIPAddresses {
 	return &NeighborIPAddresses{IPs: make(map[*IP]struct{})}
+}
+
+func (ips *NeighborIPAddresses) Union(other *NeighborIPAddresses) *NeighborIPAddresses {
+	union := NewNeighborIPAddresses()
+	set := map[string]struct{}{}
+	for ip := range ips.IPs {
+		union.Add(ip)
+		set[ip.String()] = struct{}{}
+	}
+	for ip := range other.IPs {
+		if _, ok := set[ip.String()]; !ok {
+			union.Add(ip)
+		}
+	}
+	return union
 }
 
 func (ips *NeighborIPAddresses) GetPreferredAddress(preferIPv6 bool) *IP {

--- a/plugins/spa/frontend/src/app/stores/NodeStore.ts
+++ b/plugins/spa/frontend/src/app/stores/NodeStore.ts
@@ -350,6 +350,7 @@ export class NodeStore {
 
     @action
     updateNeighborMetrics = (neighborMetrics: Array<NeighborMetric>) => {
+        let updated = [];
         for (let i = 0; i < neighborMetrics.length; i++) {
             let metric = neighborMetrics[i];
             let neighbMetrics: NeighborMetrics = this.neighbor_metrics.get(metric.identity);
@@ -358,6 +359,13 @@ export class NodeStore {
             }
             neighbMetrics.addMetric(metric);
             this.neighbor_metrics.set(metric.identity, neighbMetrics);
+            updated.push(metric.identity);
+        }
+        // remove duplicates
+        for (const k of this.neighbor_metrics.keys()) {
+            if (!updated.includes(k)) {
+                this.neighbor_metrics.delete(k);
+            }
         }
     };
 

--- a/plugins/spa/frontend/tsconfig.json
+++ b/plugins/spa/frontend/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "sourceMap": true,
-    "target": "es5",
+    "target": "es6",
     "jsx": "react",
     "module": "es6",
     "moduleResolution": "node",


### PR DESCRIPTION
* Lets moves of neighbors from the different neighbors set, automatically cleanup entries within the reconnect pool
* The SPA now removes neighbor metrics for neighbors which are no longer sent downstream to the browser client
* An inbound neighbor will automatically gain the origin addresses and looked up IP addresses of any entry within the reconnect pool where at least one IP address identity matches
* It is now logged when an entry is removed from the reconnect pool