### PR TITLE
feat: Improve DEB package

### DIFF
--- a/nfpm/deb_files/postinst
+++ b/nfpm/deb_files/postinst
@@ -6,11 +6,11 @@ configure)
 	if type systemctl >/dev/null 2>/dev/null; then
 		systemctl daemon-reload
 
-		if ! systemctl is-enabled -q hornet.service; then
-			systemctl enable hornet.service >/dev/null 2>/dev/null
+		# Only restart if the HORNET service is enabled
+		if systemctl is-enabled -q hornet.service; then
+			systemctl --no-block restart hornet.service
 		fi
 
-		systemctl --no-block restart hornet.service
 	fi
 	;;
 

--- a/nfpm/deb_files/preinst
+++ b/nfpm/deb_files/preinst
@@ -13,7 +13,9 @@ install)
     ;;
 
 upgrade)
+    echo "Stopping HORNET. This may take a while..."
     systemctl stop hornet.service
+    echo "HORNET stopped, start update..."
     ;;
 
 abort-upgrade) ;;


### PR DESCRIPTION
- Only restart HORNET if the system service was enabled before (e.g. to let the user modify the config.json after an initial installation)
- Output a message that the HORNET service is stopped (which may take longer depending on the hardware)