### PR TITLE
Validate strict bundle semantics up on solidification too

### DIFF
--- a/packages/model/tangle/bundle.go
+++ b/packages/model/tangle/bundle.go
@@ -238,7 +238,6 @@ func (bundle *Bundle) validate(onMaybeMilestone func() bool) bool {
 		cachedCurrentTx.Release(true) // tx -1
 	}
 
-
 	// validate bundle semantics and signatures
 	if iotago_bundle.ValidBundle(iotaGoBundle) != nil {
 		bundle.setValid(false)

--- a/packages/model/tangle/bundle.go
+++ b/packages/model/tangle/bundle.go
@@ -16,11 +16,12 @@ func BundleCaller(handler interface{}, params ...interface{}) {
 }
 
 const (
-	HORNET_BUNDLE_METADATA_SOLID         = 0
-	HORNET_BUNDLE_METADATA_VALID         = 1
-	HORNET_BUNDLE_METADATA_CONFIRMED     = 2
-	HORNET_BUNDLE_METADATA_IS_MILESTONE  = 3
-	HORNET_BUNDLE_METADATA_IS_VALUE_SPAM = 4
+	HORNET_BUNDLE_METADATA_SOLID                  = 0
+	HORNET_BUNDLE_METADATA_VALID                  = 1
+	HORNET_BUNDLE_METADATA_CONFIRMED              = 2
+	HORNET_BUNDLE_METADATA_IS_MILESTONE           = 3
+	HORNET_BUNDLE_METADATA_IS_VALUE_SPAM          = 4
+	HORNET_BUNDLE_METADATA_VALID_STRICT_SEMANTICS = 5
 )
 
 // Storable Object
@@ -152,6 +153,16 @@ func (bundle *Bundle) IsValid() bool {
 	return bundle.metadata.HasFlag(HORNET_BUNDLE_METADATA_VALID)
 }
 
+func (bundle *Bundle) setValidStrictSemantics(valid bool) {
+	if valid != bundle.metadata.HasFlag(HORNET_BUNDLE_METADATA_VALID_STRICT_SEMANTICS) {
+		bundle.metadata = bundle.metadata.ModifyFlag(HORNET_BUNDLE_METADATA_VALID_STRICT_SEMANTICS, valid)
+	}
+}
+
+func (bundle *Bundle) ValidStrictSemantics() bool {
+	return bundle.metadata.HasFlag(HORNET_BUNDLE_METADATA_VALID_STRICT_SEMANTICS)
+}
+
 func (bundle *Bundle) setConfirmed(confirmed bool) {
 	if confirmed != bundle.metadata.HasFlag(HORNET_BUNDLE_METADATA_CONFIRMED) {
 		bundle.metadata = bundle.metadata.ModifyFlag(HORNET_BUNDLE_METADATA_CONFIRMED, confirmed)
@@ -203,7 +214,7 @@ func (bundle *Bundle) isComplete() bool {
 }
 
 // Checks if a bundle is syntactically valid and has valid signatures
-func (bundle *Bundle) validate() bool {
+func (bundle *Bundle) validate(onMaybeMilestone func() bool) bool {
 
 	// Because the bundle is already complete when this function gets called, the amount of tx has to be correct,
 	// otherwise the bundle was not constructed correctly
@@ -215,22 +226,71 @@ func (bundle *Bundle) validate() bool {
 	// check all tx
 	iotaGoBundle := make(iotago_bundle.Bundle, len(bundle.txs))
 
-	cachedCurrentTx := loadBundleTxIfExistsOrPanic(bundle.tailTx, bundle.hash) // tx +1
-	lastIndex := int(cachedCurrentTx.GetTransaction().Tx.LastIndex)
-	iotaGoBundle[0] = *cachedCurrentTx.GetTransaction().Tx
-	cachedCurrentTx.Release(true) // tx -1
+	cachedCurrentTailTx := loadBundleTxIfExistsOrPanic(bundle.tailTx, bundle.hash) // tx +1
+	lastIndex := int(cachedCurrentTailTx.GetTransaction().Tx.LastIndex)
+	iotaGoBundle[0] = *cachedCurrentTailTx.GetTransaction().Tx
+	defer cachedCurrentTailTx.Release(true) // tx -1
 
+	cachedCurrentTx := cachedCurrentTailTx
 	for i := 1; i < lastIndex+1; i++ {
-		cachedCurrentTx = loadBundleTxIfExistsOrPanic(cachedCurrentTx.GetTransaction().GetTrunk(), bundle.hash) // tx +1
+		cachedCurrentTx := loadBundleTxIfExistsOrPanic(cachedCurrentTx.GetTransaction().GetTrunk(), bundle.hash) // tx +1
 		iotaGoBundle[i] = *cachedCurrentTx.GetTransaction().Tx
 		cachedCurrentTx.Release(true) // tx -1
 	}
 
-	// validate bundle semantics and signatures
-	valid := iotago_bundle.ValidBundle(iotaGoBundle) == nil
+	validStrictSemantics := true
 
-	bundle.setValid(valid)
-	return valid
+	// enforce that non head transactions within the bundle approve as their branch transaction
+	// the trunk transaction of the head transaction.
+	headTx := iotaGoBundle[len(iotaGoBundle)-1]
+	if len(iotaGoBundle) > 1 {
+		for i := 0; i < len(iotaGoBundle)-1; i++ {
+			if iotaGoBundle[i].BranchTransaction != headTx.TrunkTransaction {
+				validStrictSemantics = false
+			}
+		}
+	}
+
+	// validate bundle semantics and signatures
+	if iotago_bundle.ValidBundle(iotaGoBundle) != nil {
+		bundle.setValid(false)
+		bundle.setValidStrictSemantics(false)
+		return false
+	}
+
+	// verify that the head transaction only approves tail transactions.
+	// this is fine within the validation code, since the bundle is only complete when it is solid.
+	// however, as a special rule, milestone bundles might not be solid
+	checkTails := true
+	if IsMaybeMilestone(cachedCurrentTailTx) {
+		checkTails = !onMaybeMilestone()
+	}
+
+	// check whether the bundle approves tails
+	if checkTails {
+		approveeHashes := []trinary.Hash{headTx.TrunkTransaction}
+		if headTx.TrunkTransaction != headTx.BranchTransaction {
+			approveeHashes = append(approveeHashes, headTx.BranchTransaction)
+		}
+
+		for _, approveeHash := range approveeHashes {
+			cachedApproveeTx := GetCachedTransactionOrNil(approveeHash) // tx +1
+			if cachedApproveeTx == nil {
+				log.Panicf("Tx with hash %v not found", approveeHash)
+			}
+
+			if !cachedApproveeTx.GetTransaction().IsTail() {
+				validStrictSemantics = false
+				cachedApproveeTx.Release(true) // tx -1
+				break
+			}
+			cachedApproveeTx.Release(true) // tx -1
+		}
+	}
+
+	bundle.setValidStrictSemantics(validStrictSemantics)
+	bundle.setValid(true)
+	return true
 }
 
 // Calculates the ledger changes of the bundle

--- a/packages/model/tangle/bundle.go
+++ b/packages/model/tangle/bundle.go
@@ -233,7 +233,7 @@ func (bundle *Bundle) validate(onMaybeMilestone func() bool) bool {
 
 	cachedCurrentTx := cachedCurrentTailTx
 	for i := 1; i < lastIndex+1; i++ {
-		cachedCurrentTx := loadBundleTxIfExistsOrPanic(cachedCurrentTx.GetTransaction().GetTrunk(), bundle.hash) // tx +1
+		cachedCurrentTx = loadBundleTxIfExistsOrPanic(cachedCurrentTx.GetTransaction().GetTrunk(), bundle.hash) // tx +1
 		iotaGoBundle[i] = *cachedCurrentTx.GetTransaction().Tx
 		cachedCurrentTx.Release(true) // tx -1
 	}
@@ -274,6 +274,9 @@ func (bundle *Bundle) validate(onMaybeMilestone func() bool) bool {
 		}
 
 		for _, approveeHash := range approveeHashes {
+			if SolidEntryPointsContain(approveeHash) {
+				continue
+			}
 			cachedApproveeTx := GetCachedTransactionOrNil(approveeHash) // tx +1
 			if cachedApproveeTx == nil {
 				log.Panicf("Tx with hash %v not found", approveeHash)

--- a/plugins/tangle/consistency.go
+++ b/plugins/tangle/consistency.go
@@ -3,6 +3,7 @@ package tangle
 import (
 	"errors"
 
+	"github.com/gohornet/hornet/packages/model/hornet"
 	"github.com/iotaledger/iota.go/trinary"
 
 	"github.com/gohornet/hornet/packages/model/milestone_index"
@@ -142,40 +143,6 @@ func computeConeDiff(visited map[trinary.Hash]struct{}, tailTxHash trinary.Hash,
 				continue
 			}
 
-			// Check the tangle structure
-			approveeHashes := []trinary.Hash{cachedTx.GetTransaction().GetTrunk()}
-			if cachedTx.GetTransaction().GetTrunk() != cachedTx.GetTransaction().GetBranch() {
-				approveeHashes = append(approveeHashes, cachedTx.GetTransaction().GetBranch())
-			}
-
-			for _, approveeHash := range approveeHashes {
-				cachedApproveeTx, exists := cachedTxs[approveeHash]
-				if !exists {
-					cachedApproveeTx = tangle.GetCachedTransactionOrNil(approveeHash) // tx +1
-					if cachedApproveeTx == nil {
-						log.Panicf("Tx with hash %v not found", approveeHash)
-					}
-					cachedTxs[approveeHash] = cachedApproveeTx
-				}
-
-				if cachedApproveeTx.GetTransaction().Tx.Bundle != cachedTx.GetTransaction().Tx.Bundle {
-					// Tx references another Bundle => Check if the referenced tx is a tail
-					if !cachedApproveeTx.GetTransaction().IsTail() {
-						return nil, ErrRefBundleNotValid
-					}
-				}
-			}
-
-			// we only load up bundles when we're traversing tails, so we don't
-			// check the same bundle twice, however, we still add the trunk and branch of the
-			// bundle transaction to ensure, that if a transaction within the bundle would reference
-			// another trunk (as seen from the view of the bundle), we'd get that cone too.
-			if !cachedTx.GetTransaction().IsTail() {
-				txsToTraverse[cachedTx.GetTransaction().GetTrunk()] = struct{}{}
-				txsToTraverse[cachedTx.GetTransaction().GetBranch()] = struct{}{}
-				continue
-			}
-
 			cachedBndl, exists := cachedBndls[txHash]
 			if !exists {
 				cachedBndl = tangle.GetCachedBundleOrNil(txHash) // bundle +1
@@ -189,16 +156,25 @@ func computeConeDiff(visited map[trinary.Hash]struct{}, tailTxHash trinary.Hash,
 				return nil, ErrRefBundleNotValid
 			}
 
-			if !cachedBndl.GetBundle().IsValueSpam() {
+			// note that through the stricter bundle validation rules, this
+			// check also ensures that the bundle is actually approving only tail transactions
+			if !cachedBndl.GetBundle().ValidStrictSemantics() {
+				return nil, ErrRefBundleNotValid
+			}
 
+			if !cachedBndl.GetBundle().IsValueSpam() {
 				ledgerChanges := cachedBndl.GetBundle().GetLedgerChanges()
 				for addr, change := range ledgerChanges {
 					coneDiff[addr] += change
 				}
 			}
 
-			txsToTraverse[cachedTx.GetTransaction().GetTrunk()] = struct{}{}
-			txsToTraverse[cachedTx.GetTransaction().GetBranch()] = struct{}{}
+			// at this point the bundle is valid and therefore the trunk/branch of
+			// the head tx are tail transactions
+			cachedBndl.GetBundle().GetHead().ConsumeTransaction(func(headTx *hornet.Transaction, _ *hornet.TransactionMetadata) {
+				txsToTraverse[headTx.GetTrunk()] = struct{}{}
+				txsToTraverse[headTx.GetBranch()] = struct{}{}
+			})
 		}
 	}
 

--- a/plugins/tangle/consistency.go
+++ b/plugins/tangle/consistency.go
@@ -3,9 +3,9 @@ package tangle
 import (
 	"errors"
 
-	"github.com/gohornet/hornet/packages/model/hornet"
 	"github.com/iotaledger/iota.go/trinary"
 
+	"github.com/gohornet/hornet/packages/model/hornet"
 	"github.com/gohornet/hornet/packages/model/milestone_index"
 	"github.com/gohornet/hornet/packages/model/tangle"
 )

--- a/plugins/tipselection/tipselection.go
+++ b/plugins/tipselection/tipselection.go
@@ -237,13 +237,14 @@ func SelectTips(depth uint, reference *trinary.Hash) ([]trinary.Hash, *TipSelSta
 					continue
 				}
 
-				if !cachedBndl.GetBundle().IsValid() {
+				if !cachedBndl.GetBundle().IsValid() || !cachedBndl.GetBundle().ValidStrictSemantics() {
 					tanglePlugin.PutInvalidBundleReference(candidateHash)
 					approverHashes = removeElementAtIndex(approverHashes, candidateIndex)
 					cachedCandidateTx.Release() // tx -1
 					cachedBndl.Release()        // bundle -1
 					continue
 				}
+
 				if tanglePlugin.IsBelowMaxDepth(cachedBndl.GetBundle().GetTail(), lowerAllowedSnapshotIndex, false) { // tx pass +1
 					approverHashes = removeElementAtIndex(approverHashes, candidateIndex)
 					cachedCandidateTx.Release() // tx -1


### PR DESCRIPTION
This PR adds a new metadata flag to a bundle instance telling whether a bundle is valid regarding strict bundle semantics:
* the non head txs of a bundle approve through their branch the trunk transaction of the head tx
* the head tx only approves tail transactions

The strict bundle semantics are checked during tip-selection, respectively when computing a cone diff of a given trasaction.

This PR enforces that non milestone bundles are solid during solidification as the 2nd check needs that. Milestone bundles are of course still validated and it is assumed that they obey to the strict bundle semantics.