### PR TITLE
Improves warp synchronization

### DIFF
--- a/pkg/dag/helper.go
+++ b/pkg/dag/helper.go
@@ -69,7 +69,7 @@ type OnMissingApprovee func(approveeHash trinary.Hash)
 
 // TraverseApprovees starts to traverse the approvees of the given start transaction until
 // the traversal stops due to no more transactions passing the given condition.
-func TraverseApprovees(startTxHash trinary.Hash, condition Predicate, consumer Consumer, onMissingApprovee OnMissingApprovee) {
+func TraverseApprovees(startTxHash trinary.Hash, condition Predicate, consumer Consumer, onMissingApprovee OnMissingApprovee, forceRelease bool) {
 
 	if tangle.SolidEntryPointsContain(startTxHash) {
 		return
@@ -87,7 +87,7 @@ func TraverseApprovees(startTxHash trinary.Hash, condition Predicate, consumer C
 			}
 
 			if txHash != startTxHash && !condition(cachedTx.Retain()) { // tx + 1
-				cachedTx.Release()
+				cachedTx.Release(forceRelease)
 				continue
 			}
 
@@ -101,7 +101,7 @@ func TraverseApprovees(startTxHash trinary.Hash, condition Predicate, consumer C
 				cachedTx.GetTransaction().GetBranch(): {},
 			}
 
-			cachedTx.Release(true) // tx -1
+			cachedTx.Release(forceRelease) // tx -1
 
 			for approveeHash := range approveeHashes {
 				if tangle.SolidEntryPointsContain(approveeHash) {

--- a/pkg/dag/helper.go
+++ b/pkg/dag/helper.go
@@ -58,17 +58,17 @@ func FindAllTails(txHash trinary.Hash, forceRelease bool) (map[string]struct{}, 
 	return tails, nil
 }
 
-// Predicate defines the condition whether the traversal should continue or not
+// Predicate defines whether a traversal should continue or not.
 type Predicate func(cachedTx *tangle.CachedTransaction) bool
 
-// Consumer consumes the given transaction doing traversal
+// Consumer consumes the given transaction during traversal.
 type Consumer func(cachedTx *tangle.CachedTransaction)
 
 // OnMissingApprovee gets called when during traversal an approvee is missing.
 type OnMissingApprovee func(approveeHash trinary.Hash)
 
 // TraverseApprovees starts to traverse the approvees of the given start transaction until
-// the traversal stops due to transaction not passing the given condition.
+// the traversal stops due to no more transactions passing the given condition.
 func TraverseApprovees(startTxHash trinary.Hash, condition Predicate, consumer Consumer, onMissingApprovee OnMissingApprovee) {
 
 	if tangle.SolidEntryPointsContain(startTxHash) {

--- a/pkg/protocol/rqueue/rqueue.go
+++ b/pkg/protocol/rqueue/rqueue.go
@@ -160,8 +160,7 @@ func (pq *priorityqueue) Received(hash trinary.Hash) *Request {
 	}
 
 	// check if the request is in the queue (was enqueued again after request)
-	req, _ := pq.queued[hash]
-	return req
+	return pq.queued[hash]
 }
 
 func (pq *priorityqueue) EnqueuePending(discardOlderThan time.Duration) int {

--- a/pkg/protocol/rqueue/rqueue.go
+++ b/pkg/protocol/rqueue/rqueue.go
@@ -155,10 +155,11 @@ func (pq *priorityqueue) Received(hash trinary.Hash) *Request {
 			pq.latencySum = 0
 			pq.avgLatency.Store(0)
 		}
+
 		return req
 	}
 
-	// Check if the request is in the queue (was enqueued again after request)
+	// check if the request is in the queue (was enqueued again after request)
 	req, _ := pq.queued[hash]
 	return req
 }
@@ -166,6 +167,9 @@ func (pq *priorityqueue) Received(hash trinary.Hash) *Request {
 func (pq *priorityqueue) EnqueuePending(discardOlderThan time.Duration) int {
 	pq.Lock()
 	defer pq.Unlock()
+	if len(pq.queued) != 0 {
+		return 0
+	}
 	enqueued := len(pq.pending)
 	s := time.Now()
 	for k, v := range pq.pending {

--- a/pkg/protocol/warpsync/warpsync.go
+++ b/pkg/protocol/warpsync/warpsync.go
@@ -61,8 +61,8 @@ const DefaultAdvancementThreshold = 0.0
 // when the current one was reached by >=X% by the current solid milestone in relation to the previous checkpoint.
 func AdvanceAtPercentageReached(threshold float64) AdvanceCheckpointCriteria {
 	return func(currentSolid, previousCheckpoint, currentCheckpoint milestone.Index) bool {
-		// the previous checkpoint can be over the current solid one, as advancements
-		// move the checkpoint window above the solid milestone
+		// the previous checkpoint can be over the current solid milestone,
+		// as advancements move the checkpoint window above the solid milestone
 		if currentSolid < previousCheckpoint {
 			return false
 		}

--- a/pkg/protocol/warpsync/warpsync.go
+++ b/pkg/protocol/warpsync/warpsync.go
@@ -1,7 +1,6 @@
 package warpsync
 
 import (
-	"fmt"
 	"sync"
 	"time"
 
@@ -9,31 +8,23 @@ import (
 	"github.com/iotaledger/hive.go/events"
 )
 
-// New creates a new WarpSync instance.
-func New(rangePerCheckpoint int) *WarpSync {
+// New creates a new WarpSync instance with the given advancement range and criteria func.
+// If no advancement func is provided, the WarpSync uses AdvanceAtPercentReached with DefaultAdvancementThreshold.
+func New(advRange int, advanceCheckpointCriteriaFunc ...AdvanceCheckpointCriteria) *WarpSync {
 	ws := &WarpSync{
 		Events: Events{
 			CheckpointUpdated: events.NewEvent(CheckpointCaller),
 			Start:             events.NewEvent(SyncStartCaller),
 			Done:              events.NewEvent(SyncDoneCaller),
 		},
-		current:         0,
-		target:          0,
-		checkpointRange: rangePerCheckpoint,
+		AdvancementRange: advRange,
+	}
+	if len(advanceCheckpointCriteriaFunc) > 0 {
+		ws.advCheckpointCriteria = advanceCheckpointCriteriaFunc[0]
+	} else {
+		ws.advCheckpointCriteria = AdvanceAtPercentReached(DefaultAdvancementThreshold)
 	}
 	return ws
-}
-
-// WarpSync is metadata about doing a synchronization via STING messages.
-type WarpSync struct {
-	mu sync.Mutex
-	Events
-	start           time.Time
-	init            milestone.Index
-	current         milestone.Index
-	checkpoint      milestone.Index
-	target          milestone.Index
-	checkpointRange int
 }
 
 func SyncStartCaller(handler interface{}, params ...interface{}) {
@@ -58,98 +49,133 @@ type Events struct {
 	Done *events.Event
 }
 
-// Update updates the WarpSync state.
-func (ws *WarpSync) Update(current milestone.Index, target ...milestone.Index) {
+// AdvanceCheckpointCriteria is a function which determines whether the checkpoint should be advanced.
+type AdvanceCheckpointCriteria func(currentSolid, previousCheckpoint, currentCheckpoint milestone.Index) bool
+
+// DefaultAdvancementThreshold is the default threshold at which a checkpoint advancement is done.
+// Per default an advancement is always done as soon the solid milestone enters the range between
+// the previous and current checkpoint.
+const DefaultAdvancementThreshold = 0.0
+
+// AdvanceAtPercentReached is an AdvanceCheckpointCriteria which advances the checkpoint
+// when the current one was reached by >=X% by the current solid milestone in relation to the previous checkpoint.
+func AdvanceAtPercentReached(threshold float64) AdvanceCheckpointCriteria {
+	return func(currentSolid, previousCheckpoint, currentCheckpoint milestone.Index) bool {
+		// the previous checkpoint can be over the current solid one, as advancements
+		// move the checkpoint window above the solid milestone
+		if currentSolid < previousCheckpoint {
+			return false
+		}
+		checkpointDelta := currentCheckpoint - previousCheckpoint
+		progress := currentSolid - previousCheckpoint
+		return float64(progress)/float64(checkpointDelta) >= threshold
+	}
+}
+
+// WarpSync is metadata about doing a synchronization via STING messages.
+type WarpSync struct {
+	mu                    sync.Mutex
+	start                 time.Time
+	advCheckpointCriteria AdvanceCheckpointCriteria
+	Events                Events
+	// The starting point of the synchronization.
+	Init milestone.Index
+	// The current solid milestone of the node.
+	CurrentSolidMs milestone.Index
+	// The target milestone to which to synchronize to.
+	TargetMs milestone.Index
+	// The previous checkpoint of the synchronization.
+	PreviousCheckpoint milestone.Index
+	// The current checkpoint of the synchronization.
+	CurrentCheckpoint milestone.Index
+	// The used advancement range per checkpoint.
+	AdvancementRange int
+}
+
+// UpdateCurrent updates the current solid milestone index state.
+func (ws *WarpSync) UpdateCurrent(current milestone.Index) {
 	ws.mu.Lock()
 	defer ws.mu.Unlock()
+	if current <= ws.CurrentSolidMs {
+		return
+	}
+	ws.CurrentSolidMs = current
 
-	// prevent warp sync during normal operation when the node is already synced
-	if ws.checkpoint == 0 && len(target) == 0 ||
-		(len(target) > 0 && target[0]-current <= 1) {
+	// synchronization not started
+	if ws.CurrentCheckpoint == 0 {
 		return
 	}
 
-	if len(target) != 0 && ws.target != 0 {
-		if ws.target < target[0] {
-			ws.target = target[0]
-		}
-		return
-	}
-
-	if current >= ws.current {
-		ws.current = current
-	}
-
-	// we're over the checkpoint, trigger a milestone request trigger
-	if ws.checkpoint != 0 {
-		currentToCheckpointDelta := ws.checkpoint - ws.current
-
-		// advance checkpoint when when're over/equal the checkpoint.
-		// as an optimization we also update the checkpoint when we're at half the range
-		// in order to have a continuous stream of solidifications
-		if int(currentToCheckpointDelta) >= ws.checkpointRange/2 || ws.current >= ws.checkpoint {
-			// advance checkpoint
-			oldCheckpoint := ws.checkpoint
-			if msRange := ws.advanceCheckpoint(); msRange != 0 {
-				ws.Events.CheckpointUpdated.Trigger(ws.checkpoint, oldCheckpoint, msRange)
-			}
-		}
-	}
-
-	// done
-	if ws.current >= ws.target && ws.target != 0 {
-		ws.Events.Done.Trigger(int(ws.target-ws.init), time.Since(ws.start))
+	// finished
+	if ws.TargetMs != 0 && ws.CurrentSolidMs >= ws.TargetMs {
+		ws.Events.Done.Trigger(int(ws.TargetMs-ws.Init), time.Since(ws.start))
 		ws.reset()
 		return
 	}
 
-	if len(target) == 0 {
+	// check whether advancement criteria is fulfilled
+	if !ws.advCheckpointCriteria(ws.CurrentSolidMs, ws.PreviousCheckpoint, ws.CurrentCheckpoint) {
 		return
 	}
 
-	// auto. set on first call
-	if ws.target == 0 {
-		ws.target = target[0]
+	oldCheckpoint := ws.CurrentCheckpoint
+	if msRange := ws.advanceCheckpoint(); msRange != 0 {
+		ws.Events.CheckpointUpdated.Trigger(ws.CurrentCheckpoint, oldCheckpoint, msRange)
 	}
+}
 
-	// set checkpoint for the first time
-	if ws.checkpoint == 0 && ws.target != 0 && ws.current < ws.target {
-		ws.start = time.Now()
-		ws.init = ws.current
-		msRange := ws.advanceCheckpoint()
-		ws.Events.Start.Trigger(ws.target, ws.checkpoint, msRange)
-	}
-
-	if target[0] <= ws.target {
+// UpdateTarget updates the synchronization target if it is higher than the current one and
+// triggers a synchronization start if the target was set for the first time.
+func (ws *WarpSync) UpdateTarget(target milestone.Index) {
+	ws.mu.Lock()
+	defer ws.mu.Unlock()
+	if target <= ws.TargetMs {
 		return
 	}
-	ws.target = target[0]
+
+	ws.TargetMs = target
+
+	if ws.CurrentCheckpoint != 0 || ws.CurrentSolidMs >= ws.TargetMs || target-ws.CurrentSolidMs <= 1 {
+		return
+	}
+
+	ws.start = time.Now()
+	ws.Init = ws.CurrentSolidMs
+	ws.PreviousCheckpoint = ws.CurrentSolidMs
+	advancementRange := ws.advanceCheckpoint()
+	ws.Events.Start.Trigger(ws.TargetMs, ws.CurrentCheckpoint, advancementRange)
 }
 
 // advances the next checkpoint by either incrementing from the current
 // via the checkpoint range or max to the target of the synchronization.
 // returns the chosen range.
 func (ws *WarpSync) advanceCheckpoint() int32 {
-	fmt.Println("old", ws.checkpoint)
-	msRange := milestone.Index(ws.checkpointRange)
-	if ws.current+msRange > ws.target {
-		ws.checkpoint = ws.target
-		msRange = ws.target - ws.current
-	} else {
-		if ws.checkpoint == 0 {
-			ws.checkpoint = ws.current + msRange
-		} else {
-			ws.checkpoint = ws.checkpoint + msRange
-		}
+	if ws.CurrentCheckpoint != 0 {
+		ws.PreviousCheckpoint = ws.CurrentCheckpoint
 	}
-	fmt.Println("new", ws.checkpoint)
-	return int32(msRange)
+
+	advRange := milestone.Index(ws.AdvancementRange)
+
+	// if we reach the target, just take the delta from target to current solid
+	if ws.CurrentSolidMs+advRange >= ws.TargetMs {
+		ws.CurrentCheckpoint = ws.TargetMs
+		return int32(ws.TargetMs - ws.CurrentSolidMs)
+	}
+
+	// at start simply advance from the current solid
+	if ws.CurrentCheckpoint == 0 {
+		ws.CurrentCheckpoint = ws.CurrentSolidMs + advRange
+		return int32(ws.AdvancementRange)
+	}
+
+	ws.CurrentCheckpoint = ws.CurrentCheckpoint + advRange
+	return int32(advRange)
 }
 
 // resets the warp sync.
 func (ws *WarpSync) reset() {
-	ws.current = 0
-	ws.checkpoint = 0
-	ws.target = 0
-	ws.init = 0
+	ws.CurrentSolidMs = 0
+	ws.CurrentCheckpoint = 0
+	ws.TargetMs = 0
+	ws.Init = 0
 }

--- a/pkg/protocol/warpsync/warpsync.go
+++ b/pkg/protocol/warpsync/warpsync.go
@@ -9,7 +9,7 @@ import (
 )
 
 // New creates a new WarpSync instance with the given advancement range and criteria func.
-// If no advancement func is provided, the WarpSync uses AdvanceAtPercentReached with DefaultAdvancementThreshold.
+// If no advancement func is provided, the WarpSync uses AdvanceAtPercentageReached with DefaultAdvancementThreshold.
 func New(advRange int, advanceCheckpointCriteriaFunc ...AdvanceCheckpointCriteria) *WarpSync {
 	ws := &WarpSync{
 		Events: Events{
@@ -22,7 +22,7 @@ func New(advRange int, advanceCheckpointCriteriaFunc ...AdvanceCheckpointCriteri
 	if len(advanceCheckpointCriteriaFunc) > 0 {
 		ws.advCheckpointCriteria = advanceCheckpointCriteriaFunc[0]
 	} else {
-		ws.advCheckpointCriteria = AdvanceAtPercentReached(DefaultAdvancementThreshold)
+		ws.advCheckpointCriteria = AdvanceAtPercentageReached(DefaultAdvancementThreshold)
 	}
 	return ws
 }
@@ -57,9 +57,9 @@ type AdvanceCheckpointCriteria func(currentSolid, previousCheckpoint, currentChe
 // the previous and current checkpoint.
 const DefaultAdvancementThreshold = 0.0
 
-// AdvanceAtPercentReached is an AdvanceCheckpointCriteria which advances the checkpoint
+// AdvanceAtPercentageReached is an AdvanceCheckpointCriteria which advances the checkpoint
 // when the current one was reached by >=X% by the current solid milestone in relation to the previous checkpoint.
-func AdvanceAtPercentReached(threshold float64) AdvanceCheckpointCriteria {
+func AdvanceAtPercentageReached(threshold float64) AdvanceCheckpointCriteria {
 	return func(currentSolid, previousCheckpoint, currentCheckpoint milestone.Index) bool {
 		// the previous checkpoint can be over the current solid one, as advancements
 		// move the checkpoint window above the solid milestone

--- a/pkg/protocol/warpsync/warpsync_test.go
+++ b/pkg/protocol/warpsync/warpsync_test.go
@@ -8,14 +8,14 @@ import (
 )
 
 func TestAdvanceAtEightyPercentReached(t *testing.T) {
-	f := warpsync.AdvanceAtPercentReached(0.8)
+	f := warpsync.AdvanceAtPercentageReached(0.8)
 	assert.False(t, f(0, 0, 10))
 	assert.False(t, f(5, 0, 10))
 	assert.True(t, f(8, 0, 10))
 }
 
 func TestWarpSync_Update(t *testing.T) {
-	ws := warpsync.New(50, warpsync.AdvanceAtPercentReached(0.8))
+	ws := warpsync.New(50, warpsync.AdvanceAtPercentageReached(0.8))
 
 	ws.UpdateCurrent(100)
 	ws.UpdateTarget(1000)

--- a/pkg/protocol/warpsync/warpsync_test.go
+++ b/pkg/protocol/warpsync/warpsync_test.go
@@ -1,0 +1,45 @@
+package warpsync_test
+
+import (
+	"testing"
+
+	"github.com/gohornet/hornet/pkg/protocol/warpsync"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAdvanceAtEightyPercentReached(t *testing.T) {
+	f := warpsync.AdvanceAtPercentReached(0.8)
+	assert.False(t, f(0, 0, 10))
+	assert.False(t, f(5, 0, 10))
+	assert.True(t, f(8, 0, 10))
+}
+
+func TestWarpSync_Update(t *testing.T) {
+	ws := warpsync.New(50, warpsync.AdvanceAtPercentReached(0.8))
+
+	ws.UpdateCurrent(100)
+	ws.UpdateTarget(1000)
+
+	assert.EqualValues(t, ws.CurrentSolidMs, 100)
+	assert.EqualValues(t, ws.CurrentCheckpoint, 150)
+
+	// nothing should change besides current solid
+	ws.UpdateCurrent(120)
+	assert.EqualValues(t, ws.CurrentSolidMs, 120)
+	assert.EqualValues(t, ws.CurrentCheckpoint, 150)
+
+	// nothing should change besides current solid
+	ws.UpdateCurrent(130)
+	assert.EqualValues(t, ws.CurrentSolidMs, 130)
+	assert.EqualValues(t, ws.CurrentCheckpoint, 150)
+
+	// 80% reached
+	ws.UpdateCurrent(140)
+	assert.EqualValues(t, ws.CurrentSolidMs, 140)
+	assert.EqualValues(t, ws.CurrentCheckpoint, 200)
+
+	// shouldn't update anything - simulates non synced peer sending heartbeat
+	ws.UpdateTarget(850)
+	assert.EqualValues(t, ws.CurrentSolidMs, 140)
+	assert.EqualValues(t, ws.CurrentCheckpoint, 200)
+}

--- a/plugins/gossip/broadcast.go
+++ b/plugins/gossip/broadcast.go
@@ -37,7 +37,7 @@ func BroadcastLatestMilestoneRequest() {
 
 // BroadcastMilestoneRequests broadcasts up to N requests for milestones nearest to the current solid milestone index
 // to every connected peer who supports STING.
-func BroadcastMilestoneRequests(rangeToRequest int, from ...milestone.Index) {
+func BroadcastMilestoneRequests(rangeToRequest int, onExistingMilestoneInRange func(index milestone.Index), from ...milestone.Index) {
 
 	// make sure we only request what we don't have
 	startingPoint := tangle.GetSolidMilestoneIndex()
@@ -50,6 +50,10 @@ func BroadcastMilestoneRequests(rangeToRequest int, from ...milestone.Index) {
 		// only request if we do not have the milestone
 		if !tangle.ContainsMilestone(toReq) {
 			msIndexes = append(msIndexes, toReq)
+			continue
+		}
+		if onExistingMilestoneInRange != nil {
+			onExistingMilestoneInRange(toReq)
 		}
 	}
 

--- a/plugins/gossip/request.go
+++ b/plugins/gossip/request.go
@@ -3,6 +3,7 @@ package gossip
 import (
 	"time"
 
+	"github.com/gohornet/hornet/pkg/dag"
 	"github.com/gohornet/hornet/pkg/protocol/helpers"
 	"github.com/iotaledger/hive.go/daemon"
 	"github.com/iotaledger/iota.go/trinary"
@@ -156,4 +157,38 @@ func RequestMilestoneApprovees(cachedMsBndl *tangle.CachedBundle) bool {
 	}
 
 	return enqueued
+}
+
+// MemoizedRequestMissingMilestoneApprovees returns a function which traverses the approvees
+// of a given milestone and requests each missing approvee. As a special property, invocations
+// of the yielded function share the same 'already traversed' set to circumvent requesting
+// the same approvees multiple times.
+func MemoizedRequestMissingMilestoneApprovees(preventDiscard ...bool) func(ms milestone.Index) {
+	traversed := map[trinary.Hash]struct{}{}
+	return func(ms milestone.Index) {
+		cachedMsBundle := tangle.GetMilestoneOrNil(ms) // bundle +1
+		if cachedMsBundle == nil {
+			log.Panicf("milestone %d wasn't found", ms)
+		}
+
+		msBundleTailHash := cachedMsBundle.GetBundle().GetTailHash()
+		cachedMsBundle.Release(true) // bundle -1
+
+		dag.TraverseApprovees(msBundleTailHash,
+			// predicate
+			func(cachedTx *tangle.CachedTransaction) bool { // tx +1
+				defer cachedTx.Release() // tx -1
+				_, previouslyTraversed := traversed[cachedTx.GetTransaction().GetHash()]
+				return !cachedTx.GetMetadata().IsSolid() && !previouslyTraversed
+			},
+			// consumer
+			func(cachedTx *tangle.CachedTransaction) { // tx +1
+				defer cachedTx.Release() // tx -1
+				traversed[cachedTx.GetTransaction().GetHash()] = struct{}{}
+			},
+			// called on missing approvees
+			func(approveeHash trinary.Hash) {
+				Request(approveeHash, ms, preventDiscard...)
+			})
+	}
 }

--- a/plugins/gossip/request.go
+++ b/plugins/gossip/request.go
@@ -177,18 +177,18 @@ func MemoizedRequestMissingMilestoneApprovees(preventDiscard ...bool) func(ms mi
 		dag.TraverseApprovees(msBundleTailHash,
 			// predicate
 			func(cachedTx *tangle.CachedTransaction) bool { // tx +1
-				defer cachedTx.Release() // tx -1
+				defer cachedTx.Release(true) // tx -1
 				_, previouslyTraversed := traversed[cachedTx.GetTransaction().GetHash()]
 				return !cachedTx.GetMetadata().IsSolid() && !previouslyTraversed
 			},
 			// consumer
 			func(cachedTx *tangle.CachedTransaction) { // tx +1
-				defer cachedTx.Release() // tx -1
+				defer cachedTx.Release(true) // tx -1
 				traversed[cachedTx.GetTransaction().GetHash()] = struct{}{}
 			},
 			// called on missing approvees
 			func(approveeHash trinary.Hash) {
 				Request(approveeHash, ms, preventDiscard...)
-			})
+			}, true)
 	}
 }

--- a/plugins/tangle/milestones.go
+++ b/plugins/tangle/milestones.go
@@ -33,7 +33,7 @@ func processValidMilestone(cachedBndl *tangle.CachedBundle) {
 	milestoneSolidifierWorkerPool.TrySubmit(bundleMsIndex, false)
 
 	if bundleMsIndex > solidMsIndex {
-		log.Infof("Valid milestone detected! Index: %d, Hash: %v", bundleMsIndex, cachedBndl.GetBundle().GetMilestoneHash())
+		//log.Infof("Valid milestone detected! Index: %d, Hash: %v", bundleMsIndex, cachedBndl.GetBundle().GetMilestoneHash())
 
 		// request trunk and branch
 		gossip.RequestMilestoneApprovees(cachedBndl.Retain()) // bundle pass +1

--- a/plugins/tangle/milestones.go
+++ b/plugins/tangle/milestones.go
@@ -33,7 +33,7 @@ func processValidMilestone(cachedBndl *tangle.CachedBundle) {
 	milestoneSolidifierWorkerPool.TrySubmit(bundleMsIndex, false)
 
 	if bundleMsIndex > solidMsIndex {
-		//log.Infof("Valid milestone detected! Index: %d, Hash: %v", bundleMsIndex, cachedBndl.GetBundle().GetMilestoneHash())
+		log.Infof("Valid milestone detected! Index: %d, Hash: %v", bundleMsIndex, cachedBndl.GetBundle().GetMilestoneHash())
 
 		// request trunk and branch
 		gossip.RequestMilestoneApprovees(cachedBndl.Retain()) // bundle pass +1

--- a/plugins/tangle/plugin.go
+++ b/plugins/tangle/plugin.go
@@ -79,6 +79,8 @@ func configure(plugin *node.Plugin) {
 	}))
 
 	configureTangleProcessor(plugin)
+
+	gossip.RequestBackpressureSignal = IsReceiveTxWorkerPoolBusy
 }
 
 func run(plugin *node.Plugin) {

--- a/plugins/tangle/tangle_processor.go
+++ b/plugins/tangle/tangle_processor.go
@@ -116,18 +116,18 @@ func processIncomingTx(incomingTx *hornet.Transaction, request *rqueue.Request, 
 	// Release shouldn't be forced, to cache the latest transactions
 	defer cachedTx.Release(!isNodeSyncedWithThreshold) // tx -1
 
-	// since we only add the approvees if there was a source request, we only
-	// request them for transactions which should be part of milestone cones
-	if request != nil {
-		// add this newly received transaction's approvees to the request queue
-		gossip.RequestApprovees(cachedTx.Retain(), request.MilestoneIndex, true)
-	}
-
 	if !alreadyAdded {
 		metrics.SharedServerMetrics.NewTransactions.Inc()
 
 		if p != nil {
 			p.Metrics.NewTransactions.Inc()
+		}
+
+		// since we only add the approvees if there was a source request, we only
+		// request them for transactions which should be part of milestone cones
+		if request != nil {
+			// add this newly received transaction's approvees to the request queue
+			gossip.RequestApprovees(cachedTx.Retain(), request.MilestoneIndex, true)
 		}
 
 		solidMilestoneIndex := tangle.GetSolidMilestoneIndex()

--- a/plugins/tangle/tangle_processor.go
+++ b/plugins/tangle/tangle_processor.go
@@ -101,6 +101,10 @@ func runTangleProcessor(_ *node.Plugin) {
 	}, shutdown.PriorityMilestoneSolidifier)
 }
 
+func IsReceiveTxWorkerPoolBusy() bool {
+	return receiveTxWorkerPool.GetPendingQueueSize() > (receiveTxQueueSize / 2)
+}
+
 func processIncomingTx(incomingTx *hornet.Transaction, request *rqueue.Request, p *peer.Peer) {
 
 	latestMilestoneIndex := tangle.GetLatestMilestoneIndex()

--- a/plugins/tangle/tangle_processor.go
+++ b/plugins/tangle/tangle_processor.go
@@ -112,18 +112,18 @@ func processIncomingTx(incomingTx *hornet.Transaction, request *rqueue.Request, 
 	// Release shouldn't be forced, to cache the latest transactions
 	defer cachedTx.Release(!isNodeSyncedWithThreshold) // tx -1
 
+	// since we only add the approvees if there was a source request, we only
+	// request them for transactions which should be part of milestone cones
+	if request != nil {
+		// add this newly received transaction's approvees to the request queue
+		gossip.RequestApprovees(cachedTx.Retain(), request.MilestoneIndex, true)
+	}
+
 	if !alreadyAdded {
 		metrics.SharedServerMetrics.NewTransactions.Inc()
 
 		if p != nil {
 			p.Metrics.NewTransactions.Inc()
-		}
-
-		// since we only add the approvees if there was a source request, we only
-		// request them for transactions which should be part of milestone cones
-		if request != nil {
-			// add this newly received transaction's approvees to the request queue
-			gossip.RequestApprovees(cachedTx.Retain(), request.MilestoneIndex, true)
 		}
 
 		solidMilestoneIndex := tangle.GetSolidMilestoneIndex()

--- a/plugins/warpsync/plugin.go
+++ b/plugins/warpsync/plugin.go
@@ -51,7 +51,7 @@ func configure(plugin *node.Plugin) {
 		gossip.RequestQueue().Filter(func(r *rqueue.Request) bool {
 			return r.MilestoneIndex <= nextCheckpoint
 		})
-		gossip.BroadcastMilestoneRequests(int(advRange), oldCheckpoint)
+		gossip.BroadcastMilestoneRequests(int(advRange), gossip.MemoizedRequestMissingMilestoneApprovees(), oldCheckpoint)
 	}))
 
 	warpSync.Events.Start.Attach(events.NewClosure(func(targetMsIndex milestone.Index, nextCheckpoint milestone.Index, advRange int32) {
@@ -59,7 +59,7 @@ func configure(plugin *node.Plugin) {
 		gossip.RequestQueue().Filter(func(r *rqueue.Request) bool {
 			return r.MilestoneIndex <= nextCheckpoint
 		})
-		gossip.BroadcastMilestoneRequests(int(advRange))
+		gossip.BroadcastMilestoneRequests(int(advRange), gossip.MemoizedRequestMissingMilestoneApprovees())
 	}))
 
 	warpSync.Events.Done.Attach(events.NewClosure(func(deltaSynced int, took time.Duration) {


### PR DESCRIPTION
* Request missing approvees of milestones when doing milestone range requests
* Advance checkpoints everytime the solid milestone reaches over the previous checkpoint
* Reduce advancement range to 25 milestones
* Adds backpressure signal to request-background worker when the tangle processor is over half of its capacity. Note, if the tangle processor is reaching its capacity, the request queue will automatically have *a lot* of requests pending.
* Refactors warpsync.go package

During testing it was quite evident, that sync speed is now even more improved due to the checkpoint window shifting, but tests should only be concluded with the same static neighbors as speed is very much dependent on the peers:
* On mainnet a synchronization range of ~1000 milestones takes under a minute.
* On Comnet a synchronization range of ~1000 milestones would take around 8 minutes (note that Comnet runs at a steady ~80-150 TPS sometimes), but it depends heavily on the peers.