### PR TITLE
Set autopeering version according to network

### DIFF
--- a/plugins/autopeering/autopeering.go
+++ b/plugins/autopeering/autopeering.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"hash/fnv"
 	"net"
 	"strings"
 
@@ -42,7 +43,11 @@ func configureAP() {
 	}
 	log.Debugf("Entry node peers: %v", entryNodes)
 
-	Discovery = discover.New(local.GetInstance(), discover.Logger(log.Named("disc")), discover.MasterPeers(entryNodes))
+	gossipServiceKeyHash := fnv.New32a()
+	gossipServiceKeyHash.Write([]byte(services.GossipServiceKey()))
+	version := gossipServiceKeyHash.Sum32()
+
+	Discovery = discover.New(local.GetInstance(), discover.Logger(log.Named("disc")), discover.MasterPeers(entryNodes), discover.Version(version))
 
 	// enable peer selection only when gossip is enabled
 	Selection = selection.New(local.GetInstance(), Discovery, selection.Logger(log.Named("sel")), selection.NeighborValidator(selection.ValidatorFunc(isValidNeighbor)))


### PR DESCRIPTION
# Description

This PR set the autopeering `version` field according to the network (ie. the Coo address), preventing nodes to discover/ping/store nodes on others IOTA networks they won't be able to peer with.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

# How Has This Been Tested?

I tested the autopeering between nodes on different networks.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have tested my code extensively
- [x] I have selected the `develop` branch as the target branch
