### PR TITLE
Fixes non-tail bundle txs not being marked as confirmed

### DIFF
--- a/plugins/tangle/confirmation.go
+++ b/plugins/tangle/confirmation.go
@@ -116,7 +116,7 @@ func confirmMilestone(milestoneIndex milestone_index.MilestoneIndex, milestoneTa
 			log.Panicf("confirmMilestone: BundleBucket not found: %v, Error: %v", tx.Tx.Bundle, err)
 		}
 
-		// we only are iterating over tail txs
+		// we are only iterating over tail txs
 		bundle := bundleBucket.GetBundleOfTailTransaction(txHash)
 		if bundle == nil {
 			log.Panicf("confirmMilestone: Tx: %v, Bundle not found: %v", txHash, tx.Tx.Bundle)


### PR DESCRIPTION
We only ever marked the tail transaction of a bundle as confirmed. This PR fixes that by iterating over all transactions of a bundle of a confirmed tail transaction. It also adds a proper description to the reason why during the "confirmation-walk" we only add tail txs to the `txsToConfirm` set.