### PR TITLE
Neighbors stats

### DIFF
--- a/plugins/spa/frontend/src/app/components/LatestMilestone.tsx
+++ b/plugins/spa/frontend/src/app/components/LatestMilestone.tsx
@@ -19,7 +19,7 @@ export default class LatestMilestone extends React.Component<Props, any> {
                 {' '}
                 {
                     this.props.nodeStore.isNodeSync() ?
-                        <Badge variant="light">Synced</Badge>
+                        <Badge variant="success">Synced</Badge>
                         :
                         <Badge variant="warning">Not Synced</Badge>
                 }

--- a/plugins/spa/frontend/src/app/components/Misc.tsx
+++ b/plugins/spa/frontend/src/app/components/Misc.tsx
@@ -111,7 +111,7 @@ export class Misc extends React.Component<Props, any> {
                     <Col>
                         <Card>
                             <Card.Body>
-                                <Card.Title>Spent Adddresses</Card.Title>
+                                <Card.Title>Spent Addresses</Card.Title>
                                 <small>
                                     Shows the approximate amount of spent addresses persisted in the Cuckoo filter of
                                     the node.

--- a/plugins/spa/frontend/src/app/components/Neighbor.tsx
+++ b/plugins/spa/frontend/src/app/components/Neighbor.tsx
@@ -88,7 +88,22 @@ export class Neighbor extends React.Component<Props, any> {
                     <Card>
                         <Card.Body>
                             <Card.Title>
-                                <h5>{last.origin_addr}</h5>
+                                <h5>
+                                    {last.origin_addr}
+                                    {' '}
+                                    {
+                                        last.protocol_version == 1 ?
+                                            <Badge variant="secondary">Legacy</Badge>
+                                            :
+                                            last.heartbeat.solid_milestone_index < this.props.nodeStore.status.lmi ?
+                                                <Badge variant="warning">Unsynced</Badge>
+                                                :
+                                                last.heartbeat.pruned_milestone_index > this.props.nodeStore.status.lsmi ?
+                                                    <Badge variant="danger">Milestones Pruned</Badge>
+                                                    :
+                                                    <Badge variant="success">STING</Badge>
+                                    }
+                                </h5>
                             </Card.Title>
                             <Row className={"mb-3"}>
                                 <Col>


### PR DESCRIPTION
Added a badge to each neighbor to show the status in a quick way
Gray: Legacy neighbor using v1
Red: STING neighbor, but pruning index is too new so we won't be able to sync with it
Yellow: STING neighbor but node is unsynced
Green: STING neighbor