### PR TITLE
Simplify node sync check

### DIFF
--- a/pkg/model/tangle/milestones.go
+++ b/pkg/model/tangle/milestones.go
@@ -29,7 +29,6 @@ var (
 	latestMilestoneLock   syncutils.RWMutex
 	isNodeSynced          bool
 	isNodeSyncedThreshold bool
-	wasSyncBefore         bool
 
 	coordinatorAddress       string
 	coordinatorSecurityLevel int
@@ -71,13 +70,12 @@ func IsNodeSyncedWithThreshold() bool {
 }
 
 func updateNodeSynced(latestSolidIndex, latestIndex milestone.Index) {
-	if latestIndex == 0 || (!wasSyncBefore && (latestIndex < GetLatestSeenMilestoneIndexFromSnapshot())) {
+	if latestIndex == 0 || latestIndex < GetLatestSeenMilestoneIndexFromSnapshot() {
 		isNodeSynced = false
 		isNodeSyncedThreshold = false
 		return
 	}
 
-	wasSyncBefore = true
 	isNodeSynced = latestSolidIndex == latestIndex
 	isNodeSyncedThreshold = latestSolidIndex >= (latestIndex - NodeSyncedThreshold)
 }

--- a/pkg/model/tangle/milestones.go
+++ b/pkg/model/tangle/milestones.go
@@ -29,6 +29,7 @@ var (
 	latestMilestoneLock   syncutils.RWMutex
 	isNodeSynced          bool
 	isNodeSyncedThreshold bool
+	wasSyncBefore         bool
 
 	coordinatorAddress       string
 	coordinatorSecurityLevel int
@@ -70,12 +71,13 @@ func IsNodeSyncedWithThreshold() bool {
 }
 
 func updateNodeSynced(latestSolidIndex, latestIndex milestone.Index) {
-	if latestIndex == 0 {
+	if latestIndex == 0 || (!wasSyncBefore && (latestIndex < GetLatestSeenMilestoneIndexFromSnapshot())) {
 		isNodeSynced = false
 		isNodeSyncedThreshold = false
 		return
 	}
 
+	wasSyncBefore = true
 	isNodeSynced = latestSolidIndex == latestIndex
 	isNodeSyncedThreshold = latestSolidIndex >= (latestIndex - NodeSyncedThreshold)
 }

--- a/plugins/graph/plugin.go
+++ b/plugins/graph/plugin.go
@@ -39,6 +39,8 @@ var (
 	newMilestoneWorkerQueueSize = 100
 	newMilestoneWorkerPool      *workerpool.WorkerPool
 
+	wasSyncBefore = false
+
 	router   *http.ServeMux
 	server   *http.Server
 	upgrader *websocket.Upgrader
@@ -103,10 +105,12 @@ func configure(plugin *node.Plugin) {
 func run(_ *node.Plugin) {
 
 	notifyNewTx := events.NewClosure(func(cachedTx *tanglePackage.CachedTransaction, firstSeenLatestMilestoneIndex milestone.Index, latestSolidMilestoneIndex milestone.Index) {
-		if !tanglePackage.IsNodeSyncedWithThreshold() {
-			// Not sync
-			cachedTx.Release(true) // tx -1
-			return
+		if !wasSyncBefore {
+			if !tanglePackage.IsNodeSyncedWithThreshold() {
+				cachedTx.Release(true) // tx -1
+				return
+			}
+			wasSyncBefore = true
 		}
 
 		if _, added := newTxWorkerPool.TrySubmit(cachedTx); added { // tx pass +1
@@ -116,8 +120,7 @@ func run(_ *node.Plugin) {
 	})
 
 	notifyConfirmedTx := events.NewClosure(func(cachedTx *tanglePackage.CachedTransaction, msIndex milestone.Index, confTime int64) {
-		if !tanglePackage.IsNodeSyncedWithThreshold() {
-			// Not sync
+		if !wasSyncBefore {
 			cachedTx.Release(true) // tx -1
 			return
 		}
@@ -129,8 +132,7 @@ func run(_ *node.Plugin) {
 	})
 
 	notifyNewMilestone := events.NewClosure(func(cachedBndl *tanglePackage.CachedBundle) {
-		if !tanglePackage.IsNodeSyncedWithThreshold() {
-			// Not sync
+		if !wasSyncBefore {
 			cachedBndl.Release(true) // tx -1
 			return
 		}

--- a/plugins/monitor/plugin.go
+++ b/plugins/monitor/plugin.go
@@ -28,7 +28,6 @@ import (
 const (
 	TxBufferSize       = 50000
 	BroadcastQueueSize = 20000
-	isSyncThreshold    = 1
 )
 
 var (
@@ -50,8 +49,6 @@ var (
 	reattachmentWorkerCount     = 1
 	reattachmentWorkerQueueSize = 100
 	reattachmentWorkerPool      *workerpool.WorkerPool
-
-	wasSyncBefore = false
 
 	server            *http.Server
 	apiServer         *http.Server
@@ -140,40 +137,40 @@ func configure(plugin *node.Plugin) {
 func run(_ *node.Plugin) {
 
 	notifyNewTx := events.NewClosure(func(cachedTx *tanglePackage.CachedTransaction, firstSeenLatestMilestoneIndex milestone.Index, latestSolidMilestoneIndex milestone.Index) {
-		if !wasSyncBefore {
-			if !tanglePackage.IsNodeSynced() || (firstSeenLatestMilestoneIndex <= tanglePackage.GetLatestSeenMilestoneIndexFromSnapshot()) {
-				// Not sync
-				cachedTx.Release(true) // tx -1
-				return
-			}
-			wasSyncBefore = true
+		if !tanglePackage.IsNodeSyncedWithThreshold() {
+			// Not sync
+			cachedTx.Release(true) // tx -1
+			return
 		}
 
-		if (firstSeenLatestMilestoneIndex - latestSolidMilestoneIndex) <= isSyncThreshold {
-			_, added := newTxWorkerPool.TrySubmit(cachedTx) // tx pass +1
-			if added {
-				return // Avoid tx -1 (done inside workerpool task)
-			}
+		if _, added := newTxWorkerPool.TrySubmit(cachedTx); added { // tx pass +1
+			return // Avoid tx -1 (done inside workerpool task)
 		}
 		cachedTx.Release(true) // tx -1
 	})
 
 	notifyConfirmedTx := events.NewClosure(func(cachedTx *tanglePackage.CachedTransaction, msIndex milestone.Index, confTime int64) {
-		if wasSyncBefore {
-			_, added := confirmedTxWorkerPool.TrySubmit(cachedTx, msIndex, confTime) // tx pass +1
-			if added {
-				return // Avoid tx -1 (done inside workerpool task)
-			}
+		if !tanglePackage.IsNodeSyncedWithThreshold() {
+			// Not sync
+			cachedTx.Release(true) // tx -1
+			return
+		}
+
+		if _, added := confirmedTxWorkerPool.TrySubmit(cachedTx, msIndex, confTime); added { // tx pass +1
+			return // Avoid tx -1 (done inside workerpool task)
 		}
 		cachedTx.Release(true) // tx -1
 	})
 
 	notifyNewMilestone := events.NewClosure(func(cachedBndl *tanglePackage.CachedBundle) {
-		if wasSyncBefore {
-			_, added := newMilestoneWorkerPool.TrySubmit(cachedBndl) // bundle pass +1
-			if added {
-				return // Avoid bundle -1 (done inside workerpool task)
-			}
+		if !tanglePackage.IsNodeSyncedWithThreshold() {
+			// Not sync
+			cachedBndl.Release(true) // tx -1
+			return
+		}
+
+		if _, added := newMilestoneWorkerPool.TrySubmit(cachedBndl); added { // bundle pass +1
+			return // Avoid bundle -1 (done inside workerpool task)
 		}
 		cachedBndl.Release(true) // bundle -1
 	})

--- a/plugins/mqtt/plugin.go
+++ b/plugins/mqtt/plugin.go
@@ -15,10 +15,6 @@ import (
 	"github.com/gohornet/hornet/plugins/tangle"
 )
 
-const (
-	isSyncThreshold = 1
-)
-
 var (
 	// MQTT is disabled by default
 	PLUGIN = node.NewPlugin("MQTT", node.Disabled, configure, run)
@@ -43,8 +39,6 @@ var (
 	spentAddressWorkerCount     = 1
 	spentAddressWorkerQueueSize = 1000
 	spentAddressWorkerPool      *workerpool.WorkerPool
-
-	wasSyncBefore = false
 
 	mqttBroker *Broker
 )
@@ -91,50 +85,53 @@ func run(plugin *node.Plugin) {
 	log.Infof("Starting MQTT Broker (port %s) ...", mqttBroker.config.Port)
 
 	notifyNewTx := events.NewClosure(func(cachedTx *tanglePackage.CachedTransaction, firstSeenLatestMilestoneIndex milestone.Index, latestSolidMilestoneIndex milestone.Index) {
-		if !wasSyncBefore {
-			if !tanglePackage.IsNodeSynced() || (firstSeenLatestMilestoneIndex <= tanglePackage.GetLatestSeenMilestoneIndexFromSnapshot()) {
-				// Not sync
-				cachedTx.Release(true) // tx -1
-				return
-			}
-			wasSyncBefore = true
+		if !tanglePackage.IsNodeSyncedWithThreshold() {
+			// Not sync
+			cachedTx.Release(true) // tx -1
+			return
 		}
 
-		if (firstSeenLatestMilestoneIndex - latestSolidMilestoneIndex) <= isSyncThreshold {
-			_, added := newTxWorkerPool.TrySubmit(cachedTx) // tx pass +1
-			if added {
-				return // Avoid tx -1 (done inside workerpool task)
-			}
+		if _, added := newTxWorkerPool.TrySubmit(cachedTx); added { // tx pass +1
+			return // Avoid tx -1 (done inside workerpool task)
 		}
 		cachedTx.Release(true) // tx -1
 	})
 
 	notifyConfirmedTx := events.NewClosure(func(cachedTx *tanglePackage.CachedTransaction, msIndex milestone.Index, confTime int64) {
-		if wasSyncBefore {
-			_, added := confirmedTxWorkerPool.TrySubmit(cachedTx, msIndex, confTime) // tx pass +1
-			if added {
-				return // Avoid tx -1 (done inside workerpool task)
-			}
+		if !tanglePackage.IsNodeSyncedWithThreshold() {
+			// Not sync
+			cachedTx.Release(true) // tx -1
+			return
+		}
+
+		if _, added := confirmedTxWorkerPool.TrySubmit(cachedTx, msIndex, confTime); added { // tx pass +1
+			return // Avoid tx -1 (done inside workerpool task)
 		}
 		cachedTx.Release(true) // tx -1
 	})
 
 	notifyNewLatestMilestone := events.NewClosure(func(cachedBndl *tanglePackage.CachedBundle) {
-		if wasSyncBefore {
-			_, added := newLatestMilestoneWorkerPool.TrySubmit(cachedBndl) // bundle pass +1
-			if added {
-				return // Avoid bundle -1 (done inside workerpool task)
-			}
+		if !tanglePackage.IsNodeSyncedWithThreshold() {
+			// Not sync
+			cachedBndl.Release(true) // tx -1
+			return
+		}
+
+		if _, added := newLatestMilestoneWorkerPool.TrySubmit(cachedBndl); added { // bundle pass +1
+			return // Avoid bundle -1 (done inside workerpool task)
 		}
 		cachedBndl.Release(true) // bundle -1
 	})
 
 	notifyNewSolidMilestone := events.NewClosure(func(cachedBndl *tanglePackage.CachedBundle) {
-		if wasSyncBefore {
-			_, added := newSolidMilestoneWorkerPool.TrySubmit(cachedBndl) // bundle pass +1
-			if added {
-				return // Avoid bundle -1 (done inside workerpool task)
-			}
+		if !tanglePackage.IsNodeSyncedWithThreshold() {
+			// Not sync
+			cachedBndl.Release(true) // tx -1
+			return
+		}
+
+		if _, added := newSolidMilestoneWorkerPool.TrySubmit(cachedBndl); added { // bundle pass +1
+			return // Avoid bundle -1 (done inside workerpool task)
 		}
 		cachedBndl.Release(true) // bundle -1
 	})

--- a/plugins/snapshot/global_snapshot.go
+++ b/plugins/snapshot/global_snapshot.go
@@ -127,6 +127,7 @@ func loadSnapshotFromTextfiles(filePathLedger string, filePathsSpent []string, s
 
 	spentAddrEnabled := (spentAddressesSum != 0) || ((snapshotIndex == 0) && config.NodeConfig.GetBool(config.CfgSpentAddressesEnabled))
 	tangle.SetSnapshotMilestone(config.NodeConfig.GetString(config.CfgMilestoneCoordinator)[:81], consts.NullHashTrytes, snapshotIndex, snapshotIndex, 0, spentAddrEnabled)
+	tangle.SetLatestSeenMilestoneIndexFromSnapshot(snapshotIndex)
 
 	log.Info("Finished loading snapshot")
 

--- a/plugins/snapshot/local_snapshot.go
+++ b/plugins/snapshot/local_snapshot.go
@@ -710,6 +710,7 @@ func LoadSnapshotFromFile(filePath string) error {
 
 	tangle.SetSnapshotMilestone(config.NodeConfig.GetString(config.CfgMilestoneCoordinator)[:81], msHash[:81], milestone.Index(msIndex), milestone.Index(msIndex), msTimestamp, spentAddrsCount != 0 && config.NodeConfig.GetBool("spentAddresses.enabled"))
 	tangle.SolidEntryPointsAdd(msHash[:81], milestone.Index(msIndex))
+	tangle.SetLatestSeenMilestoneIndexFromSnapshot(milestone.Index(msIndex))
 
 	log.Info("Importing solid entry points")
 

--- a/plugins/webapi/debug.go
+++ b/plugins/webapi/debug.go
@@ -37,7 +37,7 @@ func getRequests(_ interface{}, c *gin.Context, _ <-chan struct{}) {
 		}
 	}
 	for i := 0; i < len(pending); i++ {
-		req := queued[i]
+		req := pending[i]
 		debugReqs[offset+i] = &DebugRequest{
 			Hash:             req.Hash,
 			InPending:        true,


### PR DESCRIPTION
This PR changes the the way `IsNodeSynced` and `IsNodeSyncedWithThreshold` behaves.

These functions now only return `true` if the node synced at least all milestones that were included in the local snapshot as `seenMilestones`.

It also fixes a possible race condition in some of the webapi calls, that rely on a synced node respectively the confirmation state / ledger state. 
 