### PR TITLE
Extend node info

### DIFF
--- a/plugins/webapi/info.go
+++ b/plugins/webapi/info.go
@@ -50,6 +50,7 @@ func getNodeInfo(i interface{}, c *gin.Context) {
 	// Solid milestone index
 	smi := tangle.GetSolidMilestoneIndex()
 	info.LatestSolidSubtangleMilestoneIndex = uint32(smi)
+	info.IsSynced = tangle.IsNodeSynced()
 
 	// Solid milestone hash
 	smBndl, err := tangle.GetMilestone(smi)

--- a/plugins/webapi/types.go
+++ b/plugins/webapi/types.go
@@ -159,6 +159,7 @@ type GetNodeInfoReturn struct {
 	LatestMilestoneIndex               uint32   `json:"latestMilestoneIndex"`
 	LatestSolidSubtangleMilestone      string   `json:"latestSolidSubtangleMilestone"`
 	LatestSolidSubtangleMilestoneIndex uint32   `json:"latestSolidSubtangleMilestoneIndex"`
+	IsSynced                           bool     `json:"isSynced"`
 	MilestoneStartIndex                uint32   `json:"milestoneStartIndex,omitempty"`
 	LastSnapshottedMilestoneIndex      uint32   `json:"lastSnapshottedMilestoneIndex,omitempty"`
 	Neighbors                          uint     `json:"neighbors"`


### PR DESCRIPTION
Adds `isSynced` to `getNodeInfo` like described in #70 