### PR TITLE
Added config to prefer IPv6 (addNeighbors)

### DIFF
--- a/config.json
+++ b/config.json
@@ -122,7 +122,7 @@
   "network": {
     "address": "0.0.0.0",
     "autotetheringenabled": false,
-    "preferIPv6": true,
+    "preferIPv6": false,
     "maxneighbors": 5,
     "neighbors": [
       {

--- a/config.json
+++ b/config.json
@@ -122,6 +122,7 @@
   "network": {
     "address": "0.0.0.0",
     "autotetheringenabled": false,
+    "preferIPv6": true,
     "maxneighbors": 5,
     "neighbors": [
       {

--- a/plugins/gossip/neighbors.go
+++ b/plugins/gossip/neighbors.go
@@ -412,11 +412,13 @@ func wakeupReconnectPool() {
 	reconnectPoolWakeup <- struct{}{}
 }
 
-func AddNeighbor(neighborAddr string) error {
+func AddNeighbor(neighborAddr string, preferIPv6 bool) error {
 	originAddr, err := iputils.ParseOriginAddress(neighborAddr)
 	if err != nil {
 		return errors.Wrapf(err, "invalid neighbor address %s", neighborAddr)
 	}
+
+	originAddr.PreferIPv6 = preferIPv6
 
 	// check whether the neighbor is already connected, in-flight or in the reconnect pool
 	// given any of the IP addresses to which the neighbor address resolved to

--- a/plugins/gossip/parameters.go
+++ b/plugins/gossip/parameters.go
@@ -4,7 +4,7 @@ import flag "github.com/spf13/pflag"
 
 func init() {
 	flag.Bool("network.autoTetheringEnabled", false, "Enable new connections from unknown neighbors")
-	flag.Bool("network.preferIPv6", true, "Defines if IPv6 is preferred for neighbors added through the API")
+	flag.Bool("network.preferIPv6", false, "Defines if IPv6 is preferred for neighbors added through the API")
 	flag.String("network.address", "0.0.0.0", "Bind the TCP server socket for the gossip protocol to an address")
 	flag.Int("network.port", 15600, "Bind the TCP server socket for the gossip protocol to a port")
 	flag.StringSlice("network.neighbors", nil, "Set the URLs and IP addresses of neighbors")

--- a/plugins/gossip/parameters.go
+++ b/plugins/gossip/parameters.go
@@ -4,6 +4,7 @@ import flag "github.com/spf13/pflag"
 
 func init() {
 	flag.Bool("network.autoTetheringEnabled", false, "Enable new connections from unknown neighbors")
+	flag.Bool("network.preferIPv6", true, "Defines if IPv6 is preferred for neighbors added through the API")
 	flag.String("network.address", "0.0.0.0", "Bind the TCP server socket for the gossip protocol to an address")
 	flag.Int("network.port", 15600, "Bind the TCP server socket for the gossip protocol to a port")
 	flag.StringSlice("network.neighbors", nil, "Set the URLs and IP addresses of neighbors")

--- a/plugins/webapi/neighbors.go
+++ b/plugins/webapi/neighbors.go
@@ -21,8 +21,10 @@ func addNeighbors(i interface{}, c *gin.Context) {
 	// Check if HORNET style addNeighbors call was made
 	han := &AddNeighborsHornet{}
 	if err := mapstructure.Decode(i, han); err == nil {
-		addNeighborsWithAlias(han, c)
-		return
+		if len(han.Neighbors) != 0 {
+			addNeighborsWithAlias(han, c)
+			return
+		}
 	}
 
 	an := &AddNeighbors{}
@@ -67,7 +69,7 @@ func addNeighborsWithAlias(s *AddNeighborsHornet, c *gin.Context) {
 			continue
 		}
 
-		// TODO: Add alias (uri.Alias)
+		// TODO: Add alias (neighbor.Alias)
 
 		if err := gossip.AddNeighbor(neighbor.Identity, neighbor.PreferIPv6); err != nil {
 			log.Warningf("Can't add neighbor %s, Error: %s", neighbor.Identity, err)

--- a/plugins/webapi/neighbors.go
+++ b/plugins/webapi/neighbors.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/gohornet/hornet/plugins/gossip"
+	"github.com/iotaledger/hive.go/parameter"
 	"github.com/mitchellh/mapstructure"
 )
 
@@ -19,6 +20,8 @@ func addNeighbors(i interface{}, c *gin.Context) {
 	an := &AddNeighbors{}
 	e := ErrorReturn{}
 	addedNeighbors := 0
+
+	preferIPv6 := parameter.NodeConfig.GetBool("network.preferIPv6")
 
 	if err := mapstructure.Decode(i, an); err != nil {
 		e.Error = "Internal error"
@@ -34,7 +37,7 @@ func addNeighbors(i interface{}, c *gin.Context) {
 			continue
 		}
 
-		if err := gossip.AddNeighbor(uri); err != nil {
+		if err := gossip.AddNeighbor(uri, preferIPv6); err != nil {
 			log.Warningf("Can't add neighbor %s, Error: %s", uri, err)
 		} else {
 			addedNeighbors++

--- a/plugins/webapi/neighbors.go
+++ b/plugins/webapi/neighbors.go
@@ -59,21 +59,21 @@ func addNeighbors(i interface{}, c *gin.Context) {
 func addNeighborsWithAlias(s *AddNeighborsHornet, c *gin.Context) {
 	addedNeighbors := 0
 
-	for _, uri := range s.Uris {
+	for _, neighbor := range s.Neighbors {
 
-		if strings.Contains(uri.Identity, "tcp://") {
-			uri.Identity = uri.Identity[6:]
-		} else if strings.Contains(uri.Identity, "://") {
+		if strings.Contains(neighbor.Identity, "tcp://") {
+			neighbor.Identity = neighbor.Identity[6:]
+		} else if strings.Contains(neighbor.Identity, "://") {
 			continue
 		}
 
 		// TODO: Add alias (uri.Alias)
 
-		if err := gossip.AddNeighbor(uri.Identity, uri.PreferIPv6); err != nil {
-			log.Warningf("Can't add neighbor %s, Error: %s", uri.Identity, err)
+		if err := gossip.AddNeighbor(neighbor.Identity, neighbor.PreferIPv6); err != nil {
+			log.Warningf("Can't add neighbor %s, Error: %s", neighbor.Identity, err)
 		} else {
 			addedNeighbors++
-			log.Infof("Added neighbor: %s", uri.Identity)
+			log.Infof("Added neighbor: %s", neighbor.Identity)
 		}
 	}
 

--- a/plugins/webapi/types.go
+++ b/plugins/webapi/types.go
@@ -4,10 +4,23 @@ import "github.com/gohornet/hornet/plugins/gossip"
 
 //////////////////// addNeighbors /////////////////////////////////
 
-// AddNeighbors struct
+// AddNeighbors legacy struct
 type AddNeighbors struct {
 	Command string   `json:"command"`
 	Uris    []string `json:"uris"`
+}
+
+// AddNeighborsHornet struct
+type AddNeighborsHornet struct {
+	Command string `json:"command"`
+	Uris    []URI  `json:"uris"`
+}
+
+// URI struct
+type URI struct {
+	Identity   string `json:"identity"`
+	PreferIPv6 bool   `json:"preferIPv6"`
+	Alias      string `json:"alias"`
 }
 
 // AddNeighborsResponse struct

--- a/plugins/webapi/types.go
+++ b/plugins/webapi/types.go
@@ -12,12 +12,12 @@ type AddNeighbors struct {
 
 // AddNeighborsHornet struct
 type AddNeighborsHornet struct {
-	Command string `json:"command"`
-	Uris    []URI  `json:"uris"`
+	Command   string     `json:"command"`
+	Neighbors []Neighbor `json:"neighbors"`
 }
 
-// URI struct
-type URI struct {
+// Neighbor struct
+type Neighbor struct {
 	Identity   string `json:"identity"`
 	PreferIPv6 bool   `json:"preferIPv6"`
 	Alias      string `json:"alias"`
@@ -235,22 +235,6 @@ type GetTrytes struct {
 type GetTrytesReturn struct {
 	Trytes   []string `json:"trytes"`
 	Duration int      `json:"duration"`
-}
-
-///////////////////////////////////////////////////////////////////
-
-///////////////////////// Neighbor ////////////////////////////////
-
-// Neighbor struct
-type Neighbor struct {
-	Address                           string `json:"address"`
-	NumberOfAllTransactions           uint32 `json:"numberOfAllTransactions"`
-	NumberOfRandomTransactionRequests uint32 `json:"numberOfRandomTransactionRequests"`
-	NumberOfNewTransactions           uint32 `json:"numberOfNewTransactions"`
-	NumberOfInvalidTransactions       uint32 `json:"numberOfInvalidTransactions"`
-	NumberOfStaleTransactions         uint32 `json:"numberOfStaleTransactions"`
-	NumberOfSentTransactions          uint32 `json:"numberOfSentTransactions"`
-	Connectiontype                    string `json:"connectiontype"`
 }
 
 ///////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Closes #28 
* Adds a `network.preferIPv6` setting to the config
* Adds the possibility to send an alternative addNeighbors call:
```json
{
    "command": "addNeighbors",
    "neighbors": [
        {
        	"identity": "your-node.tld:15600",
        	"preferIPv6": false,
        	"alias": ""
        }
    ]
}
```