### PR TITLE
feat: Add node alias

### DIFF
--- a/config.json
+++ b/config.json
@@ -101,6 +101,7 @@
     "maxDepth": 3
   },
   "node": {
+    "alias": "",
     "disablePlugins": [],
     "enablePlugins": []
   },

--- a/config.json
+++ b/config.json
@@ -102,6 +102,7 @@
   },
   "node": {
     "alias": "",
+    "showAliasInGetNodeInfo": false,
     "disablePlugins": [],
     "enablePlugins": []
   },

--- a/packages/config/node_config.go
+++ b/packages/config/node_config.go
@@ -3,8 +3,11 @@ package config
 const (
 	// CfgNodeAlias set an alias to identify a node
 	CfgNodeAlias = "node.Alias"
+	// CfgNodeShowAliasInGetNodeInfo defines whether to show the alias in getNodeInfo
+	CfgNodeShowAliasInGetNodeInfo = "node.showAliasInGetNodeInfo"
 )
 
 func init() {
 	NodeConfig.SetDefault(CfgNodeAlias, "")
+	NodeConfig.SetDefault(CfgNodeShowAliasInGetNodeInfo, false)
 }

--- a/packages/config/node_config.go
+++ b/packages/config/node_config.go
@@ -2,7 +2,7 @@ package config
 
 const (
 	// CfgNodeAlias set an alias to identify a node
-	CfgNodeAlias = "node.Alias"
+	CfgNodeAlias = "node.alias"
 	// CfgNodeShowAliasInGetNodeInfo defines whether to show the alias in getNodeInfo
 	CfgNodeShowAliasInGetNodeInfo = "node.showAliasInGetNodeInfo"
 )

--- a/packages/config/node_config.go
+++ b/packages/config/node_config.go
@@ -1,0 +1,10 @@
+package config
+
+const (
+	// CfgNodeAlias set an alias to identify a node
+	CfgNodeAlias = "node.Alias"
+)
+
+func init() {
+	NodeConfig.SetDefault(CfgNodeAlias, "")
+}

--- a/plugins/spa/frontend/src/app/components/Dashboard.tsx
+++ b/plugins/spa/frontend/src/app/components/Dashboard.tsx
@@ -18,6 +18,7 @@ import TipSelChart from "app/components/TipSelChart";
 import ListGroup from "react-bootstrap/ListGroup";
 import Card from "react-bootstrap/Card";
 import MemChart from "app/components/MemChart";
+import {If} from 'tsx-control-statements/components';
 
 interface Props {
     nodeStore?: NodeStore;
@@ -29,7 +30,7 @@ export class Dashboard extends React.Component<Props, any> {
     render() {
         return (
             <Container>
-                <h3>Dashboard</h3>
+                <h3>Dashboard <If condition={this.props.nodeStore.status.node_alias !== ""}>({this.props.nodeStore.status.node_alias})</If></h3>
                 <Row className={"mb-3"}>
                     <Col>
                         <Card>

--- a/plugins/spa/frontend/src/app/stores/NodeStore.ts
+++ b/plugins/spa/frontend/src/app/stores/NodeStore.ts
@@ -36,6 +36,7 @@ class Status {
     latest_version: string;
     uptime: number;
     autopeering_id: string;
+    node_alias: string;
     connected_neighbors_count: number;
     current_requested_ms: number;
     ms_request_queue_size: number;

--- a/plugins/spa/plugin.go
+++ b/plugins/spa/plugin.go
@@ -191,6 +191,7 @@ type nodestatus struct {
 	LatestVersion           string                         `json:"latest_version"`
 	Uptime                  int64                          `json:"uptime"`
 	AutopeeringID           string                         `json:"autopeering_id"`
+	NodeAlias               string                         `json:"node_alias"`
 	ConnectedNeighborsCount int                            `json:"connected_neighbors_count"`
 	CurrentRequestedMs      milestone_index.MilestoneIndex `json:"current_requested_ms"`
 	MsRequestQueueSize      int                            `json:"ms_request_queue_size"`
@@ -300,6 +301,7 @@ func currentNodeStatus() *nodestatus {
 	if !node.IsSkipped(autopeering.PLUGIN) {
 		status.AutopeeringID = autopeering.ID
 	}
+	status.NodeAlias = config.NodeConfig.GetString(config.CfgNodeAlias)
 	status.LSMI = tangle.GetSolidMilestoneIndex()
 	status.LMI = tangle.GetLatestMilestoneIndex()
 

--- a/plugins/webapi/info.go
+++ b/plugins/webapi/info.go
@@ -26,6 +26,11 @@ func getNodeInfo(i interface{}, c *gin.Context, abortSignal <-chan struct{}) {
 		AppVersion: cli.AppVersion,
 	}
 
+	// Node Alias
+	if config.NodeConfig.GetBool(config.CfgNodeShowAliasInGetNodeInfo) {
+		info.NodeAlias = config.NodeConfig.GetString(config.CfgNodeAlias)
+	}
+
 	// Number of neighbors
 	info.Neighbors = uint(gossip.GetNeighborsCount())
 

--- a/plugins/webapi/types.go
+++ b/plugins/webapi/types.go
@@ -174,6 +174,7 @@ type GetNodeInfo struct {
 type GetNodeInfoReturn struct {
 	AppName                            string   `json:"appName"`
 	AppVersion                         string   `json:"appVersion"`
+	NodeAlias                          string   `json:"nodeAlias,omitempty"`
 	LatestMilestone                    string   `json:"latestMilestone"`
 	LatestMilestoneIndex               uint32   `json:"latestMilestoneIndex"`
 	LatestSolidSubtangleMilestone      string   `json:"latestSolidSubtangleMilestone"`


### PR DESCRIPTION
Adds an alias to the Dashboard to be able to identify nodes by its name (alias)