### PR TITLE
add hornet helper scripts

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -143,6 +143,9 @@ nfpms:
       - rpm
     bindir: /usr/bin
     files:
+      "nfpm/shared_files/hornet_clean_export": "/usr/bin/hornet_clean_export"
+      "nfpm/shared_files/hornet_dashboard": "/usr/bin/hornet_dashboard"
+      "nfpm/shared_files/hornet_clean_db": "/usr/bin/hornet_clean_db"
       "nfpm/shared_files/hornet.service": "/lib/systemd/system/hornet.service"
     config_files:
       "config.json": "/var/lib/hornet/config.json"

--- a/nfpm/deb_files/postinst
+++ b/nfpm/deb_files/postinst
@@ -22,4 +22,8 @@ abort-upgrade | abort-remove | abort-deconfigure) ;;
 	;;
 esac
 
+chmod +x /usr/bin/hornet_clean_export
+chmod +x /usr/bin/hornet_clean_db
+chmod +x /usr/bin/hornet_dashboard
+
 exit 0

--- a/nfpm/rpm_files/postinst
+++ b/nfpm/rpm_files/postinst
@@ -16,4 +16,8 @@ EOF
     chmod 700 /var/lib/hornet
     chown hornet:hornet /var/lib/hornet
 
+    chmod +x /usr/bin/hornet_clean_export
+    chmod +x /usr/bin/hornet_clean_db
+    chmod +x /usr/bin/hornet_dashboard
+
 fi

--- a/nfpm/shared_files/hornet_clean_db
+++ b/nfpm/shared_files/hornet_clean_db
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+
+import os
+import shutil
+import sys
+import errno
+from optparse import OptionParser
+
+parser = OptionParser()
+parser.add_option("-m", "--mainnet",
+                  action="store_false", dest="comnet", default=True,
+                  help="Enable MainNet Dashboard (default).")
+parser.add_option("-c", "--comnet",
+                  action="store_true", dest="comnet", default=False,
+                  help="Enable ComNet Dashboard.")
+(options, args) = parser.parse_args()
+
+if os.geteuid() != 0:
+    print("You need root permissions to do this!")
+    sys.exit(1)
+
+status = os.system('systemctl is-active --quiet hornet') # will return 0 for active else inactive.
+if not status:
+    try:
+        print("Stopping hornet.service.")
+        os.system("systemctl stop hornet")
+    except:
+        print("Error while stopping hornet systemd service.")
+
+if options.comnet:
+    db_kind = "comnet"
+else:
+    db_kind = "mainnet"
+
+db_path = "/var/lib/hornet/" + db_kind + "db"
+
+exists = os.path.isdir(db_path)
+
+if not exists:
+    print("Hornet " + db_kind+ "db is already clean. Nothing to do.")
+else:
+    try:
+        shutil.rmtree(db_path)
+        print("Hornet " + db_kind + "db has been cleaned.")
+    except IOError as e:
+        errorn, strerror = e.args
+        if errorn == errno.EACCES:
+            print("You need root permissions to do this!")
+            sys.exit(1)
+
+if not status: # service was running, restart it
+    print("Starting hornet.service.")
+    os.system('systemctl start hornet')

--- a/nfpm/shared_files/hornet_clean_export
+++ b/nfpm/shared_files/hornet_clean_export
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+
+import os
+import shutil
+import sys
+import errno
+
+if os.geteuid() != 0:
+    print("You need root permissions to do this!")
+    sys.exit(1)
+
+status = os.system('systemctl is-active --quiet hornet') # will return 0 for active else inactive.
+if not status:
+    try:
+        print("Stopping hornet.service.")
+        os.system("systemctl stop hornet")
+    except:
+        print("Error while stopping hornet systemd service.")
+
+ss_path = "/var/lib/hornet/export.bin"
+
+exists = os.path.isdir(ss_path)
+
+if not exists:
+    print("Hornet export.bin is already clean. Nothing to do.")
+else:
+    try:
+        shutil.rmtree(ss_path)
+        print("Hornet export.bin has been cleaned.")
+    except IOError as e:
+        errorn, strerror = e.args
+        if errorn == errno.EACCES:
+            print("You need root permissions to do this!")
+            sys.exit(1)
+
+if not status: # service was running, restart it
+    print("Starting hornet.service.")
+    os.system('systemctl start hornet')

--- a/nfpm/shared_files/hornet_dashboard
+++ b/nfpm/shared_files/hornet_dashboard
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+
+import os
+import json
+import errno
+import sys
+import subprocess
+from optparse import OptionParser
+
+parser = OptionParser()
+parser.add_option("--off", action="store_false", dest="on", default=False, help="Disable Hornet Dashboard.")
+parser.add_option("--on", action="store_true", dest="on", default=True, help="Enable Hornet Dashboard (default).")
+parser.add_option("-m", "--mainnet", action="store_false", dest="comnet", default=True, help="MainNet (default).")
+parser.add_option("-c", "--comnet", action="store_true", dest="comnet", default=False, help="ComNet.")
+
+(options, args) = parser.parse_args()
+
+if os.geteuid() != 0:
+    print("You need root permissions to do this!")
+    sys.exit(1)
+
+status = os.system('systemctl is-active --quiet hornet') # will return 0 for active else inactive.
+if not status:
+    try:
+        print("Stopping hornet.service.")
+        os.system("systemctl stop hornet")
+    except:
+        print("Error while stopping hornet systemd service.")
+
+if options.comnet:
+    config_file = "/var/lib/hornet/config_comnet.json"
+else:
+    config_file = "/var/lib/hornet/config.json"
+
+lines = ""
+with open(config_file, "r") as f:
+    for line in f.readlines():
+        lines += line.replace("\n", "")
+
+config_json = json.loads(lines)
+
+if options.on:
+    config_json["dashboard"]["bindAddress"] = "0.0.0.0:8081"
+else:
+    config_json["dashboard"]["bindAddress"] = "localhost:8081"
+
+try:
+    f = open(config_file, "w")
+    f.write(json.dumps(config_json, indent=1))
+    f.close()
+
+    if options.comnet:
+        if options.on:
+            print("Hornet ComNet Dashboard was enabled.")
+        else:
+            print("Hornet ComNet Dashboard was disabled.")
+    else:
+        if options.on:
+            print("Hornet MainNet Dashboard was enabled.")
+        else:
+            print("Hornet MainNet Dashboard was disabled.")
+
+except IOError as e:
+    errorn, strerror = e.args
+    if errorn == errno.EACCES:
+        print("You need root permissions to do this!")
+        sys.exit(1)
+
+if not status: # service was running, restart it
+    print("Restarting hornet.service.\nIf Hornet is loading snapshot, it might take a while before the Dashboard is available. Please be patient.\nIf you note systemd errors, stop the service, run hornet_clean_db and hornet_clean_export and restart the service.")
+    os.system('systemctl start hornet')
+


### PR DESCRIPTION
add the following helper scripts:
 - `hornet_dashboard`
 - `hornet_clean_db`
 - `hornet_clean_export`

they're installed in `/usr/bin` and can be used as regular shell commands.