### PR TITLE
Replace incomingCache with objectStorage

### DIFF
--- a/config.json
+++ b/config.json
@@ -3,6 +3,9 @@
   "profiles": {
     "custom": {
       "caches": {
+        "approvers": {
+          "cacheTimeMs": 5000
+        },
         "bundles": {
           "size": 20000,
           "evictionSize": 1000
@@ -15,8 +18,11 @@
           "size": 5000,
           "evictionSize": 1000
         },
+        "transactions": {
+          "cacheTimeMs": 5000
+        },
         "incomingTransactionFilter": {
-          "size": 5000
+          "cacheTimeMs": 5000
         },
         "refsInvalidBundle": {
           "size": 10000

--- a/packages/model/tangle/approvers.go
+++ b/packages/model/tangle/approvers.go
@@ -9,6 +9,7 @@ import (
 
 	hornetDB "github.com/gohornet/hornet/packages/database"
 	"github.com/gohornet/hornet/packages/model/hornet"
+	"github.com/gohornet/hornet/packages/profile"
 )
 
 var approversStorage *objectstorage.ObjectStorage
@@ -48,11 +49,13 @@ func GetApproversStorageSize() int {
 
 func configureApproversStorage() {
 
+	opts := profile.GetProfile().Caches.Approvers
+
 	approversStorage = objectstorage.New(
 		[]byte{DBPrefixApprovers},
 		approversFactory,
 		objectstorage.BadgerInstance(hornetDB.GetHornetBadgerInstance()),
-		objectstorage.CacheTime(1500*time.Millisecond),
+		objectstorage.CacheTime(time.Duration(opts.CacheTimeMs)*time.Millisecond),
 		objectstorage.PersistenceEnabled(true))
 }
 

--- a/packages/model/tangle/transaction.go
+++ b/packages/model/tangle/transaction.go
@@ -10,6 +10,7 @@ import (
 	hornetDB "github.com/gohornet/hornet/packages/database"
 	"github.com/gohornet/hornet/packages/model/hornet"
 	"github.com/gohornet/hornet/packages/model/milestone_index"
+	"github.com/gohornet/hornet/packages/profile"
 )
 
 var txStorage *objectstorage.ObjectStorage
@@ -60,11 +61,13 @@ func GetTransactionStorageSize() int {
 
 func configureTransactionStorage() {
 
+	opts := profile.GetProfile().Caches.Transactions
+
 	txStorage = objectstorage.New(
 		[]byte{DBPrefixTransactions},
 		transactionFactory,
 		objectstorage.BadgerInstance(hornetDB.GetHornetBadgerInstance()),
-		objectstorage.CacheTime(1500*time.Millisecond),
+		objectstorage.CacheTime(time.Duration(opts.CacheTimeMs)*time.Millisecond),
 		objectstorage.PersistenceEnabled(true))
 }
 

--- a/packages/profile/profile.go
+++ b/packages/profile/profile.go
@@ -71,6 +71,9 @@ func GetProfile() *Profile {
 
 var Profile8GB = &Profile{
 	Caches: Caches{
+		Approvers: CacheOpts{
+			CacheTimeMs: 60000,
+		},
 		Bundles: CacheOpts{
 			Size:         20000,
 			EvictionSize: 1000,
@@ -83,8 +86,11 @@ var Profile8GB = &Profile{
 			Size:         5000,
 			EvictionSize: 1000,
 		},
+		Transactions: CacheOpts{
+			CacheTimeMs: 60000,
+		},
 		IncomingTransactionFilter: CacheOpts{
-			Size: 5000,
+			CacheTimeMs: 5000,
 		},
 		RefsInvalidBundle: CacheOpts{
 			Size: 10000,
@@ -122,6 +128,9 @@ var Profile8GB = &Profile{
 
 var Profile4GB = &Profile{
 	Caches: Caches{
+		Approvers: CacheOpts{
+			CacheTimeMs: 30000,
+		},
 		Bundles: CacheOpts{
 			Size:         20000,
 			EvictionSize: 1000,
@@ -134,8 +143,11 @@ var Profile4GB = &Profile{
 			Size:         5000,
 			EvictionSize: 1000,
 		},
+		Transactions: CacheOpts{
+			CacheTimeMs: 30000,
+		},
 		IncomingTransactionFilter: CacheOpts{
-			Size: 5000,
+			CacheTimeMs: 5000,
 		},
 		RefsInvalidBundle: CacheOpts{
 			Size: 10000,
@@ -173,6 +185,9 @@ var Profile4GB = &Profile{
 
 var Profile2GB = &Profile{
 	Caches: Caches{
+		Approvers: CacheOpts{
+			CacheTimeMs: 5000,
+		},
 		Bundles: CacheOpts{
 			Size:         10000,
 			EvictionSize: 1000,
@@ -185,8 +200,11 @@ var Profile2GB = &Profile{
 			Size:         2000,
 			EvictionSize: 1000,
 		},
+		Transactions: CacheOpts{
+			CacheTimeMs: 5000,
+		},
 		IncomingTransactionFilter: CacheOpts{
-			Size: 5000,
+			CacheTimeMs: 2500,
 		},
 		RefsInvalidBundle: CacheOpts{
 			Size: 10000,
@@ -224,6 +242,9 @@ var Profile2GB = &Profile{
 
 var Profile1GB = &Profile{
 	Caches: Caches{
+		Approvers: CacheOpts{
+			CacheTimeMs: 1500,
+		},
 		Bundles: CacheOpts{
 			Size:         5000,
 			EvictionSize: 1000,
@@ -236,8 +257,11 @@ var Profile1GB = &Profile{
 			Size:         2000,
 			EvictionSize: 1000,
 		},
+		Transactions: CacheOpts{
+			CacheTimeMs: 1500,
+		},
 		IncomingTransactionFilter: CacheOpts{
-			Size: 5000,
+			CacheTimeMs: 1500,
 		},
 		RefsInvalidBundle: CacheOpts{
 			Size: 10000,
@@ -281,8 +305,10 @@ type Profile struct {
 
 type Caches struct {
 	Bundles                   CacheOpts `json:"bundles"`
+	Approvers                 CacheOpts `json:"approvers"`
 	Milestones                CacheOpts `json:"milestones"`
 	SpentAddresses            CacheOpts `json:"spentAddresses"`
+	Transactions              CacheOpts `json:"transactions"`
 	IncomingTransactionFilter CacheOpts `json:"incomingTransactionFilter"`
 	RefsInvalidBundle         CacheOpts `json:"refsInvalidBundle"`
 }
@@ -290,6 +316,7 @@ type Caches struct {
 type CacheOpts struct {
 	Size         int    `json:"size"`
 	EvictionSize uint64 `json:"evictionSize"`
+	CacheTimeMs  uint64 `json:"cacheTimeMs"`
 }
 
 type BadgerOpts struct {

--- a/plugins/gossip/incoming_storage.go
+++ b/plugins/gossip/incoming_storage.go
@@ -1,0 +1,39 @@
+package gossip
+
+import (
+	"github.com/iotaledger/hive.go/objectstorage"
+)
+
+var (
+	incomingStorage *objectstorage.ObjectStorage
+)
+
+type CachedNeighborRequest struct {
+	*objectstorage.CachedObject
+}
+
+func (c *CachedNeighborRequest) GetRequest() *PendingNeighborRequests {
+	return c.Get().(*PendingNeighborRequests)
+}
+
+func incomingFactory(key []byte) objectstorage.StorableObject {
+	return &PendingNeighborRequests{
+		recTxBytes: key,
+		requests:   make([]*NeighborRequest, 0),
+	}
+}
+
+func GetIncomingStorageSize() int {
+	return incomingStorage.GetSize()
+}
+
+// +1
+func GetCachedPendingNeighborRequest(recTxBytes []byte) *CachedNeighborRequest {
+	return &CachedNeighborRequest{
+		incomingStorage.ComputeIfAbsent(recTxBytes, func(key []byte) objectstorage.StorableObject {
+			return &PendingNeighborRequests{
+				recTxBytes: key,
+				requests:   make([]*NeighborRequest, 0),
+			}
+		})}
+}

--- a/plugins/gossip/incoming_storage.go
+++ b/plugins/gossip/incoming_storage.go
@@ -30,10 +30,6 @@ func GetIncomingStorageSize() int {
 // +1
 func GetCachedPendingNeighborRequest(recTxBytes []byte) *CachedNeighborRequest {
 	return &CachedNeighborRequest{
-		incomingStorage.ComputeIfAbsent(recTxBytes, func(key []byte) objectstorage.StorableObject {
-			return &PendingNeighborRequests{
-				recTxBytes: key,
-				requests:   make([]*NeighborRequest, 0),
-			}
-		})}
+		incomingStorage.ComputeIfAbsent(recTxBytes, incomingFactory),
+	}
 }

--- a/plugins/gossip/neighbor_request.go
+++ b/plugins/gossip/neighbor_request.go
@@ -1,0 +1,258 @@
+package gossip
+
+import (
+	"github.com/iotaledger/iota.go/transaction"
+	"github.com/iotaledger/iota.go/trinary"
+
+	"github.com/iotaledger/hive.go/objectstorage"
+	"github.com/iotaledger/hive.go/syncutils"
+
+	"github.com/gohornet/hornet/packages/compressed"
+	"github.com/gohornet/hornet/packages/model/hornet"
+	"github.com/gohornet/hornet/packages/model/milestone_index"
+	"github.com/gohornet/hornet/plugins/gossip/server"
+)
+
+type NeighborRequest struct {
+	p                          *protocol
+	reqHashBytes               []byte
+	reqMilestoneIndex          milestone_index.MilestoneIndex
+	isMilestoneRequest         bool
+	isTransactionRequest       bool
+	isLegacyTransactionRequest bool
+	hasNoRequest               bool
+}
+
+func (n *NeighborRequest) punish() {
+	n.p.Neighbor.Metrics.IncrInvalidTransactionsCount()
+}
+
+func (n *NeighborRequest) notify(recHashBytes []byte) {
+	n.p.Neighbor.Reply(recHashBytes, n)
+}
+
+type PendingNeighborRequests struct {
+	objectstorage.StorableObjectFlags
+	startProcessingLock syncutils.Mutex
+
+	// data
+	dataLock     syncutils.RWMutex
+	recTxBytes   []byte
+	recHashBytes []byte
+	recHash      trinary.Hash
+	hornetTx     *hornet.Transaction
+
+	// status
+	statusLock syncutils.RWMutex
+	invalid    bool
+	hashing    bool
+
+	// requests
+	requestsLock syncutils.RWMutex
+	requests     []*NeighborRequest
+}
+
+// ObjectStorage interface
+func (p *PendingNeighborRequests) Update(other objectstorage.StorableObject) {
+	if obj, ok := other.(*PendingNeighborRequests); !ok {
+		panic("invalid object passed to PendingNeighborRequests.Update()")
+	} else {
+		// data
+		p.dataLock = obj.dataLock
+		p.recTxBytes = obj.recTxBytes
+		p.recHashBytes = obj.recHashBytes
+		p.recHash = obj.recHash
+		p.hornetTx = obj.hornetTx
+
+		// status
+		p.invalid = obj.invalid
+		p.hashing = obj.hashing
+
+		// requests
+		p.requests = obj.requests
+	}
+}
+
+func (p *PendingNeighborRequests) GetStorageKey() []byte {
+	return p.recTxBytes
+}
+
+func (p *PendingNeighborRequests) MarshalBinary() (data []byte, err error) {
+	return nil, nil
+}
+
+func (p *PendingNeighborRequests) UnmarshalBinary(data []byte) error {
+	return nil
+}
+
+func (p *PendingNeighborRequests) AddLegacyTxRequest(neighbor *protocol, reqHashBytes []byte) {
+	p.requestsLock.Lock()
+	defer p.requestsLock.Unlock()
+
+	p.requests = append(p.requests, &NeighborRequest{
+		p:                          neighbor,
+		reqHashBytes:               reqHashBytes,
+		isLegacyTransactionRequest: true,
+	})
+}
+
+func (p *PendingNeighborRequests) BlockFeedback(neighbor *protocol) {
+	p.requestsLock.Lock()
+	defer p.requestsLock.Unlock()
+
+	p.requests = append(p.requests, &NeighborRequest{
+		p:            neighbor,
+		hasNoRequest: true,
+	})
+}
+
+func (p *PendingNeighborRequests) IsHashing() bool {
+	p.statusLock.RLock()
+	defer p.statusLock.RUnlock()
+	return p.hashing
+}
+
+func (p *PendingNeighborRequests) IsHashed() bool {
+	p.statusLock.RLock()
+	defer p.statusLock.RUnlock()
+	return len(p.recHashBytes) > 0
+}
+
+func (p *PendingNeighborRequests) IsInvalid() bool {
+	p.statusLock.RLock()
+	defer p.statusLock.RUnlock()
+	return p.invalid
+}
+
+func (p *PendingNeighborRequests) GetTxHash() trinary.Hash {
+	p.dataLock.RLock()
+	defer p.dataLock.RUnlock()
+	return p.recHash
+}
+
+func (p *PendingNeighborRequests) GetTxHashBytes() []byte {
+	p.dataLock.RLock()
+	defer p.dataLock.RUnlock()
+	return p.recHashBytes
+}
+
+func (p *PendingNeighborRequests) process() {
+	p.startProcessingLock.Lock()
+
+	if p.IsHashing() {
+		p.startProcessingLock.Unlock()
+		return
+	} else if p.IsInvalid() {
+		p.startProcessingLock.Unlock()
+		p.punish()
+		return
+	} else if p.IsHashed() {
+		p.startProcessingLock.Unlock()
+
+		// Mark the pending request as received because we received the requested Tx Hash
+		requested := RequestQueue.MarkReceived(p.hornetTx.Tx.Hash)
+
+		if requested {
+			// Tx is requested => ignore that it was marked as stale before
+			p.hornetTx.SetRequested(requested)
+			Events.ReceivedTransaction.Trigger(p.hornetTx)
+		}
+
+		p.notify()
+		return
+	}
+
+	p.statusLock.Lock()
+	p.hashing = true
+	p.statusLock.Unlock()
+	p.startProcessingLock.Unlock()
+
+	tx, err := compressed.TransactionFromCompressedBytes(p.recTxBytes)
+	if err != nil {
+		return
+	}
+
+	if !transaction.HasValidNonce(tx, ownMWM) {
+		// PoW is invalid => punish neighbor
+		p.statusLock.Lock()
+		p.invalid = true
+		p.statusLock.Unlock()
+
+		// Do not answer
+		p.punish()
+		return
+	}
+
+	// Mark the pending request as received because we received the requested Tx Hash
+	requested := RequestQueue.MarkReceived(tx.Hash)
+
+	// POW valid => Process the message
+	hornetTx := hornet.NewTransactionFromGossip(tx, p.recTxBytes, requested)
+
+	// received tx was not requested and has an invalid timestamp (maybe before snapshot?)
+	// => do not store in our database
+	// => we need to reply to answer the neighbors request
+	timeValid, broadcast := checkTimestamp(hornetTx)
+	stale := !requested && !timeValid
+	recHashBytes := trinary.MustTrytesToBytes(tx.Hash)[:49]
+
+	p.dataLock.Lock()
+	p.recHash = tx.Hash
+	p.recHashBytes = recHashBytes
+	p.hornetTx = hornetTx
+	p.dataLock.Unlock()
+
+	p.statusLock.Lock()
+	p.hashing = false
+	p.statusLock.Unlock()
+
+	if !stale {
+		// Ignore stale transactions until they are requested
+		Events.ReceivedTransaction.Trigger(hornetTx)
+
+		if !requested && broadcast {
+			p.broadcast()
+		}
+	} else if len(p.requests) == 1 {
+		p.requests[0].p.Neighbor.Metrics.IncrInvalidTransactionsCount()
+	}
+
+	p.notify()
+}
+
+func (p *PendingNeighborRequests) notify() {
+	p.requestsLock.Lock()
+
+	for _, n := range p.requests {
+		n.notify(p.recHashBytes)
+	}
+
+	p.requests = make([]*NeighborRequest, 0)
+	p.requestsLock.Unlock()
+}
+
+func (p *PendingNeighborRequests) punish() {
+	p.requestsLock.Lock()
+
+	for _, n := range p.requests {
+		// Tx is known as invalid => punish neighbor
+		server.SharedServerMetrics.IncrInvalidTransactionsCount()
+		n.p.Neighbor.Metrics.IncrInvalidTransactionsCount()
+		n.punish()
+	}
+
+	p.requests = make([]*NeighborRequest, 0)
+	p.requestsLock.Unlock()
+}
+
+func (p *PendingNeighborRequests) broadcast() {
+	p.requestsLock.RLock()
+
+	excludedNeighbors := make(map[string]struct{})
+	for _, neighbor := range p.requests {
+		excludedNeighbors[neighbor.p.Neighbor.Identity] = struct{}{}
+	}
+	p.requestsLock.RUnlock()
+
+	BroadcastTransaction(excludedNeighbors, p.recTxBytes, p.GetTxHashBytes())
+}

--- a/plugins/gossip/neighbor_request.go
+++ b/plugins/gossip/neighbor_request.go
@@ -58,7 +58,6 @@ func (p *PendingNeighborRequests) Update(other objectstorage.StorableObject) {
 		panic("invalid object passed to PendingNeighborRequests.Update()")
 	} else {
 		// data
-		p.dataLock = obj.dataLock
 		p.recTxBytes = obj.recTxBytes
 		p.recHashBytes = obj.recHashBytes
 		p.recHash = obj.recHash

--- a/plugins/gossip/packet_processor.go
+++ b/plugins/gossip/packet_processor.go
@@ -162,10 +162,11 @@ func ProcessReceivedLegacyTransactionGossipData(protocol *protocol, data []byte)
 	txData := data[:txDataLen]
 	cachedRequest := GetCachedPendingNeighborRequest(txData) // +1
 	pending = cachedRequest.GetRequest()
-	cachedRequest.Release() // -1
 
 	pending.AddLegacyTxRequest(protocol, reqHashBytes)
 	pending.process()
+
+	cachedRequest.Release() // -1
 }
 
 func ProcessReceivedTransactionGossipData(protocol *protocol, txData []byte) {
@@ -177,10 +178,11 @@ func ProcessReceivedTransactionGossipData(protocol *protocol, txData []byte) {
 	var pending *PendingNeighborRequests
 	cachedRequest := GetCachedPendingNeighborRequest(txData) // +1
 	pending = cachedRequest.GetRequest()
-	cachedRequest.Release() // -1
 
 	pending.BlockFeedback(protocol)
 	pending.process()
+
+	cachedRequest.Release() // -1
 
 	protocol.Neighbor.SendTransactionRequest()
 }

--- a/plugins/gossip/packet_processor.go
+++ b/plugins/gossip/packet_processor.go
@@ -12,15 +12,12 @@ import (
 
 	"github.com/iotaledger/hive.go/batchhasher"
 	"github.com/iotaledger/hive.go/daemon"
-	"github.com/iotaledger/hive.go/lru_cache"
 	"github.com/iotaledger/hive.go/math"
-	"github.com/iotaledger/hive.go/syncutils"
-	"github.com/iotaledger/hive.go/typeutils"
+	"github.com/iotaledger/hive.go/objectstorage"
 	"github.com/iotaledger/hive.go/workerpool"
 
 	"github.com/gohornet/hornet/packages/compressed"
 	"github.com/gohornet/hornet/packages/model/hornet"
-	"github.com/gohornet/hornet/packages/model/milestone_index"
 	"github.com/gohornet/hornet/packages/model/queue"
 	"github.com/gohornet/hornet/packages/model/tangle"
 	"github.com/gohornet/hornet/packages/profile"
@@ -36,15 +33,16 @@ var (
 	packetProcessorWorkerCount = batchhasher.CURLP81.GetBatchSize() * batchhasher.CURLP81.GetWorkerCount()
 	packetProcessorWorkerPool  *workerpool.WorkerPool
 
-	RequestQueue  *queue.RequestQueue
-	IncomingCache *lru_cache.LRUCache
+	RequestQueue *queue.RequestQueue
 
 	ErrTxExpired = errors.New("tx too old")
 )
 
 func configurePacketProcessor() {
+	opts := profile.GetProfile().Caches.IncomingTransactionFilter
+
 	RequestQueue = queue.NewRequestQueue()
-	IncomingCache = lru_cache.NewLRUCache(profile.GetProfile().Caches.IncomingTransactionFilter.Size)
+	incomingStorage = objectstorage.New(nil, incomingFactory, objectstorage.CacheTime(time.Duration(opts.CacheTimeMs)*time.Millisecond), objectstorage.PersistenceEnabled(false))
 
 	gossipLogger.Infof("Configuring packetProcessorWorkerPool with %d workers", packetProcessorWorkerCount)
 	packetProcessorWorkerPool = workerpool.New(func(task workerpool.Task) {
@@ -79,179 +77,6 @@ func runPacketProcessor() {
 		packetProcessorWorkerPool.StopAndWait()
 		gossipLogger.Info("Stopping PacketProcessor ... done")
 	}, shutdown.ShutdownPriorityPacketProcessor)
-}
-
-type NeighborRequest struct {
-	p                          *protocol
-	reqHashBytes               []byte
-	reqMilestoneIndex          milestone_index.MilestoneIndex
-	isMilestoneRequest         bool
-	isTransactionRequest       bool
-	isLegacyTransactionRequest bool
-	hasNoRequest               bool
-}
-
-func (n *NeighborRequest) punish() {
-	n.p.Neighbor.Metrics.IncrInvalidTransactionsCount()
-}
-
-func (n *NeighborRequest) notify(recHashBytes []byte) {
-	n.p.Neighbor.Reply(recHashBytes, n)
-}
-
-type PendingNeighborRequests struct {
-	startProcessingLock syncutils.Mutex
-
-	// data
-	dataLock     syncutils.RWMutex
-	recTxBytes   []byte
-	recHashBytes []byte
-	recHash      trinary.Hash
-	hornetTx     *hornet.Transaction
-
-	// status
-	statusLock syncutils.RWMutex
-	invalid    bool
-	hashing    bool
-
-	// requests
-	requestsLock syncutils.RWMutex
-	requests     []*NeighborRequest
-}
-
-func (p *PendingNeighborRequests) AddLegacyTxRequest(neighbor *protocol, reqHashBytes []byte) {
-	p.requestsLock.Lock()
-	defer p.requestsLock.Unlock()
-
-	p.requests = append(p.requests, &NeighborRequest{
-		p:                          neighbor,
-		reqHashBytes:               reqHashBytes,
-		isLegacyTransactionRequest: true,
-	})
-}
-
-func (p *PendingNeighborRequests) BlockFeedback(neighbor *protocol) {
-	p.requestsLock.Lock()
-	defer p.requestsLock.Unlock()
-
-	p.requests = append(p.requests, &NeighborRequest{
-		p:            neighbor,
-		hasNoRequest: true,
-	})
-}
-
-func (p *PendingNeighborRequests) IsHashing() bool {
-	p.statusLock.RLock()
-	defer p.statusLock.RUnlock()
-	return p.hashing
-}
-
-func (p *PendingNeighborRequests) IsHashed() bool {
-	p.statusLock.RLock()
-	defer p.statusLock.RUnlock()
-	return len(p.recHashBytes) > 0
-}
-
-func (p *PendingNeighborRequests) IsInvalid() bool {
-	p.statusLock.RLock()
-	defer p.statusLock.RUnlock()
-	return p.invalid
-}
-
-func (p *PendingNeighborRequests) GetTxHash() trinary.Hash {
-	p.dataLock.RLock()
-	defer p.dataLock.RUnlock()
-	return p.recHash
-}
-
-func (p *PendingNeighborRequests) GetTxHashBytes() []byte {
-	p.dataLock.RLock()
-	defer p.dataLock.RUnlock()
-	return p.recHashBytes
-}
-
-func (p *PendingNeighborRequests) process() {
-	p.startProcessingLock.Lock()
-
-	if p.IsHashing() {
-		p.startProcessingLock.Unlock()
-		return
-	} else if p.IsInvalid() {
-		p.startProcessingLock.Unlock()
-		p.punish()
-		return
-	} else if p.IsHashed() {
-		p.startProcessingLock.Unlock()
-
-		// Mark the pending request as received because we received the requested Tx Hash
-		requested := RequestQueue.MarkReceived(p.hornetTx.Tx.Hash)
-
-		if requested {
-			// Tx is requested => ignore that it was marked as stale before
-			p.hornetTx.SetRequested(requested)
-			Events.ReceivedTransaction.Trigger(p.hornetTx)
-		}
-
-		p.notify()
-		return
-	}
-
-	p.statusLock.Lock()
-	p.hashing = true
-	p.statusLock.Unlock()
-	p.startProcessingLock.Unlock()
-
-	tx, err := compressed.TransactionFromCompressedBytes(p.recTxBytes)
-	if err != nil {
-		return
-	}
-
-	if !transaction.HasValidNonce(tx, ownMWM) {
-		// PoW is invalid => punish neighbor
-		p.statusLock.Lock()
-		p.invalid = true
-		p.statusLock.Unlock()
-
-		// Do not answer
-		p.punish()
-		return
-	}
-
-	// Mark the pending request as received because we received the requested Tx Hash
-	requested := RequestQueue.MarkReceived(tx.Hash)
-
-	// POW valid => Process the message
-	hornetTx := hornet.NewTransactionFromGossip(tx, p.recTxBytes, requested)
-
-	// received tx was not requested and has an invalid timestamp (maybe before snapshot?)
-	// => do not store in our database
-	// => we need to reply to answer the neighbors request
-	timeValid, broadcast := checkTimestamp(hornetTx)
-	stale := !requested && !timeValid
-	recHashBytes := trinary.MustTrytesToBytes(tx.Hash)[:49]
-
-	p.dataLock.Lock()
-	p.recHash = tx.Hash
-	p.recHashBytes = recHashBytes
-	p.hornetTx = hornetTx
-	p.dataLock.Unlock()
-
-	p.statusLock.Lock()
-	p.hashing = false
-	p.statusLock.Unlock()
-
-	if !stale {
-		// Ignore stale transactions until they are requested
-		Events.ReceivedTransaction.Trigger(hornetTx)
-
-		if !requested && broadcast {
-			p.broadcast()
-		}
-	} else if len(p.requests) == 1 {
-		p.requests[0].p.Neighbor.Metrics.IncrInvalidTransactionsCount()
-	}
-
-	p.notify()
 }
 
 func BroadcastTransactionFromAPI(txTrytes trinary.Trytes) error {
@@ -302,60 +127,6 @@ func BroadcastTransactionFromAPI(txTrytes trinary.Trytes) error {
 	return nil
 }
 
-func (p *PendingNeighborRequests) notify() {
-	p.requestsLock.Lock()
-
-	for _, n := range p.requests {
-		n.notify(p.recHashBytes)
-	}
-
-	p.requests = make([]*NeighborRequest, 0)
-	p.requestsLock.Unlock()
-}
-
-func (p *PendingNeighborRequests) punish() {
-	p.requestsLock.Lock()
-
-	for _, n := range p.requests {
-		// Tx is known as invalid => punish neighbor
-		server.SharedServerMetrics.IncrInvalidTransactionsCount()
-		n.p.Neighbor.Metrics.IncrInvalidTransactionsCount()
-		n.punish()
-	}
-
-	p.requests = make([]*NeighborRequest, 0)
-	p.requestsLock.Unlock()
-}
-
-func (p *PendingNeighborRequests) broadcast() {
-	p.requestsLock.RLock()
-
-	excludedNeighbors := make(map[string]struct{})
-	for _, neighbor := range p.requests {
-		excludedNeighbors[neighbor.p.Neighbor.Identity] = struct{}{}
-	}
-	p.requestsLock.RUnlock()
-
-	BroadcastTransaction(excludedNeighbors, p.recTxBytes, p.GetTxHashBytes())
-}
-
-func pendingRequestFor(recTxBytes []byte) (result *PendingNeighborRequests) {
-
-	cacheKey := typeutils.BytesToString(recTxBytes)
-
-	if cacheResult := IncomingCache.ComputeIfAbsent(cacheKey, func() interface{} {
-		return &PendingNeighborRequests{
-			recTxBytes: recTxBytes,
-			requests:   make([]*NeighborRequest, 0),
-		}
-	}); !typeutils.IsInterfaceNil(cacheResult) {
-		result = cacheResult.(*PendingNeighborRequests)
-	}
-	return
-}
-
-var genesisTruncatedBytes = make([]byte, NON_SIG_TX_PART_BYTES_LENGTH)
-
 func ProcessReceivedMilestoneRequest(protocol *protocol, data []byte) {
 	server.SharedServerMetrics.IncrReceivedMilestoneRequestsCount()
 	protocol.Neighbor.Metrics.IncrReceivedMilestoneRequestsCount()
@@ -389,7 +160,9 @@ func ProcessReceivedLegacyTransactionGossipData(protocol *protocol, data []byte)
 	reqHashBytes := ExtractRequestedTxHash(data)
 
 	txData := data[:txDataLen]
-	pending = pendingRequestFor(txData)
+	cachedRequest := GetCachedPendingNeighborRequest(txData) // +1
+	defer cachedRequest.Release()
+	pending = cachedRequest.GetRequest()
 	pending.AddLegacyTxRequest(protocol, reqHashBytes)
 	pending.process()
 }
@@ -401,7 +174,9 @@ func ProcessReceivedTransactionGossipData(protocol *protocol, txData []byte) {
 	protocol.Neighbor.Metrics.IncrAllTransactionsCount()
 
 	var pending *PendingNeighborRequests
-	pending = pendingRequestFor(txData)
+	cachedRequest := GetCachedPendingNeighborRequest(txData)
+	defer cachedRequest.Release()
+	pending = cachedRequest.GetRequest()
 	pending.BlockFeedback(protocol)
 	pending.process()
 

--- a/plugins/gossip/packet_processor.go
+++ b/plugins/gossip/packet_processor.go
@@ -161,8 +161,9 @@ func ProcessReceivedLegacyTransactionGossipData(protocol *protocol, data []byte)
 
 	txData := data[:txDataLen]
 	cachedRequest := GetCachedPendingNeighborRequest(txData) // +1
-	defer cachedRequest.Release()
 	pending = cachedRequest.GetRequest()
+	cachedRequest.Release() // -1
+
 	pending.AddLegacyTxRequest(protocol, reqHashBytes)
 	pending.process()
 }
@@ -174,9 +175,10 @@ func ProcessReceivedTransactionGossipData(protocol *protocol, txData []byte) {
 	protocol.Neighbor.Metrics.IncrAllTransactionsCount()
 
 	var pending *PendingNeighborRequests
-	cachedRequest := GetCachedPendingNeighborRequest(txData)
-	defer cachedRequest.Release()
+	cachedRequest := GetCachedPendingNeighborRequest(txData) // +1
 	pending = cachedRequest.GetRequest()
+	cachedRequest.Release() // -1
+
 	pending.BlockFeedback(protocol)
 	pending.process()
 

--- a/plugins/spa/plugin.go
+++ b/plugins/spa/plugin.go
@@ -335,8 +335,8 @@ func currentNodeStatus() *nodestatus {
 			Capacity: 0,
 		},
 		IncomingTransactionFilter: cache{
-			Size:     gossip.IncomingCache.GetSize(),
-			Capacity: gossip.IncomingCache.GetCapacity(),
+			Size:     gossip.GetIncomingStorageSize(),
+			Capacity: 0,
 		},
 		RefsInvalidBundle: cache{
 			Size:     tangle_plugin.RefsAnInvalidBundleCache.GetSize(),


### PR DESCRIPTION
This PR replaces the LRU cache for filtering the incoming transactions with an object storage.
It also adds CacheTimes to the profiles.