### PR TITLE
Adds rate limiting for writes to WebSockets

### DIFF
--- a/plugins/spa/frontend/src/app/components/TPSChart.tsx
+++ b/plugins/spa/frontend/src/app/components/TPSChart.tsx
@@ -57,8 +57,8 @@ export default class TPSChart extends React.Component<Props, any> {
                     <Card.Title>Transactions Per Second</Card.Title>
                     <small>
                         Incoming: {this.props.nodeStore.last_tps_metric.incoming}.
-                        Outgoing: {this.props.nodeStore.last_tps_metric.outgoing}.
                         New: {this.props.nodeStore.last_tps_metric.new}.
+                        Outgoing: {this.props.nodeStore.last_tps_metric.outgoing}.
                     </small>
 
                     <Line height={50} data={this.props.nodeStore.tpsSeries} options={lineChartOptions}/>

--- a/plugins/spa/plugin.go
+++ b/plugins/spa/plugin.go
@@ -130,7 +130,8 @@ var webSocketWriteTimeout = time.Duration(3) * time.Second
 
 var (
 	upgrader = websocket.Upgrader{
-		HandshakeTimeout: webSocketWriteTimeout,
+		HandshakeTimeout:  webSocketWriteTimeout,
+		EnableCompression: true,
 	}
 )
 


### PR DESCRIPTION
* A max. of 20 msgs/s are now sent downstream to the client.
* The transaction live feed is disabled until the node is synchronized.
* The transaction live feed is limited to 10 msgs/s.
* Rearranged Incoming/New/Outgoing info above the TPS chart.
* Also enables WebSocket compression.