### PR TITLE
Manually trigger solidifer from warp sync start

### DIFF
--- a/plugins/gossip/broadcast.go
+++ b/plugins/gossip/broadcast.go
@@ -36,8 +36,9 @@ func BroadcastLatestMilestoneRequest() {
 }
 
 // BroadcastMilestoneRequests broadcasts up to N requests for milestones nearest to the current solid milestone index
-// to every connected peer who supports STING.
-func BroadcastMilestoneRequests(rangeToRequest int, onExistingMilestoneInRange func(index milestone.Index), from ...milestone.Index) {
+// to every connected peer who supports STING. Returns the number of milestones requested.
+func BroadcastMilestoneRequests(rangeToRequest int, onExistingMilestoneInRange func(index milestone.Index), from ...milestone.Index) int {
+	var requested int
 
 	// make sure we only request what we don't have
 	startingPoint := tangle.GetSolidMilestoneIndex()
@@ -49,6 +50,7 @@ func BroadcastMilestoneRequests(rangeToRequest int, onExistingMilestoneInRange f
 		toReq := startingPoint + milestone.Index(i)
 		// only request if we do not have the milestone
 		if !tangle.ContainsMilestone(toReq) {
+			requested++
 			msIndexes = append(msIndexes, toReq)
 			continue
 		}
@@ -58,7 +60,7 @@ func BroadcastMilestoneRequests(rangeToRequest int, onExistingMilestoneInRange f
 	}
 
 	if len(msIndexes) == 0 {
-		return
+		return requested
 	}
 
 	// send each ms request to a random peer who supports the message
@@ -74,4 +76,5 @@ func BroadcastMilestoneRequests(rangeToRequest int, onExistingMilestoneInRange f
 			return true
 		})
 	}
+	return requested
 }

--- a/plugins/tangle/solidifier.go
+++ b/plugins/tangle/solidifier.go
@@ -47,6 +47,11 @@ type ConfirmedMilestoneMetric struct {
 	TimeSinceLastMilestone float64         `json:"time_since_last_ms"`
 }
 
+// TriggerSolidifier can be used to manually trigger the solidifier from other plugins.
+func TriggerSolidifier() {
+	milestoneSolidifierWorkerPool.TrySubmit(milestone.Index(0), true)
+}
+
 func markTransactionAsSolid(cachedTx *tangle.CachedTransaction) {
 	// Construct the complete bundle if the tail got solid (before setting solid flag => otherwise not threadsafe)
 	if cachedTx.GetTransaction().IsTail() {


### PR DESCRIPTION
If at the start of a warp sync  some milestones were not requested because they already existed, we trigger the solidifier **once** manually to kick start warp synchronization. This ensures that if the node was solidifying a checkpoint range it will continue warp syncing up on restart.