### PR TITLE
Speed up revalidation and pruning.

### DIFF
--- a/pkg/model/tangle/address_storage.go
+++ b/pkg/model/tangle/address_storage.go
@@ -137,17 +137,6 @@ func DeleteAddress(address trinary.Hash, txHash trinary.Hash) {
 	addressesStorage.Delete(databaseKeyPrefixForAddressTransaction(address, txHash, true))
 }
 
-// DeleteAddressFromStore deletes the address from the persistence layer without accessing the cache.
-func DeleteAddressFromStore(address trinary.Hash, txHashBytes []byte) {
-
-	prefix := databaseKeyPrefixForAddress(address)
-	addressesStorage.DeleteEntryFromStore(append(prefix, txHashBytes...))
-
-	var isValueByte byte = hornet.AddressTxIsValue
-	valuePrefix := append(prefix, isValueByte)
-	addressesStorage.DeleteEntryFromStore(append(valuePrefix, txHashBytes...))
-}
-
 func ShutdownAddressStorage() {
 	addressesStorage.Shutdown()
 }

--- a/pkg/model/tangle/approvers_storage.go
+++ b/pkg/model/tangle/approvers_storage.go
@@ -116,11 +116,6 @@ func DeleteApprover(transactionHash trinary.Hash, approverHash trinary.Hash) {
 	approversStorage.Delete(approver.ObjectStorageKey())
 }
 
-// DeleteApproverFromStore deletes the approver from the persistence layer without accessing the cache.
-func DeleteApproverFromStore(transactionHash trinary.Hash, approverHashBytes []byte) {
-	approversStorage.DeleteEntryFromStore(append(trinary.MustTrytesToBytes(transactionHash)[:49], approverHashBytes...))
-}
-
 // approvers +-0
 func DeleteApprovers(transactionHash trinary.Hash) {
 
@@ -131,18 +126,6 @@ func DeleteApprovers(transactionHash trinary.Hash) {
 		cachedObject.Release(true)
 		return true
 	}, txHash)
-}
-
-// DeleteApproversFromStore deletes the approvers from the persistence layer without accessing the cache.
-func DeleteApproversFromStore(txHashBytes []byte) {
-
-	var approversToDelete [][]byte
-	approversStorage.ForEachKeyOnly(func(key []byte) bool {
-		approversToDelete = append(approversToDelete, key)
-		return true
-	}, true, txHashBytes)
-
-	approversStorage.DeleteEntriesFromStore(approversToDelete)
 }
 
 func ShutdownApproversStorage() {

--- a/pkg/model/tangle/bundle_storage.go
+++ b/pkg/model/tangle/bundle_storage.go
@@ -200,11 +200,6 @@ func DeleteBundle(tailTxHash trinary.Hash) {
 	bundleStorage.Delete(databaseKeyForBundle(tailTxHash))
 }
 
-// DeleteBundleFromStore deletes the bundle from the persistence layer without accessing the cache.
-func DeleteBundleFromStore(tailTxHashBytes []byte) {
-	bundleStorage.DeleteEntryFromStore(tailTxHashBytes)
-}
-
 func ShutdownBundleStorage() {
 	bundleStorage.Shutdown()
 }

--- a/pkg/model/tangle/bundle_transaction_storage.go
+++ b/pkg/model/tangle/bundle_transaction_storage.go
@@ -233,11 +233,6 @@ func DeleteBundleTransaction(bundleHash trinary.Hash, transactionHash trinary.Ha
 	bundleTransactionsStorage.Delete(databaseKeyForBundleTransaction(bundleHash, transactionHash, isTail))
 }
 
-// DeleteBundleTransactionFromStore deletes the bundle transaction from the persistence layer without accessing the cache.
-func DeleteBundleTransactionFromStore(bundleHash trinary.Hash, txHashBytes []byte, isTail bool) {
-	bundleTransactionsStorage.DeleteEntryFromStore(databaseKeyForBundleTransactionTxHashBytes(bundleHash, txHashBytes, isTail))
-}
-
 func ShutdownBundleTransactionsStorage() {
 	bundleTransactionsStorage.Shutdown()
 }

--- a/pkg/model/tangle/milestones_storage.go
+++ b/pkg/model/tangle/milestones_storage.go
@@ -178,10 +178,6 @@ func DeleteMilestone(milestoneIndex milestone.Index) {
 	milestoneStorage.Delete(databaseKeyForMilestoneIndex(milestoneIndex))
 }
 
-func DeleteMilestoneFromStore(milestoneIndex milestone.Index) {
-	milestoneStorage.DeleteEntryFromStore(databaseKeyForMilestoneIndex(milestoneIndex))
-}
-
 func ShutdownMilestoneStorage() {
 	milestoneStorage.Shutdown()
 }

--- a/pkg/model/tangle/tags_storage.go
+++ b/pkg/model/tangle/tags_storage.go
@@ -111,11 +111,6 @@ func DeleteTag(txTag trinary.Trytes, txHash trinary.Hash) {
 	tagsStorage.Delete(append(trinary.MustTrytesToBytes(trinary.MustPad(txTag, 27))[:17], trinary.MustTrytesToBytes(txHash)[:49]...))
 }
 
-// DeleteTagFromStore deletes the tag from the persistence layer without accessing the cache.
-func DeleteTagFromStore(txTag trinary.Trytes, txHashBytes []byte) {
-	tagsStorage.DeleteEntryFromStore(append(trinary.MustTrytesToBytes(trinary.MustPad(txTag, 27))[:17], txHashBytes...))
-}
-
 // tag +-0
 func DeleteTags(txTag trinary.Trytes) {
 

--- a/pkg/model/tangle/transaction_storage.go
+++ b/pkg/model/tangle/transaction_storage.go
@@ -236,13 +236,13 @@ func ForEachTransaction(consumer TransactionConsumer) {
 	})
 }
 
-// ForEachTransactionHashBytes loops over all transaction hashes (binary representation) in the database.
+// ForEachTransactionHashBytes loops over all transaction hashes (binary representation).
 // Transaction that only exist in the cache are ignored.
 func ForEachTransactionHashBytes(consumer TransactionHashBytesConsumer) {
 	txStorage.ForEachKeyOnly(func(txHashBytes []byte) bool {
 		consumer(txHashBytes)
 		return true
-	}, true)
+	}, false)
 }
 
 // tx +-0

--- a/pkg/model/tangle/transaction_storage.go
+++ b/pkg/model/tangle/transaction_storage.go
@@ -252,12 +252,6 @@ func DeleteTransaction(transactionHash trinary.Hash) {
 	metadataStorage.Delete(txHash)
 }
 
-// DeleteTransactionFromStore deletes the transaction and metadata from the persistence layer without accessing the cache.
-func DeleteTransactionFromStore(txHashBytes []byte) {
-	txStorage.DeleteEntryFromStore(txHashBytes)
-	metadataStorage.DeleteEntryFromStore(txHashBytes)
-}
-
 func ShutdownTransactionStorage() {
 	txStorage.Shutdown()
 	metadataStorage.Shutdown()

--- a/pkg/model/tangle/unconfirmed_tx_storage.go
+++ b/pkg/model/tangle/unconfirmed_tx_storage.go
@@ -75,7 +75,7 @@ func GetUnconfirmedTxHashBytes(msIndex milestone.Index, forceRelease bool) [][]b
 	unconfirmedTxStorage.ForEachKeyOnly(func(key []byte) bool {
 		unconfirmedTxHashBytes = append(unconfirmedTxHashBytes, key[4:])
 		return true
-	}, true, key)
+	}, false, key)
 
 	return unconfirmedTxHashBytes
 }
@@ -106,7 +106,7 @@ func DeleteUnconfirmedTxs(msIndex milestone.Index) {
 	unconfirmedTxStorage.ForEachKeyOnly(func(key []byte) bool {
 		unconfirmedTxStorage.Delete(key)
 		return true
-	}, true, msIndexBytes)
+	}, false, msIndexBytes)
 }
 
 func ShutdownUnconfirmedTxsStorage() {

--- a/pkg/model/tangle/unconfirmed_tx_storage.go
+++ b/pkg/model/tangle/unconfirmed_tx_storage.go
@@ -97,19 +97,16 @@ func StoreUnconfirmedTx(msIndex milestone.Index, txHash trinary.Hash) *CachedUnc
 	return &CachedUnconfirmedTx{CachedObject: cachedObj}
 }
 
-// DeleteUnconfirmedTxsFromStore deletes unconfirmed transaction entries without accessing the cache.
-func DeleteUnconfirmedTxsFromStore(msIndex milestone.Index) {
+// DeleteUnconfirmedTxs deletes unconfirmed transaction entries.
+func DeleteUnconfirmedTxs(msIndex milestone.Index) {
 
 	msIndexBytes := make([]byte, 4)
 	binary.LittleEndian.PutUint32(msIndexBytes, uint32(msIndex))
 
-	var txHashes [][]byte
 	unconfirmedTxStorage.ForEachKeyOnly(func(key []byte) bool {
-		txHashes = append(txHashes, key)
+		unconfirmedTxStorage.Delete(key)
 		return true
 	}, true, msIndexBytes)
-
-	unconfirmedTxStorage.DeleteEntriesFromStore(txHashes)
 }
 
 func ShutdownUnconfirmedTxsStorage() {

--- a/plugins/snapshot/pruning.go
+++ b/plugins/snapshot/pruning.go
@@ -49,7 +49,7 @@ func pruneUnconfirmedTransactions(targetIndex milestone.Index) int {
 	}
 
 	txCount := pruneTransactions(txsBytesToCheckMap)
-	tangle.DeleteUnconfirmedTxsFromStore(targetIndex)
+	tangle.DeleteUnconfirmedTxs(targetIndex)
 
 	return txCount
 }
@@ -62,7 +62,7 @@ func pruneMilestone(milestoneIndex milestone.Index) {
 		log.Error(err)
 	}
 
-	tangle.DeleteMilestoneFromStore(milestoneIndex)
+	tangle.DeleteMilestone(milestoneIndex)
 }
 
 // pruneTransactions prunes the approvers, bundles, bundle txs, addresses, tags and transaction metadata from the database
@@ -97,14 +97,16 @@ func pruneTransactions(txsBytesToCheckMap map[string]struct{}) int {
 			continue
 		}
 
-		// Delete the reference in the approvees
-		tangle.DeleteApproverFromStore(storedTx.GetTrunk(), txHashBytesToDelete)
-		tangle.DeleteApproverFromStore(storedTx.GetBranch(), txHashBytesToDelete)
+		txHash := trinary.MustBytesToTrytes(txHashBytesToDelete, 81)
 
-		tangle.DeleteTagFromStore(storedTx.Tx.Tag, txHashBytesToDelete)
-		tangle.DeleteAddressFromStore(storedTx.Tx.Address, txHashBytesToDelete)
-		tangle.DeleteApproversFromStore(txHashBytesToDelete)
-		tangle.DeleteTransactionFromStore(txHashBytesToDelete)
+		// Delete the reference in the approvees
+		tangle.DeleteApprover(storedTx.GetTrunk(), txHash)
+		tangle.DeleteApprover(storedTx.GetBranch(), txHash)
+
+		tangle.DeleteTag(storedTx.Tx.Tag, txHash)
+		tangle.DeleteAddress(storedTx.Tx.Address, txHash)
+		tangle.DeleteApprovers(txHash)
+		tangle.DeleteTransaction(txHash)
 	}
 
 	return len(txsBytesToDeleteMap)


### PR DESCRIPTION
We do not access the storage layer directly anymore.
This way we can use the batched writes of the object storage to speed up storage layer access.