### PR TITLE
Invalid bundle object storage

### DIFF
--- a/config.json
+++ b/config.json
@@ -25,7 +25,7 @@
           "cacheTimeMs": 5000
         },
         "refsInvalidBundle": {
-          "size": 10000
+          "cacheTimeMs": 180000
         }
       },
       "badger": {

--- a/packages/profile/profile.go
+++ b/packages/profile/profile.go
@@ -93,7 +93,7 @@ var Profile8GB = &Profile{
 			CacheTimeMs: 5000,
 		},
 		RefsInvalidBundle: CacheOpts{
-			Size: 10000,
+			CacheTimeMs: 180000,
 		},
 	},
 	Badger: BadgerOpts{
@@ -150,7 +150,7 @@ var Profile4GB = &Profile{
 			CacheTimeMs: 5000,
 		},
 		RefsInvalidBundle: CacheOpts{
-			Size: 10000,
+			CacheTimeMs: 180000,
 		},
 	},
 	Badger: BadgerOpts{
@@ -207,7 +207,7 @@ var Profile2GB = &Profile{
 			CacheTimeMs: 2500,
 		},
 		RefsInvalidBundle: CacheOpts{
-			Size: 10000,
+			CacheTimeMs: 180000,
 		},
 	},
 	Badger: BadgerOpts{
@@ -264,7 +264,7 @@ var Profile1GB = &Profile{
 			CacheTimeMs: 1500,
 		},
 		RefsInvalidBundle: CacheOpts{
-			Size: 10000,
+			CacheTimeMs: 180000,
 		},
 	},
 	Badger: BadgerOpts{

--- a/plugins/gossip/incoming_storage.go
+++ b/plugins/gossip/incoming_storage.go
@@ -1,7 +1,11 @@
 package gossip
 
 import (
+	"time"
+
 	"github.com/iotaledger/hive.go/objectstorage"
+
+	"github.com/gohornet/hornet/packages/profile"
 )
 
 var (
@@ -21,6 +25,15 @@ func incomingFactory(key []byte) objectstorage.StorableObject {
 		recTxBytes: key,
 		requests:   make([]*NeighborRequest, 0),
 	}
+}
+
+func configureIncomingStorage() {
+	opts := profile.GetProfile().Caches.IncomingTransactionFilter
+
+	incomingStorage = objectstorage.New(nil,
+		incomingFactory,
+		objectstorage.CacheTime(time.Duration(opts.CacheTimeMs)*time.Millisecond),
+		objectstorage.PersistenceEnabled(false))
 }
 
 func GetIncomingStorageSize() int {

--- a/plugins/gossip/neighbor_config_observer.go
+++ b/plugins/gossip/neighbor_config_observer.go
@@ -35,7 +35,7 @@ func runConfigObserver() {
 			gossipLogger.Infof("Modify neighbors due to config change")
 			for _, nb := range modified {
 				if err := RemoveNeighbor(nb.Identity); err != nil {
-					gossipLogger.Error(err)
+					gossipLogger.Warn(err)
 				}
 			}
 			addNewNeighbors(modified)
@@ -51,7 +51,7 @@ func runConfigObserver() {
 		if len(removed) > 0 {
 			for _, nb := range removed {
 				if err := RemoveNeighbor(nb.Identity); err != nil {
-					gossipLogger.Errorf("Remove neighbor due to config change failed with: %v", err)
+					gossipLogger.Warnf("Remove neighbor due to config change failed with: %v", err)
 				} else {
 					gossipLogger.Infof("Remove neighbor (%s) due to config change was successful", nb.Identity)
 				}

--- a/plugins/gossip/neighbors.go
+++ b/plugins/gossip/neighbors.go
@@ -343,7 +343,7 @@ func setupNeighborEventHandlers(neighbor *Neighbor) {
 		if errors.Cause(err) == ErrNeighborAlreadyConnected {
 			neighbor.Duplicate = true
 		}
-		gossipLogger.Errorf("protocol error on neighbor %s: %s", neighbor.IdentityOrAddress(), err.Error())
+		gossipLogger.Warnf("protocol error on neighbor %s: %s", neighbor.IdentityOrAddress(), err.Error())
 	}))
 
 	// connection error log
@@ -354,7 +354,7 @@ func setupNeighborEventHandlers(neighbor *Neighbor) {
 		if neighbor.Duplicate {
 			return
 		}
-		gossipLogger.Errorf("connection error on neighbor %s: %s", neighbor.IdentityOrAddress(), err.Error())
+		gossipLogger.Warnf("connection error on neighbor %s: %s", neighbor.IdentityOrAddress(), err.Error())
 	}))
 
 	// automatically put the disconnected neighbor back into the reconnect pool

--- a/plugins/gossip/packet_processor.go
+++ b/plugins/gossip/packet_processor.go
@@ -13,14 +13,12 @@ import (
 	"github.com/iotaledger/hive.go/batchhasher"
 	"github.com/iotaledger/hive.go/daemon"
 	"github.com/iotaledger/hive.go/math"
-	"github.com/iotaledger/hive.go/objectstorage"
 	"github.com/iotaledger/hive.go/workerpool"
 
 	"github.com/gohornet/hornet/packages/compressed"
 	"github.com/gohornet/hornet/packages/model/hornet"
 	"github.com/gohornet/hornet/packages/model/queue"
 	"github.com/gohornet/hornet/packages/model/tangle"
-	"github.com/gohornet/hornet/packages/profile"
 	"github.com/gohornet/hornet/packages/shutdown"
 	"github.com/gohornet/hornet/plugins/gossip/server"
 )
@@ -39,10 +37,9 @@ var (
 )
 
 func configurePacketProcessor() {
-	opts := profile.GetProfile().Caches.IncomingTransactionFilter
 
 	RequestQueue = queue.NewRequestQueue()
-	incomingStorage = objectstorage.New(nil, incomingFactory, objectstorage.CacheTime(time.Duration(opts.CacheTimeMs)*time.Millisecond), objectstorage.PersistenceEnabled(false))
+	configureIncomingStorage()
 
 	gossipLogger.Infof("Configuring packetProcessorWorkerPool with %d workers", packetProcessorWorkerCount)
 	packetProcessorWorkerPool = workerpool.New(func(task workerpool.Task) {

--- a/plugins/gossip/reconnect_pool.go
+++ b/plugins/gossip/reconnect_pool.go
@@ -79,7 +79,7 @@ next:
 		originAddr := recNeigh.OriginAddr
 		neighborAddrs, err := possibleIdentitiesFromNeighborAddress(originAddr)
 		if err != nil {
-			gossipLogger.Error(err.Error())
+			gossipLogger.Warn(err.Error())
 			continue
 		}
 
@@ -116,7 +116,7 @@ next:
 		neighborsLock.Unlock()
 
 		if err := Connect(neighbor); err != nil {
-			gossipLogger.Errorf("connection attempt to %s failed: %s", neighbor.InitAddress.String(), err.Error())
+			gossipLogger.Warnf("connection attempt to %s failed: %s", neighbor.InitAddress.String(), err.Error())
 			neighborsLock.Lock()
 			moveFromInFlightToReconnectPool(neighbor)
 			neighborsLock.Unlock()
@@ -136,7 +136,7 @@ func cleanReconnectPool(neighbor *Neighbor) {
 		if recNeigh.CachedIPs == nil {
 			ips, err := possibleIdentitiesFromNeighborAddress(recNeigh.OriginAddr)
 			if err != nil {
-				gossipLogger.Errorf("can't check reconnect pool existence on %s, as IP lookups failed: %s", recNeigh.OriginAddr.String(), err.Error())
+				gossipLogger.Warnf("can't check reconnect pool existence on %s, as IP lookups failed: %s", recNeigh.OriginAddr.String(), err.Error())
 				recNeigh.mu.Unlock()
 				continue
 			}

--- a/plugins/spa/plugin.go
+++ b/plugins/spa/plugin.go
@@ -339,8 +339,8 @@ func currentNodeStatus() *nodestatus {
 			Capacity: 0,
 		},
 		RefsInvalidBundle: cache{
-			Size:     tangle_plugin.RefsAnInvalidBundleCache.GetSize(),
-			Capacity: tangle_plugin.RefsAnInvalidBundleCache.GetCapacity(),
+			Size:     tangle_plugin.GetRefsAnInvalidBundleStorageSize(),
+			Capacity: 0,
 		},
 	}
 

--- a/plugins/tangle/plugin.go
+++ b/plugins/tangle/plugin.go
@@ -8,7 +8,6 @@ import (
 	"github.com/iotaledger/hive.go/daemon"
 	"github.com/iotaledger/hive.go/events"
 	"github.com/iotaledger/hive.go/logger"
-	"github.com/iotaledger/hive.go/lru_cache"
 	"github.com/iotaledger/hive.go/node"
 	"github.com/iotaledger/hive.go/timeutil"
 
@@ -31,7 +30,7 @@ func configure(plugin *node.Plugin) {
 	log = logger.NewLogger(plugin.Name)
 
 	belowMaxDepthTransactionLimit = parameter.NodeConfig.GetInt("tipsel.belowMaxDepthTransactionLimit")
-	RefsAnInvalidBundleCache = lru_cache.NewLRUCache(profile.GetProfile().Caches.RefsInvalidBundle.Size)
+	configureRefsAnInvalidBundleStorage()
 
 	tangle.InitBundleCache()
 	tangle.InitMilestoneCache()

--- a/plugins/tangle/refs_invalid_bundles_storage.go
+++ b/plugins/tangle/refs_invalid_bundles_storage.go
@@ -46,7 +46,12 @@ func invalidBundleFactory(key []byte) objectstorage.StorableObject {
 
 func configureRefsAnInvalidBundleStorage() {
 	opts := profile.GetProfile().Caches.RefsInvalidBundle
-	refsAnInvalidBundleStorage = objectstorage.New(nil, invalidBundleFactory, objectstorage.CacheTime(time.Duration(opts.CacheTimeMs)*time.Millisecond), objectstorage.PersistenceEnabled(false))
+
+	refsAnInvalidBundleStorage = objectstorage.New(
+		nil,
+		invalidBundleFactory,
+		objectstorage.CacheTime(time.Duration(opts.CacheTimeMs)*time.Millisecond),
+		objectstorage.PersistenceEnabled(false))
 }
 
 func GetRefsAnInvalidBundleStorageSize() int {

--- a/plugins/tangle/refs_invalid_bundles_storage.go
+++ b/plugins/tangle/refs_invalid_bundles_storage.go
@@ -1,0 +1,64 @@
+package tangle
+
+import (
+	"time"
+
+	"github.com/iotaledger/iota.go/trinary"
+
+	"github.com/iotaledger/hive.go/objectstorage"
+
+	"github.com/gohornet/hornet/packages/profile"
+)
+
+var (
+	refsAnInvalidBundleStorage *objectstorage.ObjectStorage
+)
+
+type invalidBundleReference struct {
+	objectstorage.StorableObjectFlags
+
+	hashBytes []byte
+}
+
+// ObjectStorage interface
+
+func (r *invalidBundleReference) Update(other objectstorage.StorableObject) {
+	panic("invalidBundleReference should never be updated")
+}
+
+func (r *invalidBundleReference) GetStorageKey() []byte {
+	return r.hashBytes
+}
+
+func (r *invalidBundleReference) MarshalBinary() (data []byte, err error) {
+	return nil, nil
+}
+
+func (r *invalidBundleReference) UnmarshalBinary(data []byte) error {
+	return nil
+}
+
+func invalidBundleFactory(key []byte) objectstorage.StorableObject {
+	return &invalidBundleReference{
+		hashBytes: key,
+	}
+}
+
+func configureRefsAnInvalidBundleStorage() {
+	opts := profile.GetProfile().Caches.RefsInvalidBundle
+	refsAnInvalidBundleStorage = objectstorage.New(nil, invalidBundleFactory, objectstorage.CacheTime(time.Duration(opts.CacheTimeMs)*time.Millisecond), objectstorage.PersistenceEnabled(false))
+}
+
+func GetRefsAnInvalidBundleStorageSize() int {
+	return refsAnInvalidBundleStorage.GetSize()
+}
+
+// +-0
+func PutInvalidBundleReference(txHash trinary.Hash) {
+	refsAnInvalidBundleStorage.Put(invalidBundleFactory(trinary.MustTrytesToBytes(txHash)[:49])).Release()
+}
+
+// +-0
+func ContainsInvalidBundleReference(txHash trinary.Hash) bool {
+	return refsAnInvalidBundleStorage.Contains(trinary.MustTrytesToBytes(txHash)[:49])
+}

--- a/plugins/tipselection/tipselection.go
+++ b/plugins/tipselection/tipselection.go
@@ -202,7 +202,7 @@ func SelectTips(depth uint, reference *trinary.Hash) ([]trinary.Hash, *TipSelSta
 
 				// check whether we determined by a previous tip-sel whether this
 				// transaction references an invalid bundle
-				if tanglePlugin.RefsAnInvalidBundleCache.Contains(candidateHash) {
+				if tanglePlugin.ContainsInvalidBundleReference(candidateHash) {
 					approverHashes = removeElementAtIndex(approverHashes, candidateIndex)
 					continue
 				}
@@ -250,7 +250,7 @@ func SelectTips(depth uint, reference *trinary.Hash) ([]trinary.Hash, *TipSelSta
 				}
 
 				if !bundle.IsValid() {
-					tanglePlugin.RefsAnInvalidBundleCache.Set(candidateHash, true)
+					tanglePlugin.PutInvalidBundleReference(candidateHash)
 					approverHashes = removeElementAtIndex(approverHashes, candidateIndex)
 					candidateTx.Release() //-1
 					continue


### PR DESCRIPTION
This PR replaces the LRU cache for RefsInvalidBundleCache with object storage.
It also uses Warnings instead of Errors in the logs of the "neighbors" functions.