### PR TITLE
Simplified the snapshot loading settings

### DIFF
--- a/config.json
+++ b/config.json
@@ -168,6 +168,7 @@
     "enabled": true,
     "delay": 40000
   },
+  "loadSnapshot": "local",
   "localsnapshots": {
     "enabled": true,
     "depth": 50,
@@ -176,12 +177,8 @@
     "path": "latest-export.gz.bin"
   },
   "globalsnapshot": {
-    "load": false,
     "path": "snapshotMainnet.txt",
     "index": 1050000
-  },
-  "privatetangle": {
-    "ledgerstatepath": "balances.txt"
   },
   "milestones": {
     "coordinator": "EQSAUZXULTTYZCLNJNTXQTQHOMOFZERHTCGTXOLTVAHKSA9OGAZDEKECURBRIXIJWNPFCQIOVFVVXJVD9",

--- a/plugins/snapshot/global_snapshot.go
+++ b/plugins/snapshot/global_snapshot.go
@@ -84,12 +84,6 @@ func loadSnapshotFromTextfiles(filePathLedger string, snapshotIndex milestone_in
 	return nil
 }
 
-func LoadEmptySnapshot(filePathLedger string) error {
-
-	log.Info("Loading empty snapshot...")
-	return loadSnapshotFromTextfiles(filePathLedger, 0)
-}
-
 func LoadGlobalSnapshot(filePathLedger string, snapshotIndex milestone_index.MilestoneIndex) error {
 
 	log.Infof("Loading global snapshot with index %v...", snapshotIndex)

--- a/plugins/snapshot/parameters.go
+++ b/plugins/snapshot/parameters.go
@@ -5,6 +5,10 @@ import (
 )
 
 func init() {
+
+	// "Which snapshot to load 'local' or 'global'."
+	parameter.NodeConfig.SetDefault("loadSnapshot", "local")
+
 	// "Enable local snapshots"
 	parameter.NodeConfig.SetDefault("localSnapshots.enabled", true)
 
@@ -20,10 +24,7 @@ func init() {
 	// "Path to the local snapshot file"
 	parameter.NodeConfig.SetDefault("localSnapshots.path", "latest-export.gz.bin")
 
-	// "Whether to load a global snapshot from provided text files."
-	parameter.NodeConfig.SetDefault("globalSnapshot.load", false)
-
-	// "Path to the global snapshot file"
+	// "Path to the global snapshot file containing the ledger state"
 	parameter.NodeConfig.SetDefault("globalSnapshot.path", "snapshotMainnet.txt")
 
 	// "Milestone index of the global snapshot"
@@ -34,7 +35,4 @@ func init() {
 
 	// "Amount of milestone transactions to keep in the database"
 	parameter.NodeConfig.SetDefault("pruning.delay", 40000)
-
-	// "Path to the ledger state file for your private tangle"
-	parameter.NodeConfig.SetDefault("privateTangle.ledgerStatePath", "balances.txt")
 }

--- a/plugins/snapshot/plugin.go
+++ b/plugins/snapshot/plugin.go
@@ -2,6 +2,7 @@ package snapshot
 
 import (
 	"errors"
+	"strings"
 
 	"github.com/iotaledger/iota.go/consts"
 	"github.com/iotaledger/iota.go/transaction"
@@ -117,21 +118,18 @@ func run(plugin *node.Plugin) {
 		return
 	}
 
-	var err error
-	if parameter.NodeConfig.GetBool("globalSnapshot.load") {
-		err = LoadGlobalSnapshot(
-			parameter.NodeConfig.GetString("globalSnapshot.path"),
-			milestone_index.MilestoneIndex(parameter.NodeConfig.GetInt("globalSnapshot.index")),
-		)
+	var err = ErrNoSnapshotSpecified
 
-	} else if parameter.NodeConfig.GetString("localSnapshots.path") != "" {
-		err = LoadSnapshotFromFile(parameter.NodeConfig.GetString("localSnapshots.path"))
+	snapshotToLoad := parameter.NodeConfig.GetString("loadSnapshot")
 
-	} else if parameter.NodeConfig.GetString("privateTangle.ledgerStatePath") != "" {
-		err = LoadEmptySnapshot(parameter.NodeConfig.GetString("privateTangle.ledgerStatePath"))
-
-	} else {
-		err = ErrNoSnapshotSpecified
+	if strings.EqualFold(snapshotToLoad, "global") {
+		if path := parameter.NodeConfig.GetString("globalSnapshot.path"); path != "" {
+			err = LoadGlobalSnapshot(path, milestone_index.MilestoneIndex(parameter.NodeConfig.GetInt("globalSnapshot.index")))
+		}
+	} else if strings.EqualFold(snapshotToLoad, "local") {
+		if path := parameter.NodeConfig.GetString("localSnapshots.path"); path != "" {
+			err = LoadSnapshotFromFile(path)
+		}
 	}
 
 	if err != nil {


### PR DESCRIPTION
- Removed `privatetangle.ledgerstatepath`, since you can use `globalsnapshot.path` while passing `globalsnapshot.index` = 0
- Removed `globalsnapshot.load` in favor of new `loadSnapshot` = `global`|`local`. This defaults to `local`