### PR TITLE
Fix/js scheme

### DIFF
--- a/plugins/graph/html.go
+++ b/plugins/graph/html.go
@@ -35,7 +35,7 @@ const index string = `
 
       var WebSocketURIConfig = "{{.URI}}";
       var WebSocketURI =
-        "ws://" +
+        (location.protocol === "https:" ? "wss://" : "ws://") +
         location.hostname +
         (location.port ? ":" + location.port : "") +
         "/ws";

--- a/plugins/monitor/frontend_patch.go
+++ b/plugins/monitor/frontend_patch.go
@@ -17,7 +17,7 @@ const index string = `
     <script>
       let apiPort = "{{.APIPort}}";
       let apiUrl =
-        "http://" +
+        "//" +
         location.hostname +
         ":" +
         apiPort +
@@ -268,7 +268,7 @@ const InitWebSocket = (that, options) => {
     websocketActiveGlobal[options.host] = true;
 
     var WebSocketURI =
-      "ws://" +
+      (location.protocol === "https:" ? "wss://" : "ws://") +
       location.hostname +
       (location.port ? ":" + location.port : "") +
       "/ws";


### PR DESCRIPTION
* Allow websocket to load correct scheme depending on location's scheme
* Remove explicit http for apiUrl letting the browser auto-complete it based on document's scheme