### PR TITLE
Removes the spent addresses database in favor of using a Cuckoo filter

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/dgraph-io/badger/v2 v2.0.1-rc1.0.20200102235959-03af216ff00a
 	github.com/dgraph-io/ristretto v0.0.1 // indirect
 	github.com/dgryski/go-farm v0.0.0-20191112170834-c2139c5d712b // indirect
+	github.com/dgryski/go-metro v0.0.0-20180109044635-280f6062b5bc // indirect
 	github.com/eclipse/paho.mqtt.golang v1.2.0
 	github.com/fhmq/hmq v0.0.0-20191230054231-fb453e8c0f61
 	github.com/gin-contrib/gzip v0.0.1
@@ -23,6 +24,7 @@ require (
 	github.com/labstack/gommon v0.3.0 // indirect
 	github.com/mitchellh/mapstructure v1.1.2
 	github.com/pkg/errors v0.8.1
+	github.com/seiflotfy/cuckoofilter v0.0.0-20200106165036-28deee3eabd7
 	github.com/shirou/gopsutil v2.19.12+incompatible
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.6.1

--- a/go.sum
+++ b/go.sum
@@ -65,6 +65,8 @@ github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2 h1:tdlZCpZ/P9DhczC
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
 github.com/dgryski/go-farm v0.0.0-20191112170834-c2139c5d712b h1:SeiGBzKrEtuDddnBABHkp4kq9sBGE9nuYmk6FPTg0zg=
 github.com/dgryski/go-farm v0.0.0-20191112170834-c2139c5d712b/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
+github.com/dgryski/go-metro v0.0.0-20180109044635-280f6062b5bc h1:8WFBn63wegobsYAX0YjD+8suexZDga5CctH4CCTx2+8=
+github.com/dgryski/go-metro v0.0.0-20180109044635-280f6062b5bc/go.mod h1:c9O8+fpSOX1DM8cPNSkX/qsBWdkD4yd2dpciOWQjpBw=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
@@ -277,6 +279,8 @@ github.com/satori/go.uuid v1.2.0 h1:0uYX9dsZ2yD7q2RtLRtPSdGDWzjeM3TbMJP9utgA0ww=
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/segmentio/fasthash v0.0.0-20180216231524-a72b379d632e h1:uO75wNGioszjmIzcY/tvdDYKRLVvzggtAmmJkn9j4GQ=
 github.com/segmentio/fasthash v0.0.0-20180216231524-a72b379d632e/go.mod h1:tm/wZFQ8e24NYaBGIlnO2WGCAi67re4HHuOm0sftE/M=
+github.com/seiflotfy/cuckoofilter v0.0.0-20200106165036-28deee3eabd7 h1:XnGUZV4RnUhngAco2rrTC0Nh8i8TjuohWxNJZfylm24=
+github.com/seiflotfy/cuckoofilter v0.0.0-20200106165036-28deee3eabd7/go.mod h1:ET5mVvNjwaGXRgZxO9UZr7X+8eAf87AfIYNwRSp9s4Y=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/shirou/gopsutil v2.18.12+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=
 github.com/shirou/gopsutil v2.19.12+incompatible h1:WRstheAymn1WOPesh+24+bZKFkqrdCR8JOc77v4xV3Q=

--- a/plugins/gossip/reconnect_pool.go
+++ b/plugins/gossip/reconnect_pool.go
@@ -76,7 +76,7 @@ func reconnect() {
 		return
 	}
 
-	gossipLogger.Info("starting reconnect attempts to %d neighbors...", len(reconnectPool))
+	gossipLogger.Infof("starting reconnect attempts to %d neighbors...", len(reconnectPool))
 
 	// try to lookup each address and if we fail to do so, keep the address in the reconnect pool
 next:

--- a/plugins/snapshot/local_snapshot.go
+++ b/plugins/snapshot/local_snapshot.go
@@ -1,15 +1,17 @@
 package snapshot
 
 import (
+	"bytes"
 	"compress/gzip"
+	"crypto/sha256"
 	"encoding/binary"
 	"fmt"
 	"io"
-	"math"
 	"os"
 	"time"
 
 	"github.com/pkg/errors"
+	cuckoo "github.com/seiflotfy/cuckoofilter"
 
 	"github.com/iotaledger/hive.go/daemon"
 	"github.com/iotaledger/iota.go/consts"
@@ -23,10 +25,13 @@ import (
 )
 
 const (
-	SpentAddressesImportBatchSize       = 100000
-	SolidEntryPointCheckThresholdPast   = 50
-	SolidEntryPointCheckThresholdFuture = 50
+	SpentAddressesImportBatchSize            = 100000
+	SolidEntryPointCheckThresholdPast        = 50
+	SolidEntryPointCheckThresholdFuture      = 50
+	SupportedLocalSnapshotFileVersion   byte = 3
 )
+
+var ErrUnsupportedLSFileVersion = errors.New("unsupported local snapshot file version")
 
 // isSolidEntryPoint checks whether any direct approver of the given transaction was confirmed by a milestone which is above the target milestone.
 func isSolidEntryPoint(txHash trinary.Hash, targetIndex milestone_index.MilestoneIndex) (bool, milestone_index.MilestoneIndex) {
@@ -266,6 +271,17 @@ func checkSnapshotLimits(targetIndex milestone_index.MilestoneIndex, snapshotInf
 
 func createSnapshotFile(filePath string, lsh *localSnapshotHeader, abortSignal <-chan struct{}) error {
 
+	var buf bytes.Buffer
+	if err := lsh.WriteToBuffer(&buf, abortSignal); err != nil {
+		return err
+	}
+
+	// write sha256 hash
+	sha256Hash := sha256.Sum256(buf.Bytes())
+	if err := binary.Write(&buf, binary.LittleEndian, sha256Hash); err != nil {
+		return err
+	}
+
 	exportFile, err := os.OpenFile(filePath, os.O_WRONLY|os.O_CREATE, 0660)
 	if err != nil {
 		return err
@@ -275,18 +291,10 @@ func createSnapshotFile(filePath string, lsh *localSnapshotHeader, abortSignal <
 	gzipWriter := gzip.NewWriter(exportFile)
 	defer gzipWriter.Close()
 
-	if err := lsh.WriteToBuffer(gzipWriter, abortSignal); err != nil {
+	if _, err = io.Copy(gzipWriter, &buf); err != nil {
 		return err
 	}
-
-	/*
-		balancesWritten, err := tangle.StreamBalancesToWriter(gzipWriter, balancesCount, totalBalanceDiffs)
-		if err != nil {
-			return err
-		}
-	*/
-
-	return tangle.StreamSpentAddressesToWriter(gzipWriter, lsh.spentAddressesCount, abortSignal)
+	return nil
 }
 
 func createLocalSnapshotWithoutLocking(targetIndex milestone_index.MilestoneIndex, filePath string, abortSignal <-chan struct{}) error {
@@ -345,11 +353,6 @@ func createLocalSnapshotWithoutLocking(targetIndex milestone_index.MilestoneInde
 	tangle.ReadLockSpentAddresses()
 	defer tangle.ReadUnlockSpentAddresses()
 
-	spentAddressesCount, err := tangle.CountSpentAddressesEntries(abortSignal)
-	if err != nil {
-		return err
-	}
-
 	lsh := &localSnapshotHeader{
 		msHash:              targetMilestone.GetTailHash(),
 		msIndex:             targetIndex,
@@ -357,7 +360,8 @@ func createLocalSnapshotWithoutLocking(targetIndex milestone_index.MilestoneInde
 		solidEntryPoints:    newSolidEntryPoints,
 		seenMilestones:      seenMilestones,
 		balances:            newBalances,
-		spentAddressesCount: spentAddressesCount,
+		spentAddressesCount: tangle.CountSpentAddressesEntries(),
+		cuckooFilterBytes:   tangle.SerializedSpentAddressesCuckooFilter(),
 	}
 
 	filePathTmp := filePath + "_tmp"
@@ -408,48 +412,46 @@ type localSnapshotHeader struct {
 	seenMilestones      map[string]milestone_index.MilestoneIndex
 	balances            map[string]uint64
 	spentAddressesCount int32
+	cuckooFilterBytes   []byte
 }
 
 func (ls *localSnapshotHeader) WriteToBuffer(buf io.Writer, abortSignal <-chan struct{}) error {
 	var err error
+
+	if err = binary.Write(buf, binary.LittleEndian, SupportedLocalSnapshotFileVersion); err != nil {
+		return err
+	}
 
 	msHashBytes, err := trinary.TrytesToBytes(ls.msHash)
 	if err != nil {
 		return err
 	}
 
-	err = binary.Write(buf, binary.BigEndian, msHashBytes[:49])
-	if err != nil {
+	if err = binary.Write(buf, binary.LittleEndian, msHashBytes[:49]); err != nil {
 		return err
 	}
 
-	err = binary.Write(buf, binary.BigEndian, ls.msIndex)
-	if err != nil {
+	if err = binary.Write(buf, binary.LittleEndian, ls.msIndex); err != nil {
 		return err
 	}
 
-	err = binary.Write(buf, binary.BigEndian, ls.msTimestamp)
-	if err != nil {
+	if err = binary.Write(buf, binary.LittleEndian, ls.msTimestamp); err != nil {
 		return err
 	}
 
-	err = binary.Write(buf, binary.BigEndian, int32(len(ls.solidEntryPoints)))
-	if err != nil {
+	if err = binary.Write(buf, binary.LittleEndian, int32(len(ls.solidEntryPoints))); err != nil {
 		return err
 	}
 
-	err = binary.Write(buf, binary.BigEndian, int32(len(ls.seenMilestones)))
-	if err != nil {
+	if err = binary.Write(buf, binary.LittleEndian, int32(len(ls.seenMilestones))); err != nil {
 		return err
 	}
 
-	err = binary.Write(buf, binary.BigEndian, int32(len(ls.balances)))
-	if err != nil {
+	if err = binary.Write(buf, binary.LittleEndian, int32(len(ls.balances))); err != nil {
 		return err
 	}
 
-	err = binary.Write(buf, binary.BigEndian, ls.spentAddressesCount)
-	if err != nil {
+	if err = binary.Write(buf, binary.LittleEndian, ls.spentAddressesCount); err != nil {
 		return err
 	}
 
@@ -465,13 +467,11 @@ func (ls *localSnapshotHeader) WriteToBuffer(buf io.Writer, abortSignal <-chan s
 			return err
 		}
 
-		err = binary.Write(buf, binary.BigEndian, addrBytes[:49])
-		if err != nil {
+		if err = binary.Write(buf, binary.LittleEndian, addrBytes[:49]); err != nil {
 			return err
 		}
 
-		err = binary.Write(buf, binary.BigEndian, val)
-		if err != nil {
+		if err = binary.Write(buf, binary.LittleEndian, val); err != nil {
 			return err
 		}
 	}
@@ -488,13 +488,11 @@ func (ls *localSnapshotHeader) WriteToBuffer(buf io.Writer, abortSignal <-chan s
 			return err
 		}
 
-		err = binary.Write(buf, binary.BigEndian, addrBytes[:49])
-		if err != nil {
+		if err = binary.Write(buf, binary.LittleEndian, addrBytes[:49]); err != nil {
 			return err
 		}
 
-		err = binary.Write(buf, binary.BigEndian, val)
-		if err != nil {
+		if err = binary.Write(buf, binary.LittleEndian, val); err != nil {
 			return err
 		}
 	}
@@ -512,15 +510,20 @@ func (ls *localSnapshotHeader) WriteToBuffer(buf io.Writer, abortSignal <-chan s
 			return err
 		}
 
-		err = binary.Write(buf, binary.BigEndian, addrBytes[:49])
-		if err != nil {
+		if err = binary.Write(buf, binary.LittleEndian, addrBytes[:49]); err != nil {
 			return err
 		}
 
-		err = binary.Write(buf, binary.BigEndian, val)
-		if err != nil {
+		if err = binary.Write(buf, binary.LittleEndian, val); err != nil {
 			return err
 		}
+	}
+
+	if err := binary.Write(buf, binary.LittleEndian, int32(len(ls.cuckooFilterBytes))); err != nil {
+		return err
+	}
+	if err := binary.Write(buf, binary.LittleEndian, ls.cuckooFilterBytes); err != nil {
+		return err
 	}
 
 	return nil
@@ -541,9 +544,18 @@ func LoadSnapshotFromFile(filePath string) error {
 	}
 	defer gzipReader.Close()
 
+	// check file version
+	var fileVersion byte
+	if err := binary.Read(gzipReader, binary.LittleEndian, &fileVersion); err != nil {
+		return err
+	}
+
+	if fileVersion != SupportedLocalSnapshotFileVersion {
+		return errors.Wrapf(ErrUnsupportedLSFileVersion, "local snapshot file version is %d but this Hornet version only supports %d", fileVersion, SupportedLocalSnapshotFileVersion)
+	}
+
 	hashBuf := make([]byte, 49)
-	_, err = gzipReader.Read(hashBuf)
-	if err != nil {
+	if _, err := gzipReader.Read(hashBuf); err != nil {
 		return err
 	}
 
@@ -562,36 +574,30 @@ func LoadSnapshotFromFile(filePath string) error {
 		return err
 	}
 
-	err = binary.Read(gzipReader, binary.BigEndian, &msIndex)
-	if err != nil {
+	if err := binary.Read(gzipReader, binary.LittleEndian, &msIndex); err != nil {
 		return err
 	}
 
-	err = binary.Read(gzipReader, binary.BigEndian, &msTimestamp)
-	if err != nil {
+	if err := binary.Read(gzipReader, binary.LittleEndian, &msTimestamp); err != nil {
 		return err
 	}
 
 	tangle.SetSnapshotMilestone(msHash[:81], milestone_index.MilestoneIndex(msIndex), milestone_index.MilestoneIndex(msIndex), msTimestamp)
 	tangle.SolidEntryPointsAdd(msHash[:81], milestone_index.MilestoneIndex(msIndex))
 
-	err = binary.Read(gzipReader, binary.BigEndian, &solidEntryPointsCount)
-	if err != nil {
+	if err := binary.Read(gzipReader, binary.LittleEndian, &solidEntryPointsCount); err != nil {
 		return err
 	}
 
-	err = binary.Read(gzipReader, binary.BigEndian, &seenMilestonesCount)
-	if err != nil {
+	if err := binary.Read(gzipReader, binary.LittleEndian, &seenMilestonesCount); err != nil {
 		return err
 	}
 
-	err = binary.Read(gzipReader, binary.BigEndian, &ledgerEntriesCount)
-	if err != nil {
+	if err := binary.Read(gzipReader, binary.LittleEndian, &ledgerEntriesCount); err != nil {
 		return err
 	}
 
-	err = binary.Read(gzipReader, binary.BigEndian, &spentAddrsCount)
-	if err != nil {
+	if err := binary.Read(gzipReader, binary.LittleEndian, &spentAddrsCount); err != nil {
 		return err
 	}
 
@@ -604,13 +610,11 @@ func LoadSnapshotFromFile(filePath string) error {
 
 		var val int32
 
-		err = binary.Read(gzipReader, binary.BigEndian, hashBuf)
-		if err != nil {
+		if err := binary.Read(gzipReader, binary.LittleEndian, hashBuf); err != nil {
 			return errors.Wrapf(ErrSnapshotImportFailed, "solidEntryPoints: %v", err)
 		}
 
-		err = binary.Read(gzipReader, binary.BigEndian, &val)
-		if err != nil {
+		if err := binary.Read(gzipReader, binary.LittleEndian, &val); err != nil {
 			return errors.Wrapf(ErrSnapshotImportFailed, "solidEntryPoints: %v", err)
 		}
 
@@ -635,13 +639,11 @@ func LoadSnapshotFromFile(filePath string) error {
 
 		var val int32
 
-		err = binary.Read(gzipReader, binary.BigEndian, hashBuf)
-		if err != nil {
+		if err := binary.Read(gzipReader, binary.LittleEndian, hashBuf); err != nil {
 			return errors.Wrapf(ErrSnapshotImportFailed, "seenMilestones: %v", err)
 		}
 
-		err = binary.Read(gzipReader, binary.BigEndian, &val)
-		if err != nil {
+		if err := binary.Read(gzipReader, binary.LittleEndian, &val); err != nil {
 			return errors.Wrapf(ErrSnapshotImportFailed, "seenMilestones: %v", err)
 		}
 
@@ -664,13 +666,11 @@ func LoadSnapshotFromFile(filePath string) error {
 
 		var val uint64
 
-		err = binary.Read(gzipReader, binary.BigEndian, hashBuf)
-		if err != nil {
+		if err := binary.Read(gzipReader, binary.LittleEndian, hashBuf); err != nil {
 			return errors.Wrapf(ErrSnapshotImportFailed, "ledgerEntries: %v", err)
 		}
 
-		err = binary.Read(gzipReader, binary.BigEndian, &val)
-		if err != nil {
+		if err := binary.Read(gzipReader, binary.LittleEndian, &val); err != nil {
 			return errors.Wrapf(ErrSnapshotImportFailed, "ledgerEntries: %v", err)
 		}
 
@@ -686,42 +686,30 @@ func LoadSnapshotFromFile(filePath string) error {
 		return errors.Wrapf(ErrSnapshotImportFailed, "ledgerEntries: %v", err)
 	}
 
-	log.Infof("Importing %d spent addresses. This can take a while...", spentAddrsCount)
+	log.Infof("Deserializing spent addresses cuckoo filter containing %d addresses.", spentAddrsCount)
 
-	batchAmount := int(math.Ceil(float64(spentAddrsCount) / float64(SpentAddressesImportBatchSize)))
-	for i := 0; i < batchAmount; i++ {
-		if daemon.IsStopped() {
-			return ErrSnapshotImportWasAborted
-		}
-
-		var batchEntries [][]byte
-		batchStart := int32(i * SpentAddressesImportBatchSize)
-		batchEnd := batchStart + SpentAddressesImportBatchSize
-
-		if batchEnd > spentAddrsCount {
-			batchEnd = spentAddrsCount
-		}
-
-		for j := batchStart; j < batchEnd; j++ {
-
-			spentAddrBuf := make([]byte, 49)
-			err = binary.Read(gzipReader, binary.BigEndian, spentAddrBuf)
-			if err != nil {
-				return errors.Wrapf(ErrSnapshotImportFailed, "spentAddrs: %v", err)
-			}
-
-			batchEntries = append(batchEntries, spentAddrBuf)
-		}
-
-		err = tangle.StoreSpentAddressesBytesInDatabase(batchEntries)
-		if err != nil {
-			return errors.Wrapf(ErrSnapshotImportFailed, "spentAddrs: %v", err)
-		}
-
-		log.Infof("Processed %d/%d spent addresses", batchEnd, spentAddrsCount)
+	// read serialized cuckoo filter byte size
+	var cuckooFilterSize int32
+	if err := binary.Read(gzipReader, binary.LittleEndian, &cuckooFilterSize); err != nil {
+		return errors.Wrapf(ErrSnapshotImportFailed, "couldn't deserialize cuckoo filter size: %v", err)
 	}
 
-	log.Info("Finished loading snapshot")
+	cuckooFilterData := make([]byte, cuckooFilterSize)
+	if err := binary.Read(gzipReader, binary.LittleEndian, &cuckooFilterData); err != nil {
+		return errors.Wrapf(ErrSnapshotImportFailed, "couldn't read serialized cuckoo filter bytes: %v", err)
+	}
 
+	cuckooFilter, err := cuckoo.Decode(cuckooFilterData)
+	if err != nil {
+		return errors.Wrapf(ErrSnapshotImportFailed, "couldn't reconstruct the cuckoo filter from the data within the snapshot file: %v", err)
+	}
+
+	if err := tangle.ImportSpentAddressesCuckooFilter(cuckooFilter); err != nil {
+		return err
+	}
+
+	tangle.InitSpentAddressesCuckooFilter()
+
+	log.Info("Finished loading snapshot")
 	return nil
 }

--- a/plugins/spa/explorer_routes.go
+++ b/plugins/spa/explorer_routes.go
@@ -327,11 +327,6 @@ func findAddress(hash Hash) (*ExplorerAdress, error) {
 		}
 	}
 
-	spent, err := tangle.WasAddressSpentFrom(hash)
-	if err != nil {
-		return nil, ErrInternalError
-	}
-
 	balance, _, err := tangle.GetBalanceForAddress(hash)
 	if err != nil {
 		return nil, err
@@ -341,5 +336,5 @@ func findAddress(hash Hash) (*ExplorerAdress, error) {
 		return nil, errors.Wrapf(ErrNotFound, "address %s not found", hash)
 	}
 
-	return &ExplorerAdress{Balance: balance, Txs: txs, Spent: spent}, nil
+	return &ExplorerAdress{Balance: balance, Txs: txs, Spent: tangle.WasAddressSpentFrom(hash)}, nil
 }

--- a/plugins/spa/frontend/src/app/components/Misc.tsx
+++ b/plugins/spa/frontend/src/app/components/Misc.tsx
@@ -111,6 +111,21 @@ export class Misc extends React.Component<Props, any> {
                     <Col>
                         <Card>
                             <Card.Body>
+                                <Card.Title>Spent Adddresses</Card.Title>
+                                <small>
+                                    Shows the approximate amount of spent addresses persisted in the Cuckoo filter of
+                                    the node.
+                                </small>
+                                <Line height={60} data={this.props.nodeStore.spentAddrsSeries}
+                                      options={reqLineChartOptions}/>
+                            </Card.Body>
+                        </Card>
+                    </Col>
+                </Row>
+                <Row className={"mb-3"}>
+                    <Col>
+                        <Card>
+                            <Card.Body>
                                 <Card.Title>Requests</Card.Title>
                                 <Line height={60} data={this.props.nodeStore.stingReqs}
                                       options={reqLineChartOptions}/>

--- a/plugins/spa/frontend/src/app/stores/NodeStore.ts
+++ b/plugins/spa/frontend/src/app/stores/NodeStore.ts
@@ -84,6 +84,7 @@ class ServerMetrics {
     dropped_sent_packets: number;
     rec_tx_req: number;
     sent_tx_req: number;
+    spent_addrs_count: number;
     ts: number;
 }
 
@@ -562,6 +563,21 @@ export class NodeStore {
                 all, invalid, stale, random, sent, newTx, droppedSent
             ],
         };
+    }
+
+    @computed
+    get spentAddrsSeries() {
+        let spentAddrs = Object.assign({}, chartSeriesOpts,
+            series("Spent Addresses", 'rgba(219, 53, 53,1)', 'rgba(219, 53, 53,0.4)')
+        );
+
+        let labels = [];
+        for (let i = 0; i < this.collected_server_metrics.length; i++) {
+            let metric: ServerMetrics = this.collected_server_metrics[i];
+            labels.push(metric.spent_addrs_count);
+        }
+
+        return {labels: labels, datasets: [spentAddrs],};
     }
 
     @computed

--- a/plugins/spa/plugin.go
+++ b/plugins/spa/plugin.go
@@ -211,6 +211,7 @@ type servermetrics struct {
 	DroppedSentPackets uint32 `json:"dropped_sent_packets"`
 	RecTxReq           uint32 `json:"rec_tx_req"`
 	SentTxReq          uint32 `json:"sent_tx_req"`
+	SpentAddrsCount    int32  `json:"spent_addrs_count"`
 }
 
 type memmetrics struct {
@@ -313,10 +314,6 @@ func currentNodeStatus() *nodestatus {
 			Size:     tangle.MilestoneCache.GetSize(),
 			Capacity: tangle.MilestoneCache.GetCapacity(),
 		},
-		SpentAddresses: cache{
-			Size:     tangle.SpentAddressesCache.GetSize(),
-			Capacity: tangle.SpentAddressesCache.GetCapacity(),
-		},
 		Transactions: cache{
 			Size:     tangle.TransactionCache.GetSize(),
 			Capacity: tangle.TransactionCache.GetCapacity(),
@@ -344,6 +341,7 @@ func currentNodeStatus() *nodestatus {
 		SentMsReq:          server.SharedServerMetrics.GetSentMilestoneRequestsCount(),
 		RecTxReq:           server.SharedServerMetrics.GetReceivedTransactionRequestCount(),
 		SentTxReq:          server.SharedServerMetrics.GetSentTransactionRequestCount(),
+		SpentAddrsCount:    tangle.CountSpentAddressesEntries(),
 	}
 
 	// memory metrics

--- a/plugins/spa/routes.go
+++ b/plugins/spa/routes.go
@@ -145,11 +145,11 @@ func websocketRoute(c echo.Context) error {
 		<-msgRateLimiter.C
 		msg := <-channel
 		if err := ws.WriteJSON(msg); err != nil {
-			log.Errorf("error while writing to web socket client %s: %s", c.RealIP(), err.Error())
+			log.Warnf("error while writing to web socket client %s: %s", c.RealIP(), err.Error())
 			break
 		}
 		if err := ws.SetWriteDeadline(time.Now().Add(webSocketWriteTimeout)); err != nil {
-			log.Errorf("error while setting write deadline on web socket client %s: %s", c.RealIP(), err.Error())
+			log.Warnf("error while setting write deadline on web socket client %s: %s", c.RealIP(), err.Error())
 			break
 		}
 	}

--- a/plugins/webapi/spent.go
+++ b/plugins/webapi/spent.go
@@ -47,15 +47,8 @@ func wereAddressesSpentFrom(i interface{}, c *gin.Context, abortSignal <-chan st
 			return
 		}
 
-		spent, err := tangle.WasAddressSpentFrom(addr[:81])
-		if err != nil {
-			e.Error = "Spent addresses db invalid"
-			c.JSON(http.StatusInternalServerError, e)
-			return
-		}
-
 		// State
-		spr.States = append(spr.States, spent)
+		spr.States = append(spr.States, tangle.WasAddressSpentFrom(addr[:81]))
 	}
 
 	c.JSON(http.StatusOK, spr)


### PR DESCRIPTION
* Spent addresses will now be stored inside a cuckoo filter with a capacity of 50 million entries. (The current spent addresses size is 13 million)
* The local snapshot files obey to version 3 of https://github.com/iotaledger/iri-ls-sa-merger and therefore also newly read/write in little endian, store a cuckoo filter and a sha256 hash of the entire snapshot data
* Removed the cache for spent addresses and made a separate chart in the SPA (because there's no longer a cache size)