### PR TITLE
Update Snapshot URL

### DIFF
--- a/download_snapshot.sh
+++ b/download_snapshot.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 rm latest-export.gz.bin
-wget https://dbfiles.iota.org/mainnet/hornet/latest-export.gz.bin
+wget https://ls.manapotion.io/latest-export.gz.bin


### PR DESCRIPTION
Old URL is no longer up to date. Use https://ls.manapotion.io/latest-export.gz.bin or until a better option hosted by IF is available