### PR TITLE
feat: Dashboard improvements

### DIFF
--- a/pkg/utils/health.go
+++ b/pkg/utils/health.go
@@ -1,0 +1,40 @@
+package utils
+
+import (
+	"time"
+
+	"github.com/gohornet/hornet/pkg/model/tangle"
+	"github.com/gohornet/hornet/plugins/peering"
+)
+
+const maxAllowedMilestoneAge = time.Minute * 5
+
+// IsNodeHealthy returns whether the node is synced, has active neighbors and its latest milestone is not too old
+func IsNodeHealthy() bool {
+	// Synced
+	if !tangle.IsNodeSyncedWithThreshold() {
+		return false
+	}
+
+	// Has connected neighbors
+	if peering.Manager().ConnectedPeerCount() == 0 {
+		return false
+	}
+
+	// Latest milestone timestamp
+	var milestoneTimestamp int64
+	lmi := tangle.GetLatestMilestoneIndex()
+	cachedLatestMs := tangle.GetMilestoneOrNil(lmi) // bundle +1
+	if cachedLatestMs == nil {
+		return false
+	}
+
+	cachedMsTailTx := cachedLatestMs.GetBundle().GetTail() // tx +1
+	milestoneTimestamp = cachedMsTailTx.GetTransaction().GetTimestamp()
+	cachedMsTailTx.Release(true) // tx -1
+	cachedLatestMs.Release(true) // bundle -1
+
+	// Check whether the milestone is older than 5 minutes
+	timeMs := time.Unix(milestoneTimestamp, 0)
+	return time.Since(timeMs) < maxAllowedMilestoneAge
+}

--- a/plugins/dashboard/frontend/package.json
+++ b/plugins/dashboard/frontend/package.json
@@ -75,6 +75,7 @@
     "react-router": "^4.3.1",
     "react-router-bootstrap": "^0.25.0",
     "react-router-dom": "^5.1.2",
+    "react-tooltip": "^4.2.6",
     "vivagraphjs": "^0.12.0"
   }
 }

--- a/plugins/dashboard/frontend/src/app/components/LatestMilestone.tsx
+++ b/plugins/dashboard/frontend/src/app/components/LatestMilestone.tsx
@@ -1,7 +1,9 @@
 import * as React from 'react';
 import NodeStore from "app/stores/NodeStore";
 import {inject, observer} from "mobx-react";
+import {If} from 'tsx-control-statements/components';
 import Badge from "react-bootstrap/Badge";
+import ReactTooltip from "react-tooltip";
 
 interface Props {
     nodeStore?: NodeStore;
@@ -14,8 +16,13 @@ export default class LatestMilestone extends React.Component<Props, any> {
         return (
             <React.Fragment>
                 LSMI/LMI: {' '}
-                {this.props.nodeStore.status.lsmi} {' / '}
-                {this.props.nodeStore.status.lmi}
+                <span data-tip={this.props.nodeStore.msDelta} data-for="ms_delta">
+                    {this.props.nodeStore.status.lsmi} {' / '}
+                    {this.props.nodeStore.status.lmi}
+                </span>
+                <If condition={!this.props.nodeStore.isNodeSync}>
+                    <ReactTooltip id="ms_delta" place="bottom" effect="solid"/>
+                </If>
                 {' '}
                 {
                     this.props.nodeStore.isNodeSync ?

--- a/plugins/dashboard/frontend/src/app/stores/NodeStore.ts
+++ b/plugins/dashboard/frontend/src/app/stores/NodeStore.ts
@@ -34,6 +34,7 @@ class Status {
     lmi: number;
     snapshot_index: number;
     pruning_index: number;
+    is_healthy: boolean;
     version: string;
     latest_version: string;
     uptime: number;
@@ -432,9 +433,13 @@ export class NodeStore {
 
     @computed
     get isNodeSync(): boolean {
-        if (this.status.lmi == 0) return false;
-        return this.status.lsmi == this.status.lmi;
+        return this.status.is_healthy;
     };
+
+    @computed
+    get msDelta(): number {
+        return this.status.lmi - this.status.lsmi;
+    }
 
     @computed
     get isLatestVersion(): boolean {

--- a/plugins/dashboard/frontend/yarn.lock
+++ b/plugins/dashboard/frontend/yarn.lock
@@ -6040,6 +6040,14 @@ react-textarea-autosize@^6.1.0:
   dependencies:
     prop-types "^15.6.0"
 
+react-tooltip@^4.2.6:
+  version "4.2.6"
+  resolved "https://registry.yarnpkg.com/react-tooltip/-/react-tooltip-4.2.6.tgz#a3d5f0d1b0c597c0852ba09c5e2af0019b7cfc70"
+  integrity sha512-KX/zCsPFCI8RuulzBX86U+Ur7FvgGNRBdb7dUu0ndo8Urinn48nANq9wfq4ABlehweQjPzLl7XdNAtLKza+I3w==
+  dependencies:
+    prop-types "^15.7.2"
+    uuid "^7.0.3"
+
 react-transition-group@^4.0.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-4.3.0.tgz#fea832e386cf8796c58b61874a3319704f5ce683"
@@ -7305,6 +7313,11 @@ uuid@^3.0.1, uuid@^3.3.2:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
+
+uuid@^7.0.3:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-7.0.3.tgz#c5c9f2c8cf25dc0a372c4df1441c41f5bd0c680b"
+  integrity sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==
 
 v8-compile-cache@2.0.3:
   version "2.0.3"

--- a/plugins/dashboard/plugin.go
+++ b/plugins/dashboard/plugin.go
@@ -24,6 +24,7 @@ import (
 	"github.com/gohornet/hornet/pkg/peering/peer"
 	"github.com/gohornet/hornet/pkg/protocol/sting"
 	"github.com/gohornet/hornet/pkg/shutdown"
+	"github.com/gohornet/hornet/pkg/utils"
 	"github.com/gohornet/hornet/plugins/autopeering"
 	"github.com/gohornet/hornet/plugins/cli"
 	databaseplugin "github.com/gohornet/hornet/plugins/database"
@@ -238,6 +239,7 @@ type nodestatus struct {
 	LMI                    milestone.Index `json:"lmi"`
 	SnapshotIndex          milestone.Index `json:"snapshot_index"`
 	PruningIndex           milestone.Index `json:"pruning_index"`
+	IsHealthy              bool            `json:"is_healthy"`
 	Version                string          `json:"version"`
 	LatestVersion          string          `json:"latest_version"`
 	Uptime                 int64           `json:"uptime"`
@@ -359,6 +361,7 @@ func currentNodeStatus() *nodestatus {
 	if !node.IsSkipped(autopeering.PLUGIN) {
 		status.AutopeeringID = autopeering.ID
 	}
+	status.IsHealthy = utils.IsNodeHealthy()
 	status.NodeAlias = config.NodeConfig.GetString(config.CfgNodeAlias)
 	status.LSMI = tangle.GetSolidMilestoneIndex()
 	status.LMI = tangle.GetLatestMilestoneIndex()

--- a/plugins/dashboard/plugin.go
+++ b/plugins/dashboard/plugin.go
@@ -24,7 +24,6 @@ import (
 	"github.com/gohornet/hornet/pkg/peering/peer"
 	"github.com/gohornet/hornet/pkg/protocol/sting"
 	"github.com/gohornet/hornet/pkg/shutdown"
-	"github.com/gohornet/hornet/pkg/utils"
 	"github.com/gohornet/hornet/plugins/autopeering"
 	"github.com/gohornet/hornet/plugins/cli"
 	databaseplugin "github.com/gohornet/hornet/plugins/database"
@@ -361,7 +360,7 @@ func currentNodeStatus() *nodestatus {
 	if !node.IsSkipped(autopeering.PLUGIN) {
 		status.AutopeeringID = autopeering.ID
 	}
-	status.IsHealthy = utils.IsNodeHealthy()
+	status.IsHealthy = tangleplugin.IsNodeHealthy()
 	status.NodeAlias = config.NodeConfig.GetString(config.CfgNodeAlias)
 	status.LSMI = tangle.GetSolidMilestoneIndex()
 	status.LMI = tangle.GetLatestMilestoneIndex()

--- a/plugins/prometheus/peers.go
+++ b/plugins/prometheus/peers.go
@@ -173,13 +173,13 @@ func collectPeers() {
 	for _, peer := range peering.Manager().PeerInfos() {
 		address, port, _ := net.SplitHostPort(peer.Address)
 		labels := prometheus.Labels{
-			"address": address,
-			"port": port,
-			"domain": peer.Domain,
-			"alias": peer.Alias,
-			"type": peer.ConnectionType,
+			"address":        address,
+			"port":           port,
+			"domain":         peer.Domain,
+			"alias":          peer.Alias,
+			"type":           peer.ConnectionType,
 			"autopeering_id": peer.AutopeeringID,
-		};
+		}
 
 		peersAllTransactions.With(labels).Set(float64(peer.NumberOfAllTransactions))
 		peersNewTransactions.With(labels).Set(float64(peer.NumberOfNewTransactions))

--- a/plugins/tangle/health.go
+++ b/plugins/tangle/health.go
@@ -1,4 +1,4 @@
-package utils
+package tangle
 
 import (
 	"time"
@@ -7,9 +7,11 @@ import (
 	"github.com/gohornet/hornet/plugins/peering"
 )
 
-const maxAllowedMilestoneAge = time.Minute * 5
+const (
+	maxAllowedMilestoneAge = time.Minute * 5
+)
 
-// IsNodeHealthy returns whether the node is synced, has active neighbors and its latest milestone is not too old
+// IsNodeHealthy returns whether the node is synced, has active neighbors and its latest milestone is not too old.
 func IsNodeHealthy() bool {
 	// Synced
 	if !tangle.IsNodeSyncedWithThreshold() {

--- a/plugins/webapi/api.go
+++ b/plugins/webapi/api.go
@@ -10,10 +10,12 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/gohornet/hornet/pkg/config"
-	"github.com/gohornet/hornet/pkg/utils"
+	"github.com/gohornet/hornet/plugins/tangle"
 )
 
-const healthzRoute = "healthz"
+const (
+	healthzRoute = "healthz"
+)
 
 var (
 	// ErrNodeNotSync is returned when the node was not synced.
@@ -87,7 +89,7 @@ func restAPIRoute() {
 	// node mode
 	// GET /healthz
 	api.GET(healthzRoute, func(c *gin.Context) {
-		if !utils.IsNodeHealthy() {
+		if !tangle.IsNodeHealthy() {
 			c.Status(http.StatusServiceUnavailable)
 			return
 		}


### PR DESCRIPTION
closes #472

- Improves the sync status indicator. A node is considered to be sync if `lmi == lsmi`, it has active peers (at least one) and the lmi is not too old
- Adds a tooltip to show the milestone delta if the node is not synced
![image](https://user-images.githubusercontent.com/34713374/83771134-42820d00-a682-11ea-8dc4-11b6b23a520c.png)

