### PR TITLE
Don't load up any transactions during bundle eviction

### DIFF
--- a/packages/model/tangle/bundle_db.go
+++ b/packages/model/tangle/bundle_db.go
@@ -52,13 +52,14 @@ func StoreBundleBucketsInDatabase(bundleBuckets []*BundleBucket) error {
 			bundle.SetModified(false)
 		}
 
-		for _, tx := range bundleBucket.Transactions() {
+		for _, txHash := range bundleBucket.TransactionHashes() {
 			// tails were already stored
-			if tx.IsTail() {
+			if _, isTail := bundleBucket.bundleInstances[txHash]; isTail {
 				continue
 			}
+
 			entry := database.Entry{
-				Key:   databaseKeyForBundle(bundleBucket.GetHash(), tx.GetHash()),
+				Key:   databaseKeyForBundle(bundleBucket.GetHash(), txHash),
 				Value: []byte{},
 				Meta:  byte(0),
 			}


### PR DESCRIPTION
Until now we loaded up each transaction of bundles we were evicting on bundle eviction (to check whether it was a tail). The same check can be done against the `bundleInstances` map, as their key is a tail transaction hash.