### PR TITLE
Add ZMQ topics lm and lsm

### DIFF
--- a/plugins/mqtt/events.go
+++ b/plugins/mqtt/events.go
@@ -54,11 +54,19 @@ func onNewLatestMilestone(cachedBndl *tangle.CachedBundle) {
 	if err != nil {
 		log.Error(err.Error())
 	}
+	err = publishLM(cachedBndl.GetBundle())
+	if err != nil {
+		log.Error(err.Error())
+	}
 	cachedBndl.Release(true) // bundle -1
 }
 
 func onNewSolidMilestone(cachedBndl *tangle.CachedBundle) {
 	err := publishLMSI(cachedBndl.GetBundle().GetMilestoneIndex())
+	if err != nil {
+		log.Error(err.Error())
+	}
+	err = publishLSM(cachedBndl.GetBundle())
 	if err != nil {
 		log.Error(err.Error())
 	}
@@ -103,6 +111,22 @@ func publishLMSI(smi milestone.Index) error {
 func publishLMHS(solidMilestoneHash trinary.Hash) error {
 	return mqttBroker.Send(topicLMHS, fmt.Sprintf(`{"solidMilestoneHash":"%v","timestamp":"%s"}`,
 		solidMilestoneHash, // Solid milestone transaction hash
+		time.Now().UTC().Format(time.RFC3339)))
+}
+
+// Publish latest milestone
+func publishLM(bndl *tangle.Bundle) error {
+	return mqttBroker.Send(topicLM, fmt.Sprintf(`{"index":%d,"hash":"%v","timestamp":"%s"}`,
+		bndl.GetMilestoneIndex(), // Milestone transaction index
+		bndl.GetMilestoneHash(), // Milestone transaction hash
+		time.Now().UTC().Format(time.RFC3339)))
+}
+
+// Publish latest solid subtangle milestone
+func publishLSM(bndl *tangle.Bundle) error {
+	return mqttBroker.Send(topicLSM, fmt.Sprintf(`{"index":%d,"hash":"%v","timestamp":"%s"}`,
+		bndl.GetMilestoneIndex(), // Solid milestone transaction index
+		bndl.GetMilestoneHash(), // Solid milestone transaction hash
 		time.Now().UTC().Format(time.RFC3339)))
 }
 

--- a/plugins/mqtt/topics.go
+++ b/plugins/mqtt/topics.go
@@ -5,6 +5,8 @@ const (
 	topicLMI          = "lmi"
 	topicLMSI         = "lmsi"
 	topicLMHS         = "lmhs"
+	topicLM           = "lm"
+	topicLSM          = "lsm"
 	topicSN           = "sn"
 	topicTxTrytes     = "trytes"
 	topicTX           = "tx"

--- a/plugins/zeromq/events.go
+++ b/plugins/zeromq/events.go
@@ -64,11 +64,19 @@ func onNewLatestMilestone(cachedBndl *tangle.CachedBundle) {
 	if err != nil {
 		log.Error(err.Error())
 	}
+	err = publishLM(cachedBndl.GetBundle())
+	if err != nil {
+		log.Error(err.Error())
+	}
 	cachedBndl.Release(true) // bundle -1
 }
 
 func onNewSolidMilestone(cachedBndl *tangle.CachedBundle) {
 	err := publishLMSI(cachedBndl.GetBundle().GetMilestoneIndex())
+	if err != nil {
+		log.Error(err.Error())
+	}
+	err = publishLSM(cachedBndl.GetBundle())
 	if err != nil {
 		log.Error(err.Error())
 	}
@@ -116,6 +124,26 @@ func publishLMHS(solidMilestoneHash trinary.Hash) error {
 	}
 
 	return publisher.Send(topicLMHS, messages)
+}
+
+// Publish latest milestone
+func publishLM(bndl *tangle.Bundle) error {
+	messages := []string{
+		strconv.FormatUint(uint64(bndl.GetMilestoneIndex()), 10),
+		bndl.GetMilestoneHash(),
+	}
+
+	return publisher.Send(topicLM, messages)
+}
+
+// Publish latest solid subtangle milestone
+func publishLSM(bndl *tangle.Bundle) error {
+	messages := []string{
+		strconv.FormatUint(uint64(bndl.GetMilestoneIndex()), 10),
+		bndl.GetMilestoneHash(),
+	}
+
+	return publisher.Send(topicLSM, messages)
 }
 
 // Publish confirmed transaction

--- a/plugins/zeromq/topics.go
+++ b/plugins/zeromq/topics.go
@@ -13,6 +13,8 @@ const (
 	topicLMI          = "lmi"
 	topicLMSI         = "lmsi"
 	topicLMHS         = "lmhs"
+	topicLM           = "lm"
+	topicLSM          = "lsm"
 	topicSN           = "sn"
 	topicTxTrytes     = "trytes"
 	topicTX           = "tx"
@@ -25,6 +27,8 @@ var (
 		topicLMI,
 		topicLMSI,
 		topicLMHS,
+		topicLM,
+		topicLSM,
 		topicSN,
 		topicTxTrytes,
 		topicTX,


### PR DESCRIPTION

# Description

Add ZMQ topics `lm` (latest milestone) and `lsm` (latest solid milestone) with both the index and hash of the milestones in the same message.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

# How Has This Been Tested?

Basic tests with a ZMQ client.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have tested my code extensively
- [x] I have selected the `develop` branch as the target branch