### PR TITLE
Force release incoming tx and generated objects if the node is not synced

### DIFF
--- a/packages/model/tangle/bundle_storage.go
+++ b/packages/model/tangle/bundle_storage.go
@@ -271,7 +271,7 @@ func GetBundlesOfTransactionOrNil(txHash trinary.Hash, forceRelease bool) Cached
 ////////////////////////////////////////////////////////////////////////////////
 
 // tx +1
-func AddTransactionToStorage(hornetTx *hornet.Transaction, firstSeenLatestMilestoneIndex milestone_index.MilestoneIndex, requested bool) (cachedTx *CachedTransaction, alreadyAdded bool) {
+func AddTransactionToStorage(hornetTx *hornet.Transaction, firstSeenLatestMilestoneIndex milestone_index.MilestoneIndex, requested bool, forceRelease bool) (cachedTx *CachedTransaction, alreadyAdded bool) {
 
 	cachedTx, isNew := StoreTransactionIfAbsent(hornetTx) // tx +1
 	if !isNew {
@@ -279,11 +279,11 @@ func AddTransactionToStorage(hornetTx *hornet.Transaction, firstSeenLatestMilest
 	}
 
 	// Store the tx in the bundleTransactionsStorage
-	StoreBundleTransaction(cachedTx.GetTransaction().Tx.Bundle, cachedTx.GetTransaction().GetHash(), cachedTx.GetTransaction().IsTail()).Release()
+	StoreBundleTransaction(cachedTx.GetTransaction().Tx.Bundle, cachedTx.GetTransaction().GetHash(), cachedTx.GetTransaction().IsTail()).Release(forceRelease)
 
-	StoreApprover(cachedTx.GetTransaction().GetTrunk(), cachedTx.GetTransaction().GetHash()).Release()
+	StoreApprover(cachedTx.GetTransaction().GetTrunk(), cachedTx.GetTransaction().GetHash()).Release(forceRelease)
 	if cachedTx.GetTransaction().GetTrunk() != cachedTx.GetTransaction().GetBranch() {
-		StoreApprover(cachedTx.GetTransaction().GetBranch(), cachedTx.GetTransaction().GetHash()).Release()
+		StoreApprover(cachedTx.GetTransaction().GetBranch(), cachedTx.GetTransaction().GetHash()).Release(forceRelease)
 	}
 
 	// Force release Tag, Address, FirstSeenTx since its not needed for solidification/confirmation

--- a/plugins/snapshot/plugin.go
+++ b/plugins/snapshot/plugin.go
@@ -153,6 +153,6 @@ func installGenesisTransaction() {
 	genesisTx := hornet.NewTransaction(genesis, txBytesTruncated)
 
 	// ensure the bundle is also existent for the genesis tx
-	cachedTx, _ := tangle.AddTransactionToStorage(genesisTx, 0, false)
+	cachedTx, _ := tangle.AddTransactionToStorage(genesisTx, 0, false, false)
 	cachedTx.Release() // tx -1
 }

--- a/plugins/tangle/tangle_processor.go
+++ b/plugins/tangle/tangle_processor.go
@@ -104,12 +104,13 @@ func processIncomingTx(plugin *node.Plugin, incomingTx *hornet.Transaction, requ
 	txHash := incomingTx.GetHash()
 
 	latestMilestoneIndex := tangle.GetLatestMilestoneIndex()
+	isNodeSyncedWithThreshold := tangle.IsNodeSyncedWithThreshold()
 
 	// The tx will be added to the storage inside this function, so the transaction object automatically updates
-	cachedTx, alreadyAdded := tangle.AddTransactionToStorage(incomingTx, latestMilestoneIndex, requested) // tx +1
+	cachedTx, alreadyAdded := tangle.AddTransactionToStorage(incomingTx, latestMilestoneIndex, requested, !isNodeSyncedWithThreshold) // tx +1
 
 	// Release shouldn't be forced, to cache the latest transactions
-	defer cachedTx.Release() // tx -1
+	defer cachedTx.Release(!isNodeSyncedWithThreshold) // tx -1
 
 	if !alreadyAdded {
 		metrics.SharedServerMetrics.IncrNewTransactionsCount()


### PR DESCRIPTION
This reduces the chance to run into an OOM while syncing