### PR TITLE
Omit neighbor connection errors on shutdown

### DIFF
--- a/plugins/gossip/neighbors.go
+++ b/plugins/gossip/neighbors.go
@@ -335,11 +335,17 @@ func setupNeighborEventHandlers(neighbor *Neighbor) {
 
 	// print protocol error log
 	neighbor.Protocol.Events.Error.Attach(events.NewClosure(func(err error) {
+		if daemon.IsStopped() {
+			return
+		}
 		gossipLogger.Errorf("protocol error on neighbor %s: %s", neighbor.IdentityOrAddress(), err.Error())
 	}))
 
 	// connection error log
 	neighbor.Protocol.Conn.Events.Error.Attach(events.NewClosure(func(err error) {
+		if daemon.IsStopped() {
+			return
+		}
 		gossipLogger.Errorf("connection error on neighbor %s: %s", neighbor.IdentityOrAddress(), err.Error())
 	}))
 
@@ -347,6 +353,9 @@ func setupNeighborEventHandlers(neighbor *Neighbor) {
 	// if not closed on purpose
 	neighbor.Protocol.Conn.Events.Close.Attach(events.NewClosure(func() {
 		gossipLogger.Infof("connection closed to %s", neighbor.IdentityOrAddress())
+		if daemon.IsStopped() {
+			return
+		}
 		neighborsLock.Lock()
 		defer neighborsLock.Unlock()
 		moveNeighborFromConnectedToReconnectPool(neighbor)


### PR DESCRIPTION
Omits connection errors when the node is shutdown to make the log cleaner.

From:
```
Jan 05 23:11:18 hornet-2 hornet[18362]: 2020/01/05 23:11:18 [ INFO ] Gossip: Closing neighbor connections ...
Jan 05 23:11:18 hornet-2 hornet[18362]: 2020/01/05 23:11:18 [ ERROR ] Gossip: connection error on neighbor [REDACTED]:15600: read tcp [REDACTED]:38574->[REDACTED]:15600: use of closed network connection
Jan 05 23:11:18 hornet-2 hornet[18362]: 2020/01/05 23:11:18 [ ERROR ] Gossip: connection error on neighbor [REDACTED]:15600: close tcp [REDACTED]:38574->[REDACTED]:15600: use of closed network connection
Jan 05 23:11:18 hornet-2 hornet[18362]: 2020/01/05 23:11:18 [ ERROR ] Gossip: connection error on neighbor [REDACTED]:15600: read tcp [REDACTED]:34374->[REDACTED]:15600: use of closed network connection
....
Jan 05 23:11:18 hornet-2 hornet[18362]: 2020/01/05 23:11:18 [ INFO ] Gossip: Closing neighbor connections ... done
```

To:
```
2020/01/06 16:28:57 [ INFO ] Gossip: Closing neighbor connections ...
2020/01/06 16:28:57 [ INFO ] Gossip: connection closed to 159.69.9.6:15601
2020/01/06 16:28:57 [ INFO ] Gossip: connection closed to 159.69.9.6:15602
2020/01/06 16:28:57 [ INFO ] Gossip: Closing neighbor connections ... done
```