### PR TITLE
Fix wereAddressesSpentFrom with empty addresses

### DIFF
--- a/plugins/webapi/spent.go
+++ b/plugins/webapi/spent.go
@@ -39,12 +39,13 @@ func wereAddressesSpentFrom(i interface{}, c *gin.Context, _ <-chan struct{}) {
 		return
 	}
 
-	if len(query.Addresses) == 0 {
+	if query.Addresses == nil {
 		e.Error = "No addresses provided"
 		c.JSON(http.StatusBadRequest, e)
+		return
 	}
 
-	result := WereAddressesSpentFromReturn{}
+	result := WereAddressesSpentFromReturn{States: []bool{}}
 
 	for _, addr := range query.Addresses {
 		if err := address.ValidAddress(addr); err != nil {


### PR DESCRIPTION
# Description

Requesting `wereAddressesSpentFrom` with an empty `addresses` array leads to three issue:
- return a "No addresses provided" error, but an empty array should be valid (!= missing `addresses` parameter)
- return both the error and a result because a `return` statement is missing
- return `states` equals to `null` instead of `[]`

This PR fixes these issues.

### Actual result
```json
{
  "error": "No addresses provided"
}
{
  "states": null,
  "duration": 0
}
```

### Expected result
```json
{
  "states": [],
  "duration": 0
}
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

# How Has This Been Tested?

Basic requests with or without addresses.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have tested my code extensively
- [x] I have selected the `develop` branch as the target branch
