### PR TITLE
feat: Make graph explorer link configurable

### DIFF
--- a/config.json
+++ b/config.json
@@ -130,7 +130,9 @@
       "uri": ""
     },
     "bindAddress": "localhost:8083",
-    "networkName": "meets HORNET"
+    "networkName": "meets HORNET",
+    "explorerTxLink": "http://localhost:8081/explorer/tx/",
+    "explorerBundleLink": "http://localhost:8081/explorer/bundle/"
   },
   "monitor": {
     "tangleMonitorPath": "tanglemonitor/frontend",

--- a/pkg/config/graph_config.go
+++ b/pkg/config/graph_config.go
@@ -11,6 +11,10 @@ const (
 	CfgGraphBindAddress = "graph.bindAddress"
 	// the name of the network to be shown on the visualizer site
 	CfgGraphNetworkName = "graph.networkName"
+	// the explorer transaction link
+	CfgGraphExplorerTxLink = "graph.explorerTxLink"
+	// the explorer bundle link
+	CfgGraphExplorerBundleLink = "graph.explorerBundleLink"
 )
 
 func init() {
@@ -19,4 +23,6 @@ func init() {
 	NodeConfig.SetDefault(CfgGraphDomain, "")
 	NodeConfig.SetDefault(CfgGraphBindAddress, "localhost:8083")
 	NodeConfig.SetDefault(CfgGraphNetworkName, "meets HORNET")
+	NodeConfig.SetDefault(CfgGraphExplorerTxLink, "http://localhost:8081/explorer/tx/")
+	NodeConfig.SetDefault(CfgGraphExplorerBundleLink, "http://localhost:8081/explorer/bundle/")
 }

--- a/plugins/graph/html.go
+++ b/plugins/graph/html.go
@@ -24,13 +24,16 @@ const index string = `
     <div class="graph" id="graph"></div>
 
     <script type="application/javascript">
+
       const tg = TangleGlumb(document.getElementById("graph"), {
         CIRCLE_SIZE: 60,
         PIN_OLD_NODES: false,
         STATIC_FRONT: false,
         DARK_MODE: true,
         COLOR_BY_NUMBER: true,
-        REMOVE_OLD_NODES: true
+        REMOVE_OLD_NODES: true,
+        EXPLORER_TX_LINK: "{{.ExplorerTxLink}}",
+        EXPLORER_BUNDLE_LINK: "{{.ExplorerBundleLink}}"
       });
 
       var WebSocketURIConfig = "{{.URI}}";

--- a/plugins/graph/plugin.go
+++ b/plugins/graph/plugin.go
@@ -49,14 +49,18 @@ var (
 
 // PageData struct for html template
 type PageData struct {
-	URI string
+	URI                string
+	ExplorerTxLink     string
+	ExplorerBundleLink string
 }
 
 func wrapHandler(h http.Handler) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/" || r.URL.Path == "/index.html" || r.URL.Path == "/index.htm" {
 			data := PageData{
-				URI: config.NodeConfig.GetString(config.CfgGraphWebSocketURI),
+				URI:                config.NodeConfig.GetString(config.CfgGraphWebSocketURI),
+				ExplorerTxLink:     config.NodeConfig.GetString(config.CfgGraphExplorerTxLink),
+				ExplorerBundleLink: config.NodeConfig.GetString(config.CfgGraphExplorerBundleLink),
 			}
 			tmpl, _ := template.New("graph").Parse(index)
 			tmpl.Execute(w, data)


### PR DESCRIPTION
You need to pull the latest IOTAtangle (https://github.com/glumb/IOTAtangle/commit/8c8fb62c905ee11aae742ed9d1e42e88b8195753) to use this new feature.