### PR TITLE
Add API whitelist

### DIFF
--- a/config.json
+++ b/config.json
@@ -18,6 +18,7 @@
       "storeTransactions",
       "getTrytes"
     ],
+    "whitelistedAddresses": [],
     "bindAddress": "0.0.0.0",
     "maxbodylength": 1000000,
     "maxfindtransactions": 1000,

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/labstack/echo/v4 v4.1.15
 	github.com/mitchellh/mapstructure v1.1.2
 	github.com/pkg/errors v0.9.1
+	github.com/projectcalico/libcalico-go v3.9.0-0.dev+incompatible
 	github.com/shirou/gopsutil v2.20.2+incompatible
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.6.2

--- a/go.sum
+++ b/go.sum
@@ -252,6 +252,8 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pkg/profile v1.2.1/go.mod h1:hJw3o1OdXxsrSjjVksARp5W95eeEaEfptyVZyv6JUPA=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/projectcalico/libcalico-go v3.9.0-0.dev+incompatible h1:ru5G1RUQ6g6QxtrHzrL+9//VPMLWAz7nxeymGd6TyCo=
+github.com/projectcalico/libcalico-go v3.9.0-0.dev+incompatible/go.mod h1:0b/n/rPzNXjhn4ywFcEJuQdA/5olt9UxFIATz57xkbc=
 github.com/prometheus/client_golang v0.8.0/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v0.9.3/go.mod h1:/TN21ttK/J9q6uSwhBd54HahCDft0ttaMvbicHlPoso=

--- a/plugins/webapi/parameters.go
+++ b/plugins/webapi/parameters.go
@@ -28,6 +28,9 @@ func init() {
 			"getTrytes",
 		})
 
+	// "Allow specified addresses and networks to access all API commands"
+	parameter.NodeConfig.SetDefault("api.whitelistedAddresses", []string{})
+
 	// "Basic authentication user name"
 	parameter.NodeConfig.SetDefault("api.auth.username", "")
 


### PR DESCRIPTION
# Description

Allow specified addresses in `config.json` to access all API commands.
Accepts both IP and CIDR. `127.0.0.1` and `::1` are hard-coded as whitelisted.

To accept all IP:
```json
{
  "api": {
    "whitelistedAddresses": ["0.0.0.0/0", "::/0"]
  }
}
```

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

# How Has This Been Tested?

I tried to access permitted and protected API commands from whitelisted and unwhitelisted addresses.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have tested my code extensively
- [x] I have selected the `develop` branch as the target branch