### PR TITLE
- Moving storing of new incoming tx into the bundle bucket

### DIFF
--- a/plugins/snapshot/plugin.go
+++ b/plugins/snapshot/plugin.go
@@ -147,13 +147,11 @@ func installGenesisTransaction() {
 	genesis.Hash = consts.NullHashTrytes
 	txBytesTruncated := compressed.TruncateTx(trinary.TritsToBytes(genesisTxTrits))
 	genesisTx := hornet.NewTransactionFromAPI(genesis, txBytesTruncated)
-	transaction := tangle.StoreTransaction(genesisTx) //+1
 
 	// ensure the bundle is also existent for the genesis tx
 	genesisBundleBucket, err := tangle.GetBundleBucket(genesis.Bundle)
 	if err != nil {
 		log.Panic(err)
 	}
-	genesisBundleBucket.AddTransaction(transaction)
-	transaction.Release() //-1
+	genesisBundleBucket.AddTransaction(genesisTx)
 }

--- a/plugins/tangle/bundles.go
+++ b/plugins/tangle/bundles.go
@@ -1,15 +1,13 @@
 package tangle
 
 import (
+	"github.com/gohornet/hornet/packages/model/hornet"
 	"github.com/gohornet/hornet/packages/model/tangle"
 )
 
-func addTransactionToBundleBucket(transaction *tangle.CachedTransaction) []*tangle.Bundle {
+func addTransactionToBundleBucket(transaction *hornet.Transaction) (bundles []*tangle.Bundle, alreadyAdded bool) {
 
-	transaction.RegisterConsumer() //+1
-	defer transaction.Release()    //-1
-
-	bundleBucket, err := tangle.GetBundleBucket(transaction.GetTransaction().Tx.Bundle)
+	bundleBucket, err := tangle.GetBundleBucket(transaction.Tx.Bundle)
 	if err != nil {
 		log.Panic(err)
 	}


### PR DESCRIPTION
Incoming Tx are now stored to the OS in AddTransaction(), so that the bucket is locked when a new tx is added to the storage

This way we make sure that no solidifier can try to solidify this tx before it was processed in the bundle bucket