### PR TITLE
Implements warp synchronization

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"github.com/gohornet/hornet/plugins/warpsync"
 	"github.com/iotaledger/hive.go/node"
 
 	"github.com/gohornet/hornet/pkg/config"
@@ -42,6 +43,7 @@ func main() {
 		plugins = append(plugins, []*node.Plugin{
 			peering.PLUGIN,
 			gossip.PLUGIN,
+			warpsync.PLUGIN,
 			tangle.PLUGIN,
 			tipselection.PLUGIN,
 			metrics.PLUGIN,

--- a/pkg/protocol/warpsync/warpsync.go
+++ b/pkg/protocol/warpsync/warpsync.go
@@ -76,8 +76,7 @@ func (ws *WarpSync) Update(current milestone.Index, target ...milestone.Index) {
 		// in order to have a continuous stream of solidifications
 		if int(currentToCheckpointDelta) >= ws.checkpointRange/2 || ws.current >= ws.checkpoint {
 			// advance checkpoint
-			msRange := ws.advanceCheckpoint()
-			if msRange != 0 {
+			if msRange := ws.advanceCheckpoint(); msRange != 0 {
 				ws.Events.CheckpointUpdated.Trigger(ws.checkpoint, msRange)
 			}
 		}

--- a/pkg/protocol/warpsync/warpsync.go
+++ b/pkg/protocol/warpsync/warpsync.go
@@ -1,0 +1,137 @@
+package warpsync
+
+import (
+	"sync"
+	"time"
+
+	"github.com/gohornet/hornet/pkg/model/milestone"
+	"github.com/iotaledger/hive.go/events"
+)
+
+// New creates a new WarpSync instance.
+func New(rangePerCheckpoint int) *WarpSync {
+	ws := &WarpSync{
+		Events: Events{
+			CheckpointUpdated: events.NewEvent(CheckpointCaller),
+			Start:             events.NewEvent(milestone.IndexCaller),
+			Done:              events.NewEvent(SyncDoneCaller),
+		},
+		current:         0,
+		target:          0,
+		checkpointRange: rangePerCheckpoint,
+	}
+	return ws
+}
+
+// WarpSync is metadata about doing a synchronization via STING messages.
+type WarpSync struct {
+	mu sync.Mutex
+	Events
+	start           time.Time
+	init            milestone.Index
+	current         milestone.Index
+	checkpoint      milestone.Index
+	target          milestone.Index
+	checkpointRange int
+}
+
+func SyncDoneCaller(handler interface{}, params ...interface{}) {
+	handler.(func(delta int, dur time.Duration))(params[0].(int), params[1].(time.Duration))
+}
+
+func CheckpointCaller(handler interface{}, params ...interface{}) {
+	handler.(func(checkpoint milestone.Index, msRange int32))(params[0].(milestone.Index), params[1].(int32))
+}
+
+// Events holds WarpSync related events.
+type Events struct {
+	// Fired when a new set of milestones should be requested.
+	CheckpointUpdated *events.Event
+	// Fired when warp synchronization starts.
+	Start *events.Event
+	// Fired when the warp synchronization is done.
+	Done *events.Event
+}
+
+// Update updates the WarpSync state.
+func (ws *WarpSync) Update(current milestone.Index, target ...milestone.Index) {
+	ws.mu.Lock()
+	defer ws.mu.Unlock()
+
+	// prevent warp sync during normal operation when the node is already synced
+	if ws.checkpoint == 0 && len(target) == 0 || (len(target) > 0 && target[0]-current <= 1) {
+		return
+	}
+
+	if current >= ws.current {
+		ws.current = current
+	}
+
+	// we're over the checkpoint, trigger a milestone request trigger
+	if ws.checkpoint != 0 {
+		currentToCheckpointDelta := ws.checkpoint - ws.current
+
+		// advance checkpoint when when're over/equal the checkpoint.
+		// as an optimization we also update the checkpoint when we're at half the range
+		// in order to have a continuous stream of solidifications
+		if int(currentToCheckpointDelta) >= ws.checkpointRange/2 || ws.current >= ws.checkpoint {
+			// advance checkpoint
+			msRange := ws.advanceCheckpoint()
+			if msRange != 0 {
+				ws.Events.CheckpointUpdated.Trigger(ws.checkpoint, msRange)
+			}
+		}
+	}
+
+	// done
+	if ws.current >= ws.target && ws.target != 0 {
+		ws.Events.Done.Trigger(int(ws.target-ws.init), time.Since(ws.start))
+		ws.reset()
+		return
+	}
+
+	if len(target) == 0 {
+		return
+	}
+
+	// auto. set on first call
+	if ws.target == 0 {
+		ws.target = target[0]
+	}
+
+	// set checkpoint for the first time
+	if ws.checkpoint == 0 && ws.target != 0 && ws.current < ws.target {
+		ws.start = time.Now()
+		ws.init = ws.current
+		ws.Events.Start.Trigger(ws.target)
+		msRange := ws.advanceCheckpoint()
+		ws.Events.CheckpointUpdated.Trigger(ws.checkpoint, msRange)
+	}
+
+	if target[0] <= ws.target {
+		return
+	}
+	ws.target = target[0]
+}
+
+// advances the next checkpoint by either incrementing from the current
+// via the checkpoint range or max to the target of the synchronization.
+// returns the chosen range.
+func (ws *WarpSync) advanceCheckpoint() int32 {
+	msRange := milestone.Index(ws.checkpointRange)
+	if ws.current+msRange > ws.target {
+		ws.checkpoint = ws.target
+		msRange = ws.target - ws.current
+	} else {
+		ws.checkpoint = ws.current + msRange
+	}
+	return int32(msRange)
+}
+
+// resets the warp sync.
+func (ws *WarpSync) reset() {
+	ws.current = 0
+	ws.checkpoint = 0
+	ws.target = 0
+	ws.init = 0
+}

--- a/plugins/gossip/broadcast.go
+++ b/plugins/gossip/broadcast.go
@@ -1,8 +1,6 @@
 package gossip
 
 import (
-	"math"
-
 	"github.com/gohornet/hornet/pkg/model/milestone"
 	"github.com/gohornet/hornet/pkg/model/tangle"
 	"github.com/gohornet/hornet/pkg/peering/peer"
@@ -37,24 +35,12 @@ func BroadcastLatestMilestoneRequest() {
 	})
 }
 
-const milestoneRequestRange = 50
-
-// BroadcastMilestoneRequests broadcasts up to 50 requests for milestones nearest to the current solid milestone index
+// BroadcastMilestoneRequests broadcasts up to N requests for milestones nearest to the current solid milestone index
 // to every connected peer who supports STING.
-func BroadcastMilestoneRequests(solidMilestoneIndex milestone.Index, knownLatestMilestone milestone.Index) {
-	var rangeToRequest int
-	if solidMilestoneIndex != 0 && knownLatestMilestone != 0 {
-		rangeToRequest = int(math.Min(float64(milestoneRequestRange), float64(knownLatestMilestone-solidMilestoneIndex)))
-	} else {
-		rangeToRequest = milestoneRequestRange
-	}
-
-	// don't request anything if we are sync (or don't know about a newer ms)
-	if rangeToRequest == 0 {
-		return
-	}
+func BroadcastMilestoneRequests(rangeToRequest int) {
 
 	// make sure we only request what we don't have
+	solidMilestoneIndex := tangle.GetSolidMilestoneIndex()
 	var msIndexes []milestone.Index
 	for i := 1; i <= rangeToRequest; i++ {
 		toReq := solidMilestoneIndex + milestone.Index(i)

--- a/plugins/tangle/plugin.go
+++ b/plugins/tangle/plugin.go
@@ -67,11 +67,9 @@ func configure(plugin *node.Plugin) {
 	}, shutdown.PriorityFlushToDatabase)
 
 	Events.SolidMilestoneChanged.Attach(events.NewClosure(func(cachedBndl *tangle.CachedBundle) {
+		defer cachedBndl.Release() // bundle -1
 		// notify peers about our new solid milestone index
 		gossip.BroadcastHeartbeat()
-		msIndex := cachedBndl.GetBundle().GetMilestoneIndex()
-		gossip.BroadcastMilestoneRequests(msIndex, tangle.GetLatestMilestoneIndex())
-		cachedBndl.Release() // bundle -1
 	}))
 
 	Events.PruningMilestoneIndexChanged.Attach(events.NewClosure(func(msIndex milestone.Index) {

--- a/plugins/warpsync/plugin.go
+++ b/plugins/warpsync/plugin.go
@@ -1,0 +1,63 @@
+package warpsync
+
+import (
+	"time"
+
+	"github.com/gohornet/hornet/pkg/model/milestone"
+	"github.com/gohornet/hornet/pkg/model/tangle"
+	"github.com/gohornet/hornet/pkg/peering/peer"
+	"github.com/gohornet/hornet/pkg/protocol/rqueue"
+	"github.com/gohornet/hornet/pkg/protocol/sting"
+	"github.com/gohornet/hornet/pkg/protocol/warpsync"
+	"github.com/gohornet/hornet/plugins/gossip"
+	peeringplugin "github.com/gohornet/hornet/plugins/peering"
+	tangleplugin "github.com/gohornet/hornet/plugins/tangle"
+	"github.com/iotaledger/hive.go/events"
+	"github.com/iotaledger/hive.go/logger"
+	"github.com/iotaledger/hive.go/node"
+)
+
+var (
+	PLUGIN   = node.NewPlugin("WarpSync", node.Enabled, configure)
+	log      *logger.Logger
+	warpSync = warpsync.New(300)
+)
+
+func configure(plugin *node.Plugin) {
+	log = logger.NewLogger(plugin.Name)
+
+	peeringplugin.Manager().Events.PeerConnected.Attach(events.NewClosure(func(p *peer.Peer) {
+
+		if !p.Protocol.Supports(sting.FeatureSet) {
+			return
+		}
+
+		p.Protocol.Events.Received[sting.MessageTypeHeartbeat].Attach(events.NewClosure(func(data []byte) {
+			hb := sting.ParseHeartbeat(data)
+			warpSync.Update(tangle.GetSolidMilestoneIndex(), hb.SolidMilestoneIndex)
+		}))
+	}))
+
+	tangleplugin.Events.SolidMilestoneChanged.Attach(events.NewClosure(func(cachedMsBundle *tangle.CachedBundle) { // bundle +1
+		defer cachedMsBundle.Release() // bundle -1
+		warpSync.Update(cachedMsBundle.GetBundle().GetMilestoneIndex())
+	}))
+
+	warpSync.Events.CheckpointUpdated.Attach(events.NewClosure(func(nextCheckpoint milestone.Index, msRange int32) {
+		log.Infof("Checkpoint updated to milestone %d", nextCheckpoint)
+		// prevent any requests in the queue above our next checkpoint
+		gossip.RequestQueue().Filter(func(r *rqueue.Request) bool {
+			return r.MilestoneIndex <= nextCheckpoint
+		})
+		gossip.BroadcastMilestoneRequests(int(msRange))
+	}))
+
+	warpSync.Events.Start.Attach(events.NewClosure(func(targetMsIndex milestone.Index) {
+		log.Infof("Synchronizing to milestone %d", targetMsIndex)
+	}))
+
+	warpSync.Events.Done.Attach(events.NewClosure(func(deltaSynced int, took time.Duration) {
+		log.Infof("Synchronized %d milestones in %v", deltaSynced, took)
+		gossip.RequestQueue().Filter(nil)
+	}))
+}


### PR DESCRIPTION
Adds a new plugin which handles warp synchronization by using a checkpoint system which keeps the solidifier continuously solidifiying without blowing up the request queue as only relevant requests are kept.

An additional parameter could be specified which allows a node to decide how much data it thinks it can handle during synchronization in the checkpoint steps.