### PR TITLE
Handle inbound duplicate neighbor correctly

### DIFF
--- a/plugins/gossip/protocol.go
+++ b/plugins/gossip/protocol.go
@@ -1,8 +1,6 @@
 package gossip
 
 import (
-	"fmt"
-
 	"github.com/iotaledger/hive.go/events"
 	"github.com/iotaledger/hive.go/network"
 	"github.com/iotaledger/hive.go/syncutils"
@@ -107,11 +105,8 @@ func (protocol *protocol) Receive(data []byte) {
 
 	for offset < length && protocol.ReceivingState != nil {
 		if readBytes, err := protocol.ReceivingState.Receive(data, offset, length); err != nil {
-			println(fmt.Sprintf("ReceivingState error: %s", err.Error()))
-			Events.Error.Trigger(err)
-
+			protocol.Events.Error.Trigger(err)
 			_ = protocol.Conn.Close()
-
 			return
 		} else {
 			offset += readBytes
@@ -130,12 +125,8 @@ func (protocol *protocol) send(data interface{}) error {
 	if protocol.SendState != nil {
 		if err := protocol.SendState.Send(data); err != nil {
 			protocol.SendState = nil
-
-			_ = protocol.Conn.Close()
-
-			println(fmt.Sprintf("SendState error: %s", err.Error()))
 			protocol.Events.Error.Trigger(err)
-
+			_ = protocol.Conn.Close()
 			return err
 		}
 	}

--- a/plugins/gossip/reconnect_pool.go
+++ b/plugins/gossip/reconnect_pool.go
@@ -71,8 +71,16 @@ func reconnect() {
 	neighborsLock.Lock()
 	newlyInFlight := make([]*Neighbor, 0)
 
+	if len(reconnectPool) == 0 {
+		neighborsLock.Unlock()
+		return
+	}
+
+	gossipLogger.Info("starting reconnect attempts to %d neighbors...", len(reconnectPool))
+
 	// try to lookup each address and if we fail to do so, keep the address in the reconnect pool
-	for _, recNeigh := range reconnectPool {
+next:
+	for k, recNeigh := range reconnectPool {
 		originAddr := recNeigh.OriginAddr
 		neighborAddrs, err := possibleIdentitiesFromNeighborAddress(originAddr)
 		if err != nil {
@@ -86,6 +94,21 @@ func reconnect() {
 		recNeigh.mu.Unlock()
 
 		prefIP := neighborAddrs.GetPreferredAddress(originAddr.PreferIPv6)
+
+		// don't do any new connection attempts, if the neighbor is already connected or in-flight
+		for ip := range neighborAddrs.IPs {
+			id := NewNeighborIdentity(ip.String(), originAddr.Port)
+			if _, alreadyConnected := connectedNeighbors[id]; alreadyConnected {
+				gossipLogger.Infof("neighbor %s already connected, removing it from reconnect pool...")
+				delete(reconnectPool, k)
+				continue next
+			}
+			if _, alreadyInFlight := inFlightNeighbors[id]; alreadyInFlight {
+				gossipLogger.Infof("neighbor %s already in-fight, removing it from reconnect pool...")
+				delete(reconnectPool, k)
+				continue next
+			}
+		}
 		newlyInFlight = append(newlyInFlight, NewOutboundNeighbor(originAddr, prefIP, originAddr.Port, neighborAddrs))
 	}
 	neighborsLock.Unlock()

--- a/plugins/spa/livefeed.go
+++ b/plugins/spa/livefeed.go
@@ -62,7 +62,7 @@ func runLiveFeed() {
 		tangle.Events.ReceivedNewTransaction.Detach(notifyNewTx)
 		tangle.Events.LatestMilestoneChanged.Detach(notifyLMChanged)
 		newTxRateLimiter.Stop()
-		liveFeedWorkerPool.StopAndWait()
+		liveFeedWorkerPool.Stop()
 		log.Info("Stopping SPA[TxUpdater] ... done")
 	}, shutdown.ShutdownPrioritySPA)
 }

--- a/plugins/spa/plugin.go
+++ b/plugins/spa/plugin.go
@@ -83,7 +83,7 @@ func run(plugin *node.Plugin) {
 		metrics.Events.TPSMetricsUpdated.Detach(notifyStatus)
 		tangle_plugin.Events.SolidMilestoneChanged.Detach(notifyNewMs)
 		tangle_plugin.Events.LatestMilestoneChanged.Detach(notifyNewMs)
-		wsSendWorkerPool.StopAndWait()
+		wsSendWorkerPool.Stop()
 		log.Info("Stopping SPA[WSSend] ... done")
 	}, shutdown.ShutdownPrioritySPA)
 

--- a/plugins/webapi/plugin.go
+++ b/plugins/webapi/plugin.go
@@ -110,13 +110,8 @@ func run(plugin *node.Plugin) {
 
 		go func() {
 			log.Infof("You can now access the API using: http://%s", serveAddress)
-			err := server.ListenAndServe()
-			if err != nil {
-				if err == http.ErrServerClosed {
-					log.Info("Stopping WebAPI server ... done")
-				} else {
-					log.Error("Stopping WebAPI server due to an error ... done")
-				}
+			if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+				log.Error("Stopping WebAPI server due to an error ... done")
 			}
 		}()
 


### PR DESCRIPTION
* Prevents an inbound already connected neighbor to cause the actual already connected neighbor to be moved to the reconnect pool and potentially close of the connection. Also reduces the message occurring when such neighbor connects.
* In order to prevent falsely reconnect attempts, now before initiating any reconnect, it is checked whether the given neighbor is in-flight or connected.
* Modifies SPAs background workers to stop without waiting on their worker pools.
* Fixes a wrong trigger on the global (not-used) protocol error event from within receive/send procedures.