### PR TITLE
Fix visualizer, snapshot download, boltdb

### DIFF
--- a/pkg/model/tangle/tangle.go
+++ b/pkg/model/tangle/tangle.go
@@ -28,6 +28,7 @@ var (
 func boltDB(directory string, filename string) *bbolt.DB {
 	opts := &bbolt.Options{
 		FreelistType: bbolt.FreelistMapType,
+		NoSync:       true,
 	}
 	db, err := bolt.CreateDB(directory, filename, opts)
 	if err != nil {

--- a/plugins/dashboard/visualizer.go
+++ b/plugins/dashboard/visualizer.go
@@ -82,7 +82,7 @@ func runVisualizer() {
 						IsMilestone: false,
 						IsTip:       false,
 					},
-				}, true)
+				}, false)
 		})
 	})
 
@@ -98,7 +98,7 @@ func runVisualizer() {
 					Data: &metainfo{
 						ID: tx.GetHash()[:VisualizerIdLength],
 					},
-				}, true)
+				}, false)
 		})
 	})
 
@@ -115,7 +115,7 @@ func runVisualizer() {
 						Data: &metainfo{
 							ID: txHash[:VisualizerIdLength],
 						},
-					}, true)
+					}, false)
 			}
 		})
 	})
@@ -126,14 +126,14 @@ func runVisualizer() {
 				return
 			}
 
-			visualizerWorkerPool.Submit(
+			visualizerWorkerPool.TrySubmit(
 				&msg{
 					Type: MsgTypeConfirmedInfo,
 					Data: &confirmationinfo{
 						ID:          bndl.GetTailHash()[:VisualizerIdLength],
 						ExcludedIDs: make([]string, 0),
 					},
-				}, true)
+				}, false)
 		})
 	})
 

--- a/plugins/snapshot/download.go
+++ b/plugins/snapshot/download.go
@@ -20,6 +20,11 @@ type WriteCounter struct {
 func (wc *WriteCounter) Write(p []byte) (int, error) {
 	n := len(p)
 	wc.Total += uint64(n)
+
+	if daemon.IsStopped() {
+		return n, ErrSnapshotDownloadWasAborted
+	}
+
 	wc.PrintProgress()
 	return n, nil
 }

--- a/plugins/snapshot/download.go
+++ b/plugins/snapshot/download.go
@@ -17,6 +17,7 @@ import (
 type WriteCounter struct {
 	Expected         uint64
 	Total            uint64
+	Last             uint64
 	LastProgressTime time.Time
 }
 
@@ -36,7 +37,10 @@ func (wc *WriteCounter) PrintProgress() {
 	if time.Since(wc.LastProgressTime) < 1*time.Second {
 		return
 	}
+
+	bytesPerSecond := uint64(float64(wc.Total-wc.Last) / time.Since(wc.LastProgressTime).Seconds())
 	wc.LastProgressTime = time.Now()
+	wc.Last = wc.Total
 
 	// Clear the line by using a character return to go back to the start and remove
 	// the remaining characters by filling it with spaces
@@ -44,7 +48,7 @@ func (wc *WriteCounter) PrintProgress() {
 
 	// Return again and print current status of download
 	// We use the humanize package to print the bytes in a meaningful way (e.g. 10 MB)
-	fmt.Printf("\rDownloading... %s/%s", humanize.Bytes(wc.Total), humanize.Bytes(wc.Expected))
+	fmt.Printf("\rDownloading... %s/%s (%s/s)", humanize.Bytes(wc.Total), humanize.Bytes(wc.Expected), humanize.Bytes(bytesPerSecond))
 }
 
 func downloadSnapshotFile(filepath string, url string) error {

--- a/plugins/snapshot/plugin.go
+++ b/plugins/snapshot/plugin.go
@@ -36,6 +36,7 @@ var (
 
 	ErrNoSnapshotSpecified             = errors.New("no snapshot file was specified in the config")
 	ErrNoSnapshotDownloadURL           = fmt.Errorf("no download URL given for local snapshot under config option '%s", config.CfgLocalSnapshotsDownloadURL)
+	ErrSnapshotDownloadWasAborted      = errors.New("snapshot download was aborted")
 	ErrSnapshotImportWasAborted        = errors.New("snapshot import was aborted")
 	ErrSnapshotImportFailed            = errors.New("snapshot import failed")
 	ErrSnapshotCreationWasAborted      = errors.New("operation was aborted")


### PR DESCRIPTION
This PR changes:
- changes boltdb setting to not wait for fsync
- confirmation in the visualizer (walk the past cone of milestone tail txs)
- remove blocking websockets in visualizer
- snapshot download can be canceled
- snapshot download now shows download speed 
- progress report of snapshot download is only printed every second to reduce logs