### PR TITLE
Improve the RPM/DEB packages, alternative d/l option

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -130,6 +130,7 @@ nfpms:
     config_files:
       "config.json": "/etc/hornet/config.json"
       "neighbors.json": "/etc/hornet/neighbors.json"
+      "nfpm/shared_files/hornet.env": "/etc/default/hornet"
     dependencies:
       - systemd
       - wget

--- a/nfpm/deb_files/postinst
+++ b/nfpm/deb_files/postinst
@@ -16,14 +16,14 @@ configure | abort-upgrade | abort-remove | abort-deconfigure)
         echo "HORNET installation finished\n"
         echo "######################################\n"
         echo "Please edit the config files (/etc/hornet/config.json and /etc/hornet/neighbors.json) to fit your needs.\n"
-        echo "To start HORNET the first time, please run:\nsudo systemctl enable hornet && service hornet start\n"
+        echo "To start HORNET the first time, please run:\nsudo systemctl enable hornet && sudo service hornet start\n"
     fi
 
     adduser --no-create-home --system --group hornet >/dev/null
 
     mkdir -p /var/lib/hornet
-    chmod -R 700 /var/lib/hornet
-    chmod -R 700 /etc/hornet
+    chmod 700 /var/lib/hornet
+    chmod 700 /etc/hornet
     chown -R hornet:hornet /etc/hornet
     chown -R hornet:hornet /var/lib/hornet
     ;;

--- a/nfpm/deb_files/postrm
+++ b/nfpm/deb_files/postrm
@@ -16,6 +16,7 @@ purge)
     deb-systemd-helper purge "${SYSTEMD_SERVICE}" >/dev/null
     deb-systemd-helper unmask "${SYSTEMD_SERVICE}" >/dev/null
     rm -rf /var/lib/hornet
+    rm /etc/default/hornet
     deluser hornet >/dev/null
     ;;
 upgrade | failed-upgrade | abort-install | abort-upgrade | disappear) ;;

--- a/nfpm/rpm_files/postrm
+++ b/nfpm/rpm_files/postrm
@@ -4,4 +4,6 @@ if [ $1 -ge 1 ]; then
     /sbin/service hornet upgrade >/dev/null 2>&1 || echo \
         "Binary upgrade failed, please check hornet's log"
 fi
-rm -rf /var/lib/hornet/latest-export.gz.bin /var/lib/hornet/mainnetdb/*
+rm -rf /var/lib/hornet/latest-export.gz.bin \
+       /etc/default/hornet \
+       /var/lib/hornet/mainnetdb/*

--- a/nfpm/shared_files/download_snapshot.sh
+++ b/nfpm/shared_files/download_snapshot.sh
@@ -1,9 +1,16 @@
-#!/bin/bash
-set -e
+#!/usr/bin/env bash
 
-REMOTE_FILE="https://dbfiles.iota.org/mainnet/hornet/latest-export.gz.bin"
+# Set default if none set.
+REMOTE_FILE="${1:-https://dbfiles.iota.org/mainnet/hornet/latest-export.gz.bin}"
 
 # Download with timestamping (only download if remote file is newer)
 echo "Checking for the latest snapshot file..."
 echo "This may take a while"
-wget -N -q "${REMOTE_FILE}"
+
+# Capture only stderr
+WGET_STDERR=$( { wget -N "${REMOTE_FILE}"; } 2>&1 >/dev/null )
+if [ $? -ne 0 ]
+then
+    >&2 echo -e "Downloading latest snapshot file failed:\n${WGET_STDERR}\n"
+    exit 1
+fi

--- a/nfpm/shared_files/hornet.env
+++ b/nfpm/shared_files/hornet.env
@@ -1,0 +1,5 @@
+# Use an alternative snapshot file location
+#REMOTE_FILE="http://my-alternative.location.io/file.bin.gz"
+
+# Add cli arguments to hornet
+#OPTIONS="--node.LogLevel=127 --useProfile=1gb"

--- a/nfpm/shared_files/hornet.env
+++ b/nfpm/shared_files/hornet.env
@@ -1,5 +1,6 @@
-# Use an alternative snapshot file location
+# Use an alternative snapshot file location, e.g.:
 #REMOTE_FILE="http://my-alternative.location.io/file.bin.gz"
 
-# Add cli arguments to hornet
-#OPTIONS="--node.LogLevel=127 --useProfile=1gb"
+# Add cli arguments to hornet, e.g.:
+# (For the full list of cli options run 'hornet -h')
+#OPTIONS="--config /path/to/alternative-config --useProfile=1gb"

--- a/nfpm/shared_files/hornet.service
+++ b/nfpm/shared_files/hornet.service
@@ -4,6 +4,7 @@ Wants=network-online.target
 After=network-online.target
 
 [Service]
+EnvironmentFile=-/etc/default/hornet
 LimitNOFILE=4096
 StandardOutput=syslog
 StandardError=syslog
@@ -18,8 +19,7 @@ Group=hornet
 WorkingDirectory=/var/lib/hornet
 TimeoutSec=1200
 Restart=always
-
-ExecStart=/bin/bash -c "/usr/bin/hornet_download_snapshot.sh && /usr/bin/hornet -d /etc/hornet"
+ExecStart=/bin/bash -c "/usr/bin/hornet_download_snapshot.sh $REMOTE_FILE && /usr/bin/hornet -d /etc/hornet $OPTIONS"
 
 [Install]
 WantedBy=multi-user.target

--- a/scripts/build_goreleaser_snapshot.sh
+++ b/scripts/build_goreleaser_snapshot.sh
@@ -4,8 +4,7 @@
 # Allows building of dirty git state and will not push results to github.
 
 # make script executable independent of path
-trap 'cd $(dirs -l -0)' EXIT INT QUIT TERM
-cd ..
+cd $(dirname "$0")/../
 
 GORELEASER_IMAGE=iotmod/goreleaser-cgo-cross-compiler:1.13.5-musl
 REPO_PATH="/build"


### PR DESCRIPTION
# Motivation
I'd like to specify an alternative location where to get the snapshot file from.
Or, I'd like to specify some additional command line options for hornet (eventhough the cli options exist in the config file, it is sometimes quicker/handier to add something like `--node.LogLevel=127 --useProfile=1gb` in the env file and restart hornet)

# Changes
* Add load of environment file to help configure options (e.g. which remote snapshot file URL to use or cli options). Such file is quite common on services installed on linux to enter extra command line options etc.

# Minor Fixes
* Don't recursively chmod 700 directories as that makes any files in there executable.
* Sudo missing after a &&
* Make sure we enter the repository's root. There seems to be no need to cd back to original dir: when script ends, the dir is the original one.