### PR TITLE
Feature: Adding "sn_trytes" in zmq

### DIFF
--- a/config.json
+++ b/config.json
@@ -106,7 +106,7 @@
     "alias": "",
     "showAliasInGetNodeInfo": false,
     "disablePlugins": [],
-    "enablePlugins": ["zmq"]
+    "enablePlugins": []
   },
   "logger": {
     "level": "info",
@@ -150,7 +150,7 @@
     "config": "mqtt_config.json"
   },
   "zmq": {
-    "bindAddress": "0.0.0.0:5556"
+    "bindAddress": "localhost:5556"
   },
   "profiling": {
     "bindAddress": "localhost:6060"

--- a/config.json
+++ b/config.json
@@ -106,7 +106,7 @@
     "alias": "",
     "showAliasInGetNodeInfo": false,
     "disablePlugins": [],
-    "enablePlugins": []
+    "enablePlugins": ["zmq"]
   },
   "logger": {
     "level": "info",
@@ -150,7 +150,7 @@
     "config": "mqtt_config.json"
   },
   "zmq": {
-    "bindAddress": "localhost:5556"
+    "bindAddress": "0.0.0.0:5556"
   },
   "profiling": {
     "bindAddress": "localhost:6060"

--- a/plugins/zmq/events.go
+++ b/plugins/zmq/events.go
@@ -42,7 +42,6 @@ func onConfirmedTx(cachedTx *tangle.CachedTransaction, msIndex milestone.Index, 
 		if err != nil {
 			log.Error(err.Error())
 		}
-                
 		err = publishConfTxTrytes(tx.Tx, msIndex)
                 if err != nil {
                         log.Error(err.Error())

--- a/plugins/zmq/events.go
+++ b/plugins/zmq/events.go
@@ -179,6 +179,7 @@ func publishConfTxTrytes(iotaTx *transaction.Transaction, msIndex milestone.Inde
 
         return publisher.Send(topicSNTrytes, messages)
 }
+
 // Publish transaction trytes of an tx that has recently been added to the ledger
 func publishTxTrytes(iotaTx *transaction.Transaction) error {
 

--- a/plugins/zmq/events.go
+++ b/plugins/zmq/events.go
@@ -165,14 +165,15 @@ func publishConfTx(iotaTx *transaction.Transaction, msIndex milestone.Index) err
 	return publisher.Send(topicSN, messages)
 }
 
+// Publish transaction trytes of an tx that has recently confirmed
 func publishConfTxTrytes(iotaTx *transaction.Transaction, msIndex milestone.Index) error {
         trytes, err := transaction.TransactionToTrytes(iotaTx)
         if err != nil {
                 return err
         }
         messages := []string{
-                trytes,
-                iotaTx.Hash,
+                trytes,                                // Transaction Trytes
+                iotaTx.Hash,                           // Transaction hash
                 strconv.FormatInt(int64(msIndex), 10), // Index of the milestone that confirmed the transaction
         }
 

--- a/plugins/zmq/events.go
+++ b/plugins/zmq/events.go
@@ -42,7 +42,11 @@ func onConfirmedTx(cachedTx *tangle.CachedTransaction, msIndex milestone.Index, 
 		if err != nil {
 			log.Error(err.Error())
 		}
-
+                
+		err = publishConfTxTrytes(tx.Tx, msIndex)
+                if err != nil {
+                        log.Error(err.Error())
+                }
 		addresses := GetAddressTopics()
 		for _, addr := range addresses {
 			if strings.EqualFold(tx.Tx.Address, addr) {
@@ -161,6 +165,19 @@ func publishConfTx(iotaTx *transaction.Transaction, msIndex milestone.Index) err
 	return publisher.Send(topicSN, messages)
 }
 
+func publishConfTxTrytes(iotaTx *transaction.Transaction, msIndex milestone.Index) error {
+        trytes, err := transaction.TransactionToTrytes(iotaTx)
+        if err != nil {
+                return err
+        }
+        messages := []string{
+                trytes,
+                iotaTx.Hash,
+                strconv.FormatInt(int64(msIndex), 10), // Index of the milestone that confirmed the transaction
+        }
+
+        return publisher.Send(topicSNTrytes, messages)
+}
 // Publish transaction trytes of an tx that has recently been added to the ledger
 func publishTxTrytes(iotaTx *transaction.Transaction) error {
 

--- a/plugins/zmq/topics.go
+++ b/plugins/zmq/topics.go
@@ -16,6 +16,7 @@ const (
 	topicLM           = "lm"
 	topicLSM          = "lsm"
 	topicSN           = "sn"
+        topicSNTrytes     = "sn_trytes"
 	topicTxTrytes     = "trytes"
 	topicTX           = "tx"
 	topicSpentAddress = "spent_address"

--- a/plugins/zmq/topics.go
+++ b/plugins/zmq/topics.go
@@ -9,6 +9,7 @@ import (
 )
 
 // Topic names
+
 const (
 	topicLMI          = "lmi"
 	topicLMSI         = "lmsi"

--- a/plugins/zmq/topics.go
+++ b/plugins/zmq/topics.go
@@ -17,7 +17,7 @@ const (
 	topicLM           = "lm"
 	topicLSM          = "lsm"
 	topicSN           = "sn"
-        topicSNTrytes     = "sn_trytes"
+	topicSNTrytes     = "sn_trytes"
 	topicTxTrytes     = "trytes"
 	topicTX           = "tx"
 	topicSpentAddress = "spent_address"

--- a/plugins/zmq/topics.go
+++ b/plugins/zmq/topics.go
@@ -9,7 +9,6 @@ import (
 )
 
 // Topic names
-
 const (
 	topicLMI          = "lmi"
 	topicLMSI         = "lmsi"


### PR DESCRIPTION
Publishes confirmed transactions trytes to zmq as already requested in the following IRI feature request: 
https://github.com/iotaledger/iri/pull/1551