### PR TITLE
Add arm64 Dockerfile, add timeout on gpg receive key

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -41,6 +41,11 @@ If not running via docker-compose, build manually:
 docker build -t hornet:latest .
 ```
 
+Note: for aarch64/arm64 architecture point docker build to the `Dockerfile.arm64`:
+```sh
+docker build -f Dockerfile.arm64 -t hornet:latest .
+```
+
 ## Run
 
 Best is to run on host network for better performance (otherwise you are going to have to publish ports, that is done via iptables NAT and is slower)

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -1,18 +1,18 @@
 # ---[ build image ]---
-FROM golang:1.13 as builder
+FROM arm64v8/golang:1.13 as builder
 
 WORKDIR /go/src/github.com/gohornet/hornet
 ADD . .
 RUN CGO_ENABLED=0 GOOS=linux go build -o ./hornet main.go
 
 # ---[ runtime image ]---
-FROM alpine:latest
+FROM arm64v8/alpine:latest
 WORKDIR /app
 ENV TINI_VERSION v0.18.0
 
 # Tini is excellent: https://github.com/krallin/tini#why-tini
-ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-static /tini
-ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-static.asc /tini.asc
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-static-arm64 /tini
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-static-arm64.asc /tini.asc
 
 COPY --from=builder ["/go/src/github.com/gohornet/hornet/hornet", "/go/src/github.com/gohornet/hornet/config.json", "/app/"]
 RUN apk --no-cache add ca-certificates gnupg\

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,8 @@ services:
   hornet:
     build:
       context: .
+      # For aarch64/arm64 use Dockerfile.arm64
+      dockerfile: Dockerfile
     image: hornet:latest
     # Best performance via host network:
     network_mode: host


### PR DESCRIPTION
# Dockerfile for arm64

* Adds a Dockerfile specific for ARM64.
I didn't add ARM32 support at this time, as I think that with 32bit a user best use the binaries and skip running hornet in Docker.

* Add timeout on gpg key receive
Some gpg servers in the list may timeout, gpg doesn't have any flag to specify the timeout and it takes quite long. Using the `timeout` (which is available on alpine by default) helps terminate the process so that the next server in the list is attempted.

Note: It would have been ideal to reuse the original Dockerfile in the repository, however there are two ARGs that would have to be passed which makes it confusing for the user.
Idea was to set `--build-arg arm64` and set `tini`'s version accordingly. However, the image name requires the prefix `arm64v8/`, that would require to pass that too as an argument. There's not much that can be done with the `ARG` keyword in Dockerfile as they only support very limited parameter expansion.
