### PR TITLE
0.4.0-rc10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.4.0-rc10] - 21.05.2020
+
+### Added
+
+    - Show download speed
+
+### Changed
+
+    - Only print download progress every second
+    - Use NoSync option to speed up boltdb
+    - Confirm txs in visualizer by walking the past cone of milestone tail
+
+### Fixed
+
+    - Pruning of unconfirmed tx not verifying the milestoneIndex
+    - Responsive Dashboard design
+    - Do not block on visualizer websocket messages
+    - Speed up revalidation and pruning
+    - Abort snapshot download on daemon shutdown
+    - Limit the search for transactions of a given address
+    - Search for bundles was not possible in the dashboard
+
 ## [0.4.0-rc9] - 19.05.2020
 
 **Breaking change:**<br>

--- a/pkg/model/tangle/address_storage.go
+++ b/pkg/model/tangle/address_storage.go
@@ -79,7 +79,7 @@ func configureAddressesStorage(store kvstore.KVStore) {
 }
 
 // address +-0
-func GetTransactionHashesForAddress(address trinary.Hash, valueOnly bool, forceRelease bool, maxFind ...int) (hashes []trinary.Hash, count int) {
+func GetTransactionHashesForAddress(address trinary.Hash, valueOnly bool, forceRelease bool, maxFind ...int) []trinary.Hash {
 
 	searchPrefix := databaseKeyPrefixForAddress(address)
 	if valueOnly {
@@ -91,17 +91,14 @@ func GetTransactionHashesForAddress(address trinary.Hash, valueOnly bool, forceR
 
 	i := 0
 	addressesStorage.ForEach(func(key []byte, cachedObject objectstorage.CachedObject) bool {
+		i++
+		if (len(maxFind) > 0) && (i > maxFind[0]) {
+			cachedObject.Release(true) // address -1
+			return false
+		}
 
 		if !cachedObject.Exists() {
 			cachedObject.Release(true) // address -1
-			return true
-		}
-
-		i++
-
-		if (len(maxFind) > 0) && (i > maxFind[0]) {
-			cachedObject.Release(true) // address -1
-			// Keep iterating to count all transactions
 			return true
 		}
 
@@ -110,7 +107,7 @@ func GetTransactionHashesForAddress(address trinary.Hash, valueOnly bool, forceR
 		return true
 	}, searchPrefix)
 
-	return transactionHashes, i
+	return transactionHashes
 }
 
 // address +1

--- a/plugins/cli/plugin.go
+++ b/plugins/cli/plugin.go
@@ -21,7 +21,7 @@ import (
 
 var (
 	// AppVersion version number
-	AppVersion          = "0.4.0-rc9"
+	AppVersion          = "0.4.0-rc10"
 	LatestGithubVersion = AppVersion
 
 	// AppName app code name

--- a/plugins/dashboard/explorer_routes.go
+++ b/plugins/dashboard/explorer_routes.go
@@ -149,7 +149,6 @@ type ExplorerTag struct {
 type ExplorerAddress struct {
 	Balance      uint64        `json:"balance"`
 	Txs          []*ExplorerTx `json:"txs"`
-	Count        int           `json:"count"`
 	Spent        bool          `json:"spent"`
 	SpentEnabled bool          `json:"spent_enabled"`
 }
@@ -383,7 +382,7 @@ func findAddress(hash Hash, valueOnly bool) (*ExplorerAddress, error) {
 		return nil, errors.Wrapf(ErrInvalidParameter, "hash invalid: %s", hash)
 	}
 
-	txHashes, count := tangle.GetTransactionHashesForAddress(hash, valueOnly, true, MaxTransactionsForAddressResults)
+	txHashes := tangle.GetTransactionHashesForAddress(hash, valueOnly, true, MaxTransactionsForAddressResults)
 
 	txs := make([]*ExplorerTx, 0, len(txHashes))
 	if len(txHashes) != 0 {
@@ -407,5 +406,5 @@ func findAddress(hash Hash, valueOnly bool) (*ExplorerAddress, error) {
 		return nil, err
 	}
 
-	return &ExplorerAddress{Balance: balance, Txs: txs, Count: count, Spent: tangle.WasAddressSpentFrom(hash), SpentEnabled: tangle.GetSnapshotInfo().IsSpentAddressesEnabled()}, nil
+	return &ExplorerAddress{Balance: balance, Txs: txs, Spent: tangle.WasAddressSpentFrom(hash), SpentEnabled: tangle.GetSnapshotInfo().IsSpentAddressesEnabled()}, nil
 }

--- a/plugins/dashboard/explorer_routes.go
+++ b/plugins/dashboard/explorer_routes.go
@@ -269,7 +269,7 @@ func setupExplorerRoutes(routeGroup *echo.Group) {
 		go func() {
 			defer wg.Done()
 			addr, err := findAddress(search, false)
-			if err == nil {
+			if err == nil && len(addr.Txs) > 0 {
 				result.Address = addr
 			}
 		}()

--- a/plugins/dashboard/frontend/src/app/components/ConfirmedMilestoneChart.tsx
+++ b/plugins/dashboard/frontend/src/app/components/ConfirmedMilestoneChart.tsx
@@ -18,8 +18,6 @@ const lineChartOptions = Object.assign({
                 autoSkip: true,
                 maxTicksLimit: 30,
                 fontSize: 8,
-                minRotation: 0,
-                maxRotation: 0,
             },
             gridLines: {
                 display: false
@@ -56,8 +54,6 @@ const percentLineChartOpts = Object.assign({}, {
                 autoSkip: true,
                 maxTicksLimit: 30,
                 fontSize: 8,
-                minRotation: 0,
-                maxRotation: 0,
             },
             gridLines: {
                 display: false
@@ -96,8 +92,6 @@ const timeChartOptions = Object.assign({
                 autoSkip: true,
                 maxTicksLimit: 30,
                 fontSize: 8,
-                minRotation: 0,
-                maxRotation: 0,
             },
             gridLines: {
                 display: false
@@ -143,15 +137,15 @@ export default class ConfirmedMilestoneChart extends React.Component<Props, any>
                     </If>
                     <div className={style.hornetChartSmall}>
                         <Bar data={this.props.nodeStore.confirmedMilestonesSeries}
-                            options={lineChartOptions}/>
+                             options={lineChartOptions}/>
                     </div>
                     <div className={style.hornetChartSmall}>
                         <Bar data={this.props.nodeStore.confirmedMilestonesConfirmationSeries}
-                            options={percentLineChartOpts}/>
+                             options={percentLineChartOpts}/>
                     </div>
                     <div className={style.hornetChartSmall}>
                         <Bar data={this.props.nodeStore.confirmedMilestonesTimeSeries}
-                            options={timeChartOptions}/>
+                             options={timeChartOptions}/>
                     </div>
                 </Card.Body>
             </Card>

--- a/plugins/dashboard/frontend/src/app/components/ExplorerAddressResult.tsx
+++ b/plugins/dashboard/frontend/src/app/components/ExplorerAddressResult.tsx
@@ -121,7 +121,7 @@ export class ExplorerAddressQueryResult extends React.Component<Props, State> {
                                 Balance: <IOTAValue>{addr.balance}</IOTAValue>
                             </p>
                             {
-                                addr.txs !== null && addr.count > addr.txs.length &&
+                                addr.txs !== null && addr.txs.length === 100 &&
                                 <Alert variant={"warning"}>
                                     Max. {addr.txs.length} transactions are shown.
                                 </Alert>
@@ -137,7 +137,7 @@ export class ExplorerAddressQueryResult extends React.Component<Props, State> {
                                                 <Badge
                                                     pill
                                                     variant={"secondary"}
-                                                    className={"align-middle"}>{addr.count}</Badge>
+                                                    className={"align-middle"}>{addr.txs.length}</Badge>
                                             </div>
                                             <FormCheck id={"check-value-only"}
                                                        label={"Only show value Tx"}

--- a/plugins/dashboard/frontend/src/app/components/MemChart.tsx
+++ b/plugins/dashboard/frontend/src/app/components/MemChart.tsx
@@ -6,6 +6,7 @@ import {Line} from "react-chartjs-2";
 import {defaultChartOptions} from "app/misc/Chart";
 import * as prettysize from 'prettysize';
 import * as style from '../../assets/main.css';
+
 interface Props {
     nodeStore?: NodeStore;
 }
@@ -18,8 +19,6 @@ const lineChartOptions = Object.assign({
                 autoSkip: true,
                 maxTicksLimit: 8,
                 fontSize: 8,
-                minRotation: 0,
-                maxRotation: 0,
             },
             showXLabels: 10,
             gridLines: {
@@ -59,7 +58,7 @@ export default class MemChart extends React.Component<Props, any> {
                 <Card.Body>
                     <Card.Title>
                         Memory Usage{' '}
-                        {prettysize(mem.heap_inuse + (mem.heap_idle - mem.heap_released) + mem.m_span_inuse + mem.m_cache_inuse+mem.stack_sys)}
+                        {prettysize(mem.heap_inuse + (mem.heap_idle - mem.heap_released) + mem.m_span_inuse + mem.m_cache_inuse + mem.stack_sys)}
                     </Card.Title>
                     <small>
                         GC Cycles: {mem.num_gc} (Last Cycle: {mem.last_pause_gc / 1000000}ms) - {' '}
@@ -68,7 +67,7 @@ export default class MemChart extends React.Component<Props, any> {
                         Retained: {prettysize(mem.heap_idle - mem.heap_released)}]
                     </small>
                     <div className={style.hornetChart}>
-                        <Line data={this.props.nodeStore.memSeries} options={lineChartOptions} />
+                        <Line data={this.props.nodeStore.memSeries} options={lineChartOptions}/>
                     </div>
                 </Card.Body>
             </Card>

--- a/plugins/dashboard/frontend/src/app/components/Misc.tsx
+++ b/plugins/dashboard/frontend/src/app/components/Misc.tsx
@@ -83,8 +83,6 @@ const cacheLineChartOpts = Object.assign({}, {
                 autoSkip: true,
                 maxTicksLimit: 8,
                 fontSize: 8,
-                minRotation: 0,
-                maxRotation: 0,
             },
             showXLabels: 10,
             gridLines: {
@@ -169,11 +167,11 @@ export class Misc extends React.Component<Props, any> {
                                 <Card.Title>Tip-Selection Performance</Card.Title>
                                 <div className={style.hornetChart}>
                                     <Line data={this.props.nodeStore.tipSelSeries}
-                                      options={lineChartOptions}/>
+                                          options={lineChartOptions}/>
                                 </div>
                                 <div className={style.hornetChart}>
                                     <Line data={this.props.nodeStore.tipSelCacheSeries}
-                                      options={cacheLineChartOpts}/>
+                                          options={cacheLineChartOpts}/>
                                 </div>
                             </Card.Body>
                         </Card>
@@ -186,7 +184,7 @@ export class Misc extends React.Component<Props, any> {
                                 <Card.Title>Request Queue</Card.Title>
                                 <div className={style.hornetChart}>
                                     <Line data={this.props.nodeStore.reqQSizeSeries}
-                                        options={lineChartOptions}/>
+                                          options={lineChartOptions}/>
                                 </div>
                             </Card.Body>
                         </Card>
@@ -199,7 +197,7 @@ export class Misc extends React.Component<Props, any> {
                                 <Card.Title>Server Metrics</Card.Title>
                                 <div className={style.hornetChart}>
                                     <Line data={this.props.nodeStore.serverMetricsSeries}
-                                        options={lineChartOptions}/>
+                                          options={lineChartOptions}/>
                                 </div>
                             </Card.Body>
                         </Card>
@@ -217,7 +215,7 @@ export class Misc extends React.Component<Props, any> {
                                 </small>
                                 <div className={style.hornetChart}>
                                     <Line data={this.props.nodeStore.cacheMetricsSeries}
-                                        options={reqLineChartOptions}/>
+                                          options={reqLineChartOptions}/>
                                 </div>
                             </Card.Body>
                         </Card>
@@ -230,7 +228,7 @@ export class Misc extends React.Component<Props, any> {
                                 <Card.Title>Requests</Card.Title>
                                 <div className={style.hornetChart}>
                                     <Line data={this.props.nodeStore.stingReqs}
-                                        options={reqLineChartOptions}/>
+                                          options={reqLineChartOptions}/>
                                 </div>
                             </Card.Body>
                         </Card>
@@ -258,7 +256,7 @@ export class Misc extends React.Component<Props, any> {
                                 </If>
                                 <div className={style.hornetChart}>
                                     <Line data={this.props.nodeStore.dbSizeSeries}
-                                        options={dbSizeLineChartOpts}/>
+                                          options={dbSizeLineChartOpts}/>
                                 </div>
                             </Card.Body>
                         </Card>

--- a/plugins/dashboard/frontend/src/app/components/Neighbor.tsx
+++ b/plugins/dashboard/frontend/src/app/components/Neighbor.tsx
@@ -25,8 +25,6 @@ const lineChartOptions = Object.assign({
                 autoSkip: true,
                 maxTicksLimit: 8,
                 fontSize: 8,
-                minRotation: 0,
-                maxRotation: 0,
             },
             showXLabels: 10,
             gridLines: {

--- a/plugins/dashboard/frontend/src/app/components/TPSChart.tsx
+++ b/plugins/dashboard/frontend/src/app/components/TPSChart.tsx
@@ -5,6 +5,7 @@ import {inject, observer} from "mobx-react";
 import {Line} from "react-chartjs-2";
 import {defaultChartOptions} from "app/misc/Chart";
 import * as style from '../../assets/main.css';
+
 interface Props {
     nodeStore?: NodeStore;
 }
@@ -16,8 +17,6 @@ const lineChartOptions = Object.assign({
                 autoSkip: true,
                 maxTicksLimit: 8,
                 fontSize: 8,
-                minRotation: 0,
-                maxRotation: 0,
             },
             gridLines: {
                 display: false

--- a/plugins/dashboard/frontend/src/app/components/TipSelChart.tsx
+++ b/plugins/dashboard/frontend/src/app/components/TipSelChart.tsx
@@ -18,8 +18,6 @@ const lineChartOptions = Object.assign({
                 autoSkip: true,
                 maxTicksLimit: 8,
                 fontSize: 8,
-                minRotation: 0,
-                maxRotation: 0,
             },
             showXLabels: 10,
             gridLines: {
@@ -46,8 +44,6 @@ const cacheLineChartOpts = Object.assign({}, {
                 autoSkip: true,
                 maxTicksLimit: 8,
                 fontSize: 8,
-                minRotation: 0,
-                maxRotation: 0,
             },
             showXLabels: 10,
             gridLines: {

--- a/plugins/dashboard/frontend/src/app/stores/ExplorerStore.tsx
+++ b/plugins/dashboard/frontend/src/app/stores/ExplorerStore.tsx
@@ -41,7 +41,6 @@ export class Transaction {
 class AddressResult {
     balance: number;
     txs: Array<Transaction>;
-    count: number;
     spent: boolean;
     spent_enabled: boolean;
 }

--- a/plugins/webapi/transactions.go
+++ b/plugins/webapi/transactions.go
@@ -109,8 +109,7 @@ func findTransactions(i interface{}, c *gin.Context, _ <-chan struct{}) {
 			addr = addr[:81]
 		}
 
-		addressTxHashes, _ := tangle.GetTransactionHashesForAddress(addr, query.ValueOnly, true, maxResults-len(txHashes))
-		txHashes = append(txHashes, addressTxHashes...)
+		txHashes = append(txHashes, tangle.GetTransactionHashesForAddress(addr, query.ValueOnly, true, maxResults-len(txHashes))...)
 	}
 
 	// Searching for all approovers of the given transactions


### PR DESCRIPTION
-  Reverted counting all the transactions for an address since this could take down a node with a very big database
- Fixed search always interpreting the query as an address due to an empty address not being marked as not found anymore
- Allow al charts to rotate the timeline labels