### PR TITLE
Removes in-flight neighbor pool

### DIFF
--- a/plugins/gossip/events.go
+++ b/plugins/gossip/events.go
@@ -14,10 +14,9 @@ import (
 var Events = pluginEvents{
 	// neighbor events
 	RemovedNeighbor:                  events.NewEvent(neighborCaller),
-	NeighborPutIntoConnectedPool:     events.NewEvent(neighborCaller),
-	NeighborPutIntoInFlightPool:      events.NewEvent(neighborCaller),
-	NeighborPutBackIntoReconnectPool: events.NewEvent(neighborCaller),
-	NeighborPutIntoReconnectPool:     events.NewEvent(originAddrCaller),
+	NeighborMovedToConnectedPool:     events.NewEvent(neighborCaller),
+	NeighborMovedBackToReconnectPool: events.NewEvent(neighborCaller),
+	NeighborMovedToReconnectPool:     events.NewEvent(originAddrCaller),
 	NeighborConnectionClosed:         events.NewEvent(neighborCaller),
 
 	// low level network events
@@ -37,10 +36,9 @@ var Events = pluginEvents{
 type pluginEvents struct {
 	// neighbor events
 	RemovedNeighbor                  *events.Event
-	NeighborPutIntoConnectedPool     *events.Event
-	NeighborPutIntoInFlightPool      *events.Event
-	NeighborPutBackIntoReconnectPool *events.Event
-	NeighborPutIntoReconnectPool     *events.Event
+	NeighborMovedToConnectedPool     *events.Event
+	NeighborMovedBackToReconnectPool *events.Event
+	NeighborMovedToReconnectPool     *events.Event
 	NeighborConnectionClosed         *events.Event
 
 	// low level network events

--- a/plugins/gossip/neighbors.go
+++ b/plugins/gossip/neighbors.go
@@ -27,7 +27,7 @@ const (
 )
 
 var (
-	// master lock protecting connected-, in-flight neighbors and the reconnect pool
+	// master lock protecting connected neighbors and the reconnect pool
 	neighborsLock = sync.Mutex{}
 
 	// holds neighbors which are fully connected and handshaked
@@ -465,7 +465,7 @@ func AddNeighbor(neighborAddr string, preferIPv6 bool, alias string, autoPeer ..
 	originAddr.PreferIPv6 = preferIPv6
 	originAddr.Alias = alias
 
-	// check whether the neighbor is already connected, in-flight or in the reconnect pool
+	// check whether the neighbor is already connected or in the reconnect pool
 	// given any of the IP addresses to which the neighbor address resolved to
 	neighborsLock.Lock()
 	defer neighborsLock.Unlock()

--- a/plugins/gossip/protocol.go
+++ b/plugins/gossip/protocol.go
@@ -82,8 +82,6 @@ func (protocol *protocol) ReceivedHandshake() {
 
 	protocol.receiveHandshakeCompleted = true
 	if protocol.sendHandshakeCompleted {
-		// this will automatically move the neighbor from the in-flight pool
-		// or if it is an inbound neighbor, to the connected pool
 		protocol.Events.HandshakeCompleted.Trigger(protocol.Version)
 	}
 }

--- a/plugins/spa/plugin.go
+++ b/plugins/spa/plugin.go
@@ -270,7 +270,7 @@ func neighborMetrics() []*neighbormetric {
 			OriginAdrr: info.DomainWithPort,
 			Info:       info,
 		}
-		if info.Neighbor != nil {
+		if info.Neighbor != nil && info.Neighbor.Protocol != nil {
 			m.Identity = info.Neighbor.Identity
 			m.Alias = info.Alias
 			m.ConnectionOrigin = info.Neighbor.ConnectionOrigin


### PR DESCRIPTION
The in-flight neighbor pool represented neighbors to which a connection was established but weren't fully handshaked yet. This PR removes this pool in favor of just having a "reconnect pool" and "connected neighbors". Incoming connections are now marked as connected when their handshaking was successful.