### PR TITLE
Fix spent.addresses.paths name

### DIFF
--- a/packages/config/snapshot_config.go
+++ b/packages/config/snapshot_config.go
@@ -16,7 +16,7 @@ const (
 	// path to the global snapshot file containing the ledger state
 	CfgGlobalSnapshotPath = "snapshots.global.path"
 	// paths to the spent addresses files
-	CfgGlobalSnapshotSpentAddressesPath = "snapshots.global.spentAddressesPath"
+	CfgGlobalSnapshotSpentAddressesPaths = "snapshots.global.spentAddressesPaths"
 	// milestone index of the global snapshot
 	CfgGlobalSnapshotIndex = "snapshots.global.index"
 	// whether to delete old transaction data from the database
@@ -35,7 +35,7 @@ func init() {
 	NodeConfig.SetDefault(CfgLocalSnapshotsIntervalUnsynced, 1000)
 	NodeConfig.SetDefault(CfgLocalSnapshotsPath, "latest-export.gz.bin")
 	NodeConfig.SetDefault(CfgGlobalSnapshotPath, "snapshotMainnet.txt")
-	NodeConfig.SetDefault(CfgGlobalSnapshotSpentAddressesPath, []string{
+	NodeConfig.SetDefault(CfgGlobalSnapshotSpentAddressesPaths, []string{
 		"previousEpochsSpentAddresses1.txt",
 		"previousEpochsSpentAddresses2.txt",
 		"previousEpochsSpentAddresses3.txt",

--- a/plugins/snapshot/global_snapshot.go
+++ b/plugins/snapshot/global_snapshot.go
@@ -56,7 +56,7 @@ func loadSpentAddresses(filePathSpent string) (int, error) {
 	return spentAddressesCount, nil
 }
 
-func loadSnapshotFromTextfiles(filePathLedger string, filePathSpent []string, snapshotIndex milestone_index.MilestoneIndex) error {
+func loadSnapshotFromTextfiles(filePathLedger string, filePathsSpent []string, snapshotIndex milestone_index.MilestoneIndex) error {
 
 	tangle.WriteLockSolidEntryPoints()
 	tangle.ResetSolidEntryPoints()
@@ -116,7 +116,7 @@ func loadSnapshotFromTextfiles(filePathLedger string, filePathSpent []string, sn
 
 	spentAddressesSum := 0
 	if config.NodeConfig.GetBool(config.CfgSpentAddressesEnabled) {
-		for _, spent := range filePathSpent {
+		for _, spent := range filePathsSpent {
 			spentAddressesCount, err := loadSpentAddresses(spent)
 			if err != nil {
 				return errors.Wrapf(ErrSnapshotImportFailed, "loadSpentAddresses: %v", err)
@@ -134,8 +134,8 @@ func loadSnapshotFromTextfiles(filePathLedger string, filePathSpent []string, sn
 	return nil
 }
 
-func LoadGlobalSnapshot(filePathLedger string, filePathSpent []string, snapshotIndex milestone_index.MilestoneIndex) error {
+func LoadGlobalSnapshot(filePathLedger string, filePathsSpent []string, snapshotIndex milestone_index.MilestoneIndex) error {
 
 	log.Infof("Loading global snapshot with index %v...", snapshotIndex)
-	return loadSnapshotFromTextfiles(filePathLedger, filePathSpent, snapshotIndex)
+	return loadSnapshotFromTextfiles(filePathLedger, filePathsSpent, snapshotIndex)
 }

--- a/plugins/snapshot/plugin.go
+++ b/plugins/snapshot/plugin.go
@@ -127,7 +127,7 @@ func run(plugin *node.Plugin) {
 	case "global":
 		if path := config.NodeConfig.GetString(config.CfgGlobalSnapshotPath); path != "" {
 			err = LoadGlobalSnapshot(path,
-				config.NodeConfig.GetStringSlice(config.CfgGlobalSnapshotSpentAddressesPath),
+				config.NodeConfig.GetStringSlice(config.CfgGlobalSnapshotSpentAddressesPaths),
 				milestone_index.MilestoneIndex(config.NodeConfig.GetInt(config.CfgGlobalSnapshotIndex)))
 		}
 	case "local":


### PR DESCRIPTION
# Description

The default `config.json` uses `spentAddressesPaths` while the code uses `spentAddressesPath`. As a slice it should be plural. Technically a breaking change.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

# How Has This Been Tested?

n/a

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have tested my code extensively
- [x] I have selected the `develop` branch as the target branch