### PR TITLE
feat: Add autopeering entry node health API

### DIFF
--- a/main.go
+++ b/main.go
@@ -37,6 +37,7 @@ func main() {
 		profiling.PLUGIN,
 		database.PLUGIN,
 		autopeering.PLUGIN,
+		webapi.PLUGIN,
 	}
 
 	if !config.NodeConfig.GetBool(config.CfgNetAutopeeringRunAsEntryNode) {
@@ -48,7 +49,6 @@ func main() {
 			tipselection.PLUGIN,
 			metrics.PLUGIN,
 			snapshot.PLUGIN,
-			webapi.PLUGIN,
 			dashboard.PLUGIN,
 			zeromq.PLUGIN,
 			mqtt.PLUGIN,

--- a/plugins/webapi/api.go
+++ b/plugins/webapi/api.go
@@ -73,25 +73,25 @@ func webAPIRoute() {
 // health check
 func restAPIRoute() {
 
-	if !config.NodeConfig.GetBool(config.CfgNetAutopeeringRunAsEntryNode) {
-		// node mode
-		// GET /healthz
-		api.GET(healthzRoute, func(c *gin.Context) {
-			if !isNodeHealthy() {
-				c.Status(http.StatusServiceUnavailable)
-				return
-			}
-
-			c.Status(http.StatusOK)
-		})
-	} else {
+	if config.NodeConfig.GetBool(config.CfgNetAutopeeringRunAsEntryNode) {
 		// autopeering entry node mode
 		// GET /healthz
 		api.GET(healthzRoute, func(c *gin.Context) {
 			c.Status(http.StatusOK)
 		})
+		return
 	}
 
+	// node mode
+	// GET /healthz
+	api.GET(healthzRoute, func(c *gin.Context) {
+		if !isNodeHealthy() {
+			c.Status(http.StatusServiceUnavailable)
+			return
+		}
+
+		c.Status(http.StatusOK)
+	})
 }
 
 func isNodeHealthy() bool {

--- a/plugins/webapi/api.go
+++ b/plugins/webapi/api.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 
+	"github.com/gohornet/hornet/pkg/config"
 	"github.com/gohornet/hornet/pkg/model/tangle"
 	"github.com/gohornet/hornet/plugins/peering"
 )
@@ -72,15 +73,25 @@ func webAPIRoute() {
 // health check
 func restAPIRoute() {
 
-	// GET /healthz
-	api.GET(healthzRoute, func(c *gin.Context) {
-		if !isNodeHealthy() {
-			c.Status(http.StatusServiceUnavailable)
-			return
-		}
+	if !config.NodeConfig.GetBool(config.CfgNetAutopeeringRunAsEntryNode) {
+		// node mode
+		// GET /healthz
+		api.GET(healthzRoute, func(c *gin.Context) {
+			if !isNodeHealthy() {
+				c.Status(http.StatusServiceUnavailable)
+				return
+			}
 
-		c.Status(http.StatusOK)
-	})
+			c.Status(http.StatusOK)
+		})
+	} else {
+		// autopeering entry node mode
+		// GET /healthz
+		api.GET(healthzRoute, func(c *gin.Context) {
+			c.Status(http.StatusOK)
+		})
+	}
+
 }
 
 func isNodeHealthy() bool {

--- a/plugins/webapi/plugin.go
+++ b/plugins/webapi/plugin.go
@@ -148,8 +148,10 @@ func configure(plugin *node.Plugin) {
 		})
 	}
 
-	// WebAPI route
-	webAPIRoute()
+	if !config.NodeConfig.GetBool(config.CfgNetAutopeeringRunAsEntryNode) {
+		// WebAPI route
+		webAPIRoute()
+	}
 
 	// Handle route with auth
 	if !exclHealthCheckFromAuth {
@@ -166,13 +168,15 @@ func configure(plugin *node.Plugin) {
 func run(_ *node.Plugin) {
 	log.Info("Starting WebAPI server ...")
 
-	// Check for features
-	if _, ok := permitedEndpoints["attachtotangle"]; ok {
-		features = append(features, "RemotePOW")
-	}
+	if !config.NodeConfig.GetBool(config.CfgNetAutopeeringRunAsEntryNode) {
+		// Check for features
+		if _, ok := permitedEndpoints["attachtotangle"]; ok {
+			features = append(features, "RemotePOW")
+		}
 
-	if tangle.GetSnapshotInfo().IsSpentAddressesEnabled() {
-		features = append(features, "WereAddressesSpentFrom")
+		if tangle.GetSnapshotInfo().IsSpentAddressesEnabled() {
+			features = append(features, "WereAddressesSpentFrom")
+		}
 	}
 
 	daemon.BackgroundWorker("WebAPI server", func(shutdownSignal <-chan struct{}) {


### PR DESCRIPTION
Adds a health check to the autopeering entry node mode.
This simplifies the monitoring of an autopeering entry node.