### PR TITLE
Run autopeering entrypoint node in standalone mode

### DIFF
--- a/main.go
+++ b/main.go
@@ -3,8 +3,10 @@ package main
 import (
 	"github.com/iotaledger/hive.go/node"
 
+	"github.com/gohornet/hornet/packages/config"
 	"github.com/gohornet/hornet/plugins/autopeering"
 	"github.com/gohornet/hornet/plugins/cli"
+	"github.com/gohornet/hornet/plugins/database"
 	"github.com/gohornet/hornet/plugins/gossip"
 	"github.com/gohornet/hornet/plugins/gracefulshutdown"
 	"github.com/gohornet/hornet/plugins/graph"
@@ -25,13 +27,17 @@ func main() {
 	cli.PrintVersion()
 	cli.ParseConfig()
 
-	node.Run(
-		node.Plugins(
-			cli.PLUGIN,
-			gracefulshutdown.PLUGIN,
+	plugins := []*node.Plugin{
+		cli.PLUGIN,
+		gracefulshutdown.PLUGIN,
+		database.PLUGIN,
+		autopeering.PLUGIN,
+	}
+
+	if !config.NodeConfig.GetBool(config.CfgNetAutopeeringRunAsEntryNode) {
+		plugins = append(plugins, []*node.Plugin{
 			gossip.PLUGIN,
 			tangle.PLUGIN,
-			autopeering.PLUGIN,
 			tipselection.PLUGIN,
 			metrics.PLUGIN,
 			profiling.PLUGIN,
@@ -43,6 +49,8 @@ func main() {
 			graph.PLUGIN,
 			monitor.PLUGIN,
 			spammer.PLUGIN,
-		),
-	)
+		}...)
+	}
+
+	node.Run(node.Plugins(plugins...))
 }

--- a/packages/shutdown/shutdown.go
+++ b/packages/shutdown/shutdown.go
@@ -1,7 +1,8 @@
 package shutdown
 
 const (
-	ShutdownPriorityFlushToDatabase = iota
+	ShutdownPriorityCloseDatabase = iota
+	ShutdownPriorityFlushToDatabase
 	ShutdownPriorityPersisters
 	ShutdownPriorityRequestsProcessor
 	ShutdownPriorityMilestoneSolidifier

--- a/plugins/database/plugin.go
+++ b/plugins/database/plugin.go
@@ -1,0 +1,54 @@
+package database
+
+import (
+	"github.com/iotaledger/hive.go/daemon"
+	"github.com/iotaledger/hive.go/logger"
+	"github.com/iotaledger/hive.go/node"
+
+	"github.com/gohornet/hornet/packages/config"
+	"github.com/gohornet/hornet/packages/database"
+	"github.com/gohornet/hornet/packages/model/tangle"
+	"github.com/gohornet/hornet/packages/profile"
+	"github.com/gohornet/hornet/packages/shutdown"
+)
+
+var (
+	PLUGIN = node.NewPlugin("Database", node.Enabled, configure, run)
+	log    *logger.Logger
+)
+
+func configure(plugin *node.Plugin) {
+	log = logger.NewLogger(plugin.Name)
+
+	tangle.ConfigureDatabases(config.NodeConfig.GetString(config.CfgDatabasePath), &profile.GetProfile().Badger)
+
+	if tangle.IsDatabaseCorrupted() {
+		log.Panic("HORNET was not shut down correctly. Database is corrupted. Please delete the database folder and start with a new local snapshot.")
+	}
+
+	if !tangle.IsCorrectDatabaseVersion() {
+		log.Panic("HORNET database version mismatch. The database scheme was updated. Please delete the database folder and start with a new local snapshot.")
+	}
+
+	// Create a background worker that marks the database as corrupted at clean startup.
+	// This has to be done in a background worker, because the Daemon could receive
+	// a shutdown signal during startup. If that is the case, the BackgroundWorker will never be started
+	// and the database will never be marked as corrupted.
+	daemon.BackgroundWorker("Database Health", func(shutdownSignal <-chan struct{}) {
+		tangle.MarkDatabaseCorrupted()
+	})
+
+	daemon.BackgroundWorker("Close database", func(shutdownSignal <-chan struct{}) {
+		<-shutdownSignal
+
+		tangle.MarkDatabaseHealthy()
+
+		log.Info("Syncing database to disk...")
+		database.GetHornetBadgerInstance().Close()
+		log.Info("Syncing database to disk... done")
+	}, shutdown.ShutdownPriorityCloseDatabase)
+}
+
+func run(plugin *node.Plugin) {
+	// nothing
+}

--- a/plugins/gracefulshutdown/plugin.go
+++ b/plugins/gracefulshutdown/plugin.go
@@ -16,7 +16,7 @@ import (
 const WAIT_TO_KILL_TIME_IN_SECONDS = 120
 
 var (
-	PLUGIN = node.NewPlugin("Graceful Shutdown", node.Enabled, configure)
+	PLUGIN = node.NewPlugin("Graceful Shutdown", node.Enabled, configure, run)
 	log    *logger.Logger
 )
 
@@ -54,4 +54,8 @@ func configure(plugin *node.Plugin) {
 
 		daemon.ShutdownAndWait()
 	}()
+}
+
+func run(plugin *node.Plugin) {
+	// nothing
 }

--- a/plugins/profiling/plugin.go
+++ b/plugins/profiling/plugin.go
@@ -10,8 +10,12 @@ import (
 )
 
 var (
-	PLUGIN = node.NewPlugin("Profiling", node.Enabled, run)
+	PLUGIN = node.NewPlugin("Profiling", node.Enabled, configure, run)
 )
+
+func configure(plugin *node.Plugin) {
+	// nothing
+}
 
 func run(plugin *node.Plugin) {
 	runtime.SetMutexProfileFraction(5)

--- a/plugins/tangle/plugin.go
+++ b/plugins/tangle/plugin.go
@@ -13,7 +13,6 @@ import (
 	"github.com/gohornet/hornet/packages/database"
 	"github.com/gohornet/hornet/packages/model/milestone_index"
 	"github.com/gohornet/hornet/packages/model/tangle"
-	"github.com/gohornet/hornet/packages/profile"
 	"github.com/gohornet/hornet/packages/shutdown"
 	"github.com/gohornet/hornet/plugins/gossip"
 )
@@ -29,24 +28,6 @@ func configure(plugin *node.Plugin) {
 
 	belowMaxDepthTransactionLimit = config.NodeConfig.GetInt(config.CfgTipSelBelowMaxDepthTransactionLimit)
 	configureRefsAnInvalidBundleStorage()
-
-	tangle.ConfigureDatabases(config.NodeConfig.GetString(config.CfgDatabasePath), &profile.GetProfile().Badger)
-
-	if tangle.IsDatabaseCorrupted() {
-		log.Panic("HORNET was not shut down correctly. Database is corrupted. Please delete the database folder and start with a new local snapshot.")
-	}
-
-	if !tangle.IsCorrectDatabaseVersion() {
-		log.Panic("HORNET database version mismatch. The database scheme was updated. Please delete the database folder and start with a new local snapshot.")
-	}
-
-	// Create a background worker that marks the database as corrupted at clean startup.
-	// This has to be done in a background worker, because the Daemon could receive
-	// a shutdown signal during startup. If that is the case, the BackgroundWorker will never be started
-	// and the database will never be marked as corrupted.
-	daemon.BackgroundWorker("Database Health", func(shutdownSignal <-chan struct{}) {
-		tangle.MarkDatabaseCorrupted()
-	})
 
 	tangle.ConfigureMilestones(
 		config.NodeConfig.GetString(config.CfgMilestoneCoordinator),
@@ -69,11 +50,6 @@ func configure(plugin *node.Plugin) {
 		tangle.ShutdownSpentAddressesStorage()
 		log.Info("Flushing caches to database... done")
 
-		tangle.MarkDatabaseHealthy()
-
-		log.Info("Syncing database to disk...")
-		database.GetHornetBadgerInstance().Close()
-		log.Info("Syncing database to disk... done")
 	}, shutdown.ShutdownPriorityFlushToDatabase)
 
 	Events.SolidMilestoneChanged.Attach(events.NewClosure(func(cachedBndl *tangle.CachedBundle) {

--- a/plugins/tipselection/plugin.go
+++ b/plugins/tipselection/plugin.go
@@ -9,7 +9,7 @@ import (
 )
 
 var (
-	PLUGIN = node.NewPlugin("Tip-Sel", node.Enabled, configure)
+	PLUGIN = node.NewPlugin("Tip-Sel", node.Enabled, configure, run)
 	log    *logger.Logger
 
 	// config options
@@ -32,4 +32,8 @@ func configure(plugin *node.Plugin) {
 	log = logger.NewLogger(plugin.Name)
 
 	maxDepth = config.NodeConfig.GetInt(config.CfgTipSelMaxDepth)
+}
+
+func run(plugin *node.Plugin) {
+	// nothing
 }


### PR DESCRIPTION
If you enable "runAsEntryNode" in the config, HORNET will now run as a plain entryPointNode for autopeering.  All the other plugins like gossiping etc will not be started.