### PR TITLE
Make config files optional

### DIFF
--- a/packages/config/config.go
+++ b/packages/config/config.go
@@ -31,24 +31,23 @@ var (
 func FetchConfig(printConfig bool, ignoreSettingsAtPrint ...[]string) error {
 	// flags
 
-	err := parameter.LoadConfigFile(NodeConfig, *configDirPath, *configName, true, false)
+	err := parameter.LoadConfigFile(NodeConfig, *configDirPath, *configName, true, true)
 	if err != nil {
 		return err
 	}
-
 	parameter.PrintConfig(NodeConfig, ignoreSettingsAtPrint...)
 
-	err = parameter.LoadConfigFile(NeighborsConfig, *configDirPath, *neighborsConfigName, false, false)
+	err = parameter.LoadConfigFile(NeighborsConfig, *configDirPath, *neighborsConfigName, false, true)
 	if err != nil {
 		return err
 	}
-
-	err = parameter.LoadConfigFile(ProfilesConfig, *configDirPath, *profilesConfigName, false, false)
-	if err != nil {
-		return err
-	}
-
 	parameter.PrintConfig(NeighborsConfig)
+
+	err = parameter.LoadConfigFile(ProfilesConfig, *configDirPath, *profilesConfigName, false, true)
+	if err != nil {
+		return err
+	}
+	parameter.PrintConfig(ProfilesConfig)
 
 	return nil
 }

--- a/packages/config/config.go
+++ b/packages/config/config.go
@@ -9,10 +9,15 @@ import (
 )
 
 var (
+	// default
+	defaultConfigName          = "config"
+	defaultNeighborsConfigName = "neighbors"
+	defaultProfilesConfigName  = "profiles"
+
 	// flags
-	configName          = flag.StringP("config", "c", "config", "Filename of the config file without the file extension")
-	neighborsConfigName = flag.StringP("neighborsConfig", "n", "neighbors", "Filename of the neighbors config file without the file extension")
-	profilesConfigName  = flag.String("profilesConfig", "profiles", "Filename of the profiles config file without the file extension")
+	configName          = flag.StringP("config", "c", defaultConfigName, "Filename of the config file without the file extension")
+	neighborsConfigName = flag.StringP("neighborsConfig", "n", defaultNeighborsConfigName, "Filename of the neighbors config file without the file extension")
+	profilesConfigName  = flag.String("profilesConfig", defaultProfilesConfigName, "Filename of the profiles config file without the file extension")
 	configDirPath       = flag.StringP("config-dir", "d", ".", "Path to the directory containing the config file")
 
 	// Viper
@@ -29,21 +34,19 @@ var (
 // It automatically reads in a single config file starting with "config" (can be changed via the --config CLI flag)
 // and ending with: .json, .toml, .yaml or .yml (in this sequence).
 func FetchConfig(printConfig bool, ignoreSettingsAtPrint ...[]string) error {
-	// flags
-
-	err := parameter.LoadConfigFile(NodeConfig, *configDirPath, *configName, true, true)
+	err := parameter.LoadConfigFile(NodeConfig, *configDirPath, *configName, true, !hasFlag(defaultConfigName))
 	if err != nil {
 		return err
 	}
 	parameter.PrintConfig(NodeConfig, ignoreSettingsAtPrint...)
 
-	err = parameter.LoadConfigFile(NeighborsConfig, *configDirPath, *neighborsConfigName, false, true)
+	err = parameter.LoadConfigFile(NeighborsConfig, *configDirPath, *neighborsConfigName, false, !hasFlag(defaultNeighborsConfigName))
 	if err != nil {
 		return err
 	}
 	parameter.PrintConfig(NeighborsConfig)
 
-	err = parameter.LoadConfigFile(ProfilesConfig, *configDirPath, *profilesConfigName, false, true)
+	err = parameter.LoadConfigFile(ProfilesConfig, *configDirPath, *profilesConfigName, false, !hasFlag(defaultProfilesConfigName))
 	if err != nil {
 		return err
 	}
@@ -68,4 +71,14 @@ func IsNeighborsConfigHotReloadAllowed() bool {
 	neighborsConfigHotReloadLock.RLock()
 	defer neighborsConfigHotReloadLock.RUnlock()
 	return neighborsConfigHotReloadAllowed
+}
+
+func hasFlag(name string) bool {
+	has := false
+	flag.Visit(func(f *flag.Flag) {
+		if f.Name == name {
+			has = true
+		}
+	})
+	return has
 }

--- a/packages/config/network_config.go
+++ b/packages/config/network_config.go
@@ -43,17 +43,12 @@ func init() {
 	// neighbors
 	NeighborsConfig.SetDefault(CfgNeighborsAcceptAnyNeighborConnection, false)
 	NeighborsConfig.SetDefault(CfgNeighborsMaxNeighbors, 5)
-	NeighborsConfig.SetDefault(CfgNeighbors, []NeighborConfig{
-		{
-			Identity:   "example.neighbor.com:15600",
-			Alias:      "Example Neighbor",
-			PreferIPv6: false,
-		},
-	})
+	NeighborsConfig.SetDefault(CfgNeighbors, []NeighborConfig{})
 
 	// autopeering
 	NodeConfig.SetDefault(CfgNetAutopeeringEntryNodes, []string{
 		"LehlDBPJ6kfcfLOK6kAU4nD7B/BdR7SJhai7yFCbCCM=@enter.hornet.zone:14626",
+		"zEiNuQMDfZ6F8QDisa1ndX32ykBTyYCxbtkO0vkaWd0=@enter.manapotion.io:18626",
 	})
 	NodeConfig.SetDefault(CfgNetAutopeeringBindAddr, "0.0.0.0:14626")
 	NodeConfig.SetDefault(CfgNetAutopeeringExternalAddr, "auto")


### PR DESCRIPTION
# Description

Most node operators will probably not use static peers and custom profiles. As every config property has a default value, there is no need to panic when a config file is absent.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

# How Has This Been Tested?

Basic tests with and without the config files.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have tested my code extensively
- [x] I have selected the `develop` branch as the target branch