### PR TITLE
Refactor pruning

### DIFF
--- a/pkg/model/tangle/health_db.go
+++ b/pkg/model/tangle/health_db.go
@@ -7,7 +7,7 @@ import (
 )
 
 const (
-	DbVersion = 8
+	DbVersion = 9
 )
 
 var (

--- a/pkg/model/tangle/unconfirmed_tx_storage.go
+++ b/pkg/model/tangle/unconfirmed_tx_storage.go
@@ -66,7 +66,7 @@ func configureUnconfirmedTxStorage() {
 }
 
 // GetUnconfirmedTxHashBytes returns all hashes of unconfirmed transactions for that milestone.
-func GetUnconfirmedTxHashBytes(msIndex milestone.Index, forceRelease bool, maxFind ...int) [][]byte {
+func GetUnconfirmedTxHashBytes(msIndex milestone.Index, forceRelease bool) [][]byte {
 
 	var unconfirmedTxHashBytes [][]byte
 

--- a/pkg/model/tangle/unconfirmed_tx_storage.go
+++ b/pkg/model/tangle/unconfirmed_tx_storage.go
@@ -65,32 +65,20 @@ func configureUnconfirmedTxStorage() {
 	)
 }
 
-// unconfirmedTx +-0
-func GetUnconfirmedTxHashes(msIndex milestone.Index, forceRelease bool, maxFind ...int) []trinary.Hash {
-	var unconfirmedTxHashes []trinary.Hash
+// GetUnconfirmedTxHashBytes returns all hashes of unconfirmed transactions for that milestone.
+func GetUnconfirmedTxHashBytes(msIndex milestone.Index, forceRelease bool, maxFind ...int) [][]byte {
+
+	var unconfirmedTxHashBytes [][]byte
 
 	key := make([]byte, 4)
 	binary.LittleEndian.PutUint32(key, uint32(msIndex))
 
-	i := 0
-	unconfirmedTxStorage.ForEach(func(key []byte, cachedObject objectstorage.CachedObject) bool {
-		i++
-		if (len(maxFind) > 0) && (i > maxFind[0]) {
-			cachedObject.Release(true) // unconfirmedTx -1
-			return false
-		}
-
-		if !cachedObject.Exists() {
-			cachedObject.Release(true) // unconfirmedTx -1
-			return true
-		}
-
-		unconfirmedTxHashes = append(unconfirmedTxHashes, (&CachedUnconfirmedTx{CachedObject: cachedObject}).GetUnconfirmedTx().GetTransactionHash())
-		cachedObject.Release(forceRelease) // unconfirmedTx -1
+	unconfirmedTxStorage.ForEachKeyOnly(func(key []byte) bool {
+		unconfirmedTxHashBytes = append(unconfirmedTxHashBytes, key[4:])
 		return true
-	}, key)
+	}, true, key)
 
-	return unconfirmedTxHashes
+	return unconfirmedTxHashBytes
 }
 
 // unconfirmedTx +1
@@ -110,19 +98,7 @@ func StoreUnconfirmedTx(msIndex milestone.Index, txHash trinary.Hash) *CachedUnc
 	return &CachedUnconfirmedTx{CachedObject: cachedObj}
 }
 
-// unconfirmedTx +-0
-func DeleteUnconfirmedTxs(msIndex milestone.Index) {
-	key := make([]byte, 4)
-	binary.LittleEndian.PutUint32(key, uint32(msIndex))
-
-	unconfirmedTxStorage.ForEach(func(key []byte, cachedObject objectstorage.CachedObject) bool {
-		unconfirmedTxStorage.Delete(key)
-		cachedObject.Release(true)
-		return true
-	}, key)
-}
-
-// DeleteUnconfirmedTxsFromBadger deletes unconfirmed transactions without accessing the cache.
+// DeleteUnconfirmedTxsFromBadger deletes unconfirmed transaction entries without accessing the cache.
 func DeleteUnconfirmedTxsFromBadger(msIndex milestone.Index) {
 
 	msIndexBytes := make([]byte, 4)

--- a/plugins/snapshot/global_snapshot.go
+++ b/plugins/snapshot/global_snapshot.go
@@ -125,7 +125,7 @@ func loadSnapshotFromTextfiles(filePathLedger string, filePathsSpent []string, s
 	}
 
 	spentAddrEnabled := (spentAddressesSum != 0) || ((snapshotIndex == 0) && config.NodeConfig.GetBool(config.CfgSpentAddressesEnabled))
-	tangle.SetSnapshotMilestone(config.NodeConfig.GetString(config.CfgCoordinatorAddress)[:81], consts.NullHashTrytes, snapshotIndex, snapshotIndex, 0, spentAddrEnabled)
+	tangle.SetSnapshotMilestone(config.NodeConfig.GetString(config.CfgCoordinatorAddress)[:81], consts.NullHashTrytes, snapshotIndex, snapshotIndex, snapshotIndex, 0, spentAddrEnabled)
 	tangle.SetLatestSeenMilestoneIndexFromSnapshot(snapshotIndex)
 
 	// set the solid milestone index based on the snapshot milestone

--- a/plugins/snapshot/local_snapshot.go
+++ b/plugins/snapshot/local_snapshot.go
@@ -674,7 +674,7 @@ func LoadSnapshotFromFile(filePath string) error {
 		return err
 	}
 
-	tangle.SetSnapshotMilestone(config.NodeConfig.GetString(config.CfgCoordinatorAddress)[:81], msHash[:81], milestone.Index(msIndex), milestone.Index(msIndex), msTimestamp, spentAddrsCount != 0 && config.NodeConfig.GetBool("spentAddresses.enabled"))
+	tangle.SetSnapshotMilestone(config.NodeConfig.GetString(config.CfgCoordinatorAddress)[:81], msHash[:81], milestone.Index(msIndex), milestone.Index(msIndex), milestone.Index(msIndex), msTimestamp, spentAddrsCount != 0 && config.NodeConfig.GetBool("spentAddresses.enabled"))
 	tangle.SolidEntryPointsAdd(msHash[:81], milestone.Index(msIndex))
 	tangle.SetLatestSeenMilestoneIndexFromSnapshot(milestone.Index(msIndex))
 

--- a/plugins/snapshot/local_snapshot.go
+++ b/plugins/snapshot/local_snapshot.go
@@ -455,15 +455,6 @@ func createLocalSnapshotWithoutLocking(targetIndex milestone.Index, filePath str
 			return errors.Wrap(ErrCritical, err.Error())
 		}
 
-		tangle.WriteLockSolidEntryPoints()
-		defer tangle.WriteUnlockSolidEntryPoints()
-
-		tangle.ResetSolidEntryPoints()
-		for solidEntryPoint, index := range newSolidEntryPoints {
-			tangle.SolidEntryPointsAdd(solidEntryPoint, index)
-		}
-		tangle.StoreSolidEntryPoints()
-
 		tangle.SetSnapshotInfo(&tangle.SnapshotInfo{
 			CoordinatorAddress: snapshotInfo.CoordinatorAddress,
 			Hash:               cachedTargetMs.GetBundle().GetMilestoneHash(),

--- a/plugins/snapshot/pruning.go
+++ b/plugins/snapshot/pruning.go
@@ -121,11 +121,6 @@ func pruneDatabase(targetIndex milestone.Index, abortSignal <-chan struct{}) err
 		return ErrNotEnoughHistory
 	}
 
-	if snapshotInfo.PruningIndex < SolidEntryPointCheckThresholdPast+AdditionalPruningThreshold+1 {
-		// Not enough history
-		return ErrNotEnoughHistory
-	}
-
 	targetIndexMax := snapshotInfo.SnapshotIndex - SolidEntryPointCheckThresholdPast - AdditionalPruningThreshold - 1
 	if targetIndex > targetIndexMax {
 		targetIndex = targetIndexMax


### PR DESCRIPTION
BREAKING DB CHANGE

- Add EntryPointIndex to snapshot info
- Prune in "AdditionalPruningThreshold" steps.
- Delete directly in badger (Txs should be so old, no caching needed)
- Recalculate solid entry points for the end of the history, not the snapshot