### PR TITLE
fix: IsStaticallyPeered check

### DIFF
--- a/pkg/peering/peering.go
+++ b/pkg/peering/peering.go
@@ -171,6 +171,10 @@ func (m *Manager) IsStaticallyPeered(ips []string, port uint16) bool {
 
 		// check all peers in the reconnect pool
 		for _, reconnectInfo := range m.reconnect {
+			// if the static peer has no DNS records, CachedIPs would be nil
+			if reconnectInfo.CachedIPs == nil {
+				continue
+			}
 			for reconnectInfoIP := range reconnectInfo.CachedIPs.IPs {
 				reconnectID := peer.NewID(reconnectInfoIP.String(), reconnectInfo.OriginAddr.Port)
 


### PR DESCRIPTION
# Description

This fixes a panic that occurs when a statically added peer (domain name) has no DNS records and autopeering is enabled

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have tested my code extensively
- [x] I have selected the `develop` branch as the target branch
