### PR TITLE
Add autopeering settings

### DIFF
--- a/pkg/config/network_config.go
+++ b/pkg/config/network_config.go
@@ -30,6 +30,12 @@ const (
 	CfgNetAutopeeringSeed = "network.autopeering.seed"
 	// whether the node should act as an autopeering entry node
 	CfgNetAutopeeringRunAsEntryNode = "network.autopeering.runAsEntryNode"
+	// the number of inbound autopeers
+	CfgNetAutopeeringInboundPeers = "network.autopeering.inboundPeers"
+	// the number of outbound autopeers
+	CfgNetAutopeeringOutboundPeers = "network.autopeering.outboundPeers"
+	// lifetime (in minutes) of the private and public local salt
+	CfgNetAutopeeringSaltLifetime = "network.autopeering.saltLifetime"
 )
 
 func init() {
@@ -52,4 +58,7 @@ func init() {
 	NodeConfig.SetDefault(CfgNetAutopeeringBindAddr, "0.0.0.0:14626")
 	NodeConfig.SetDefault(CfgNetAutopeeringSeed, nil)
 	NodeConfig.SetDefault(CfgNetAutopeeringRunAsEntryNode, false)
+	NodeConfig.SetDefault(CfgNetAutopeeringInboundPeers, 2)
+	NodeConfig.SetDefault(CfgNetAutopeeringOutboundPeers, 2)
+	NodeConfig.SetDefault(CfgNetAutopeeringSaltLifetime, 30)
 }

--- a/plugins/autopeering/plugin.go
+++ b/plugins/autopeering/plugin.go
@@ -14,17 +14,17 @@ import (
 	"github.com/iotaledger/hive.go/node"
 
 	"github.com/gohornet/hornet/pkg/autopeering/services"
+	"github.com/gohornet/hornet/pkg/config"
 	"github.com/gohornet/hornet/pkg/peering/peer"
 	"github.com/gohornet/hornet/pkg/shutdown"
 	"github.com/gohornet/hornet/plugins/peering"
 )
 
 func init() {
-	// 2 inbound/outbound
 	selection.SetParameters(selection.Parameters{
-		InboundNeighborSize:        2,
-		OutboundNeighborSize:       2,
-		SaltLifetime:               30 * time.Minute,
+		InboundNeighborSize:        config.NodeConfig.GetInt(config.CfgNetAutopeeringInboundPeers),
+		OutboundNeighborSize:       config.NodeConfig.GetInt(config.CfgNetAutopeeringOutboundPeers),
+		SaltLifetime:               time.Duration(config.NodeConfig.GetInt(config.CfgNetAutopeeringSaltLifetime)) * time.Minute,
 		OutboundUpdateInterval:     30 * time.Second,
 		FullOutboundUpdateInterval: 30 * time.Second,
 	})


### PR DESCRIPTION
# Description

Allows to change the number of in/outbound autopeers and the salt lifetime through the config file. This is useful to not overload a node which has few static peers. It also makes Hornet more generic for private networks.

## Type of change

- [x] Enhancement (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have selected the `develop` branch as the target branch