### PR TITLE
Makes config opts modifiable via CLI

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -31,6 +31,19 @@ var (
 
 	peeringConfigHotReloadAllowed = true
 	peeringConfigHotReloadLock    syncutils.Mutex
+
+	// a list of flags which should be printed via --help
+	nonHiddenFlags = map[string]struct{}{
+		"config":              {},
+		"config-dir":          {},
+		"node.disablePlugins": {},
+		"node.enablePlugins":  {},
+		"overwriteCooAddress": {},
+		"peeringConfig":       {},
+		"profilesConfig":      {},
+		"useProfile":          {},
+		"version":             {},
+	}
 )
 
 // FetchConfig fetches config values from a dir defined via CLI flag --config-dir (or the current working dir if not set).
@@ -38,6 +51,13 @@ var (
 // It automatically reads in a single config file starting with "config" (can be changed via the --config CLI flag)
 // and ending with: .json, .toml, .yaml or .yml (in this sequence).
 func FetchConfig() error {
+
+	// hide all but the most essential flags
+	flag.VisitAll(func(f *flag.Flag) {
+		_, notHidden := nonHiddenFlags[f.Name]
+		f.Hidden = !notHidden
+	})
+
 	err := parameter.LoadConfigFile(NodeConfig, *configDirPath, *configName, true, !hasFlag(defaultConfigName))
 	if err != nil {
 		return err

--- a/pkg/config/coordinator_config.go
+++ b/pkg/config/coordinator_config.go
@@ -1,5 +1,9 @@
 package config
 
+import (
+	flag "github.com/spf13/pflag"
+)
+
 const (
 	// the address of the coordinator
 	CfgCoordinatorAddress = "coordinator.address"
@@ -21,12 +25,13 @@ const (
 )
 
 func init() {
-	NodeConfig.SetDefault(CfgCoordinatorAddress, "EQSAUZXULTTYZCLNJNTXQTQHOMOFZERHTCGTXOLTVAHKSA9OGAZDEKECURBRIXIJWNPFCQIOVFVVXJVD9")
-	NodeConfig.SetDefault(CfgCoordinatorSecurityLevel, 2)
-	NodeConfig.SetDefault(CfgCoordinatorMerkleTreeDepth, 23)
-	NodeConfig.SetDefault(CfgCoordinatorMWM, 14)
-	NodeConfig.SetDefault(CfgCoordinatorStateFilePath, "coordinator.state")
-	NodeConfig.SetDefault(CfgCoordinatorMerkleTreeFilePath, "coordinator.tree")
-	NodeConfig.SetDefault(CfgCoordinatorIntervalSeconds, 60)
-	NodeConfig.SetDefault(CfgCoordinatorCheckpointTransactions, 5)
+	flag.String(CfgCoordinatorAddress, "EQSAUZXULTTYZCLNJNTXQTQHOMOFZERHTCGTXOLTVAHKSA9OGAZDEKECURBRIXIJWNPFCQIOVFVVXJVD9", "the address of the coordinator")
+	flag.Int(CfgCoordinatorSecurityLevel, 2, "the security level used in coordinator signatures")
+	flag.Int(CfgCoordinatorMerkleTreeDepth, 23, "the depth of the Merkle tree which in turn determines the number of leaves (private keys) that the coordinator can use to sign a message.")
+	flag.Int(CfgCoordinatorMWM, 14, "the minimum weight magnitude is the number of trailing 0s that must appear in the end of a transaction hash. "+
+		"increasing this number by 1 will result in proof of work that is 3 times as hard.")
+	flag.String(CfgCoordinatorStateFilePath, "coordinator.state", "the path to the state file of the coordinator")
+	flag.String(CfgCoordinatorMerkleTreeFilePath, "coordinator.tree", "the path to the merkle tree of the coordinator")
+	flag.Int(CfgCoordinatorIntervalSeconds, 60, "the interval milestones are issued")
+	flag.Int(CfgCoordinatorCheckpointTransactions, 5, "the amount of checkpoints issued between two milestones")
 }

--- a/pkg/config/dashboard_config.go
+++ b/pkg/config/dashboard_config.go
@@ -1,5 +1,9 @@
 package config
 
+import (
+	flag "github.com/spf13/pflag"
+)
+
 const (
 	// the bind address on which the dashboard can be access from
 	CfgDashboardBindAddress = "dashboard.bindAddress"
@@ -18,11 +22,11 @@ const (
 )
 
 func init() {
-	NodeConfig.SetDefault(CfgDashboardBindAddress, "localhost:8081")
-	NodeConfig.SetDefault(CfgDashboardDevMode, false)
-	NodeConfig.SetDefault(CfgDashboardBasicAuthEnabled, false)
-	NodeConfig.SetDefault(CfgDashboardBasicAuthUsername, "")
-	NodeConfig.SetDefault(CfgDashboardBasicAuthPasswordHash, "")
-	NodeConfig.SetDefault(CfgDashboardBasicAuthPasswordSalt, "")
-	NodeConfig.SetDefault(CfgDashboardTheme, "default")
+	flag.String(CfgDashboardBindAddress, "localhost:8081", "the bind address on which the dashboard can be access from")
+	flag.Bool(CfgDashboardDevMode, false, "whether to run the dashboard in dev mode")
+	flag.Bool(CfgDashboardBasicAuthEnabled, false, "whether to use HTTP basic auth")
+	flag.String(CfgDashboardBasicAuthUsername, "", "the HTTP basic auth username")
+	flag.String(CfgDashboardBasicAuthPasswordHash, "", "the HTTP basic auth username")
+	flag.String(CfgDashboardBasicAuthPasswordSalt, "", "the HTTP basic auth password+salt as a sha256 hash")
+	flag.String(CfgDashboardTheme, "default", "the theme for the dashboard to use (default or dark)")
 }

--- a/pkg/config/graph_config.go
+++ b/pkg/config/graph_config.go
@@ -1,5 +1,9 @@
 package config
 
+import (
+	flag "github.com/spf13/pflag"
+)
+
 const (
 	// the path to the visualizer web assets
 	CfgGraphWebRootPath = "graph.webRootPath"
@@ -18,11 +22,11 @@ const (
 )
 
 func init() {
-	NodeConfig.SetDefault(CfgGraphWebRootPath, "IOTAtangle/webroot")
-	NodeConfig.SetDefault(CfgGraphWebSocketURI, "")
-	NodeConfig.SetDefault(CfgGraphDomain, "")
-	NodeConfig.SetDefault(CfgGraphBindAddress, "localhost:8083")
-	NodeConfig.SetDefault(CfgGraphNetworkName, "meets HORNET")
-	NodeConfig.SetDefault(CfgGraphExplorerTxLink, "http://localhost:8081/explorer/tx/")
-	NodeConfig.SetDefault(CfgGraphExplorerBundleLink, "http://localhost:8081/explorer/bundle/")
+	flag.String(CfgGraphWebRootPath, "IOTAtangle/webroot", "the path to the visualizer web assets")
+	flag.String(CfgGraphWebSocketURI, "", "the websocket URI to use (optional)")
+	flag.String(CfgGraphDomain, "", "sets the domain name from which the visualizer is served from")
+	flag.String(CfgGraphBindAddress, "localhost:8083", "the bind address from which the visualizer can be accessed from")
+	flag.String(CfgGraphNetworkName, "meets HORNET", "the name of the network to be shown on the visualizer site")
+	flag.String(CfgGraphExplorerTxLink, "http://localhost:8081/explorer/tx/", "the explorer transaction link")
+	flag.String(CfgGraphExplorerBundleLink, "http://localhost:8081/explorer/bundle/", "the explorer bundle link")
 }

--- a/pkg/config/monitor_config.go
+++ b/pkg/config/monitor_config.go
@@ -1,5 +1,9 @@
 package config
 
+import (
+	flag "github.com/spf13/pflag"
+)
+
 const (
 	// path to the tanglemonitor web assets
 	CfgMonitorTangleMonitorPath = "monitor.tangleMonitorPath"
@@ -18,11 +22,11 @@ const (
 )
 
 func init() {
-	NodeConfig.SetDefault(CfgMonitorTangleMonitorPath, "tanglemonitor/frontend")
-	NodeConfig.SetDefault(CfgMonitorDomain, "")
-	NodeConfig.SetDefault(CfgMonitorWebSocketURI, "")
-	NodeConfig.SetDefault(CfgMonitorRemoteAPIPort, 4433)
-	NodeConfig.SetDefault(CfgMonitorInitialTransactions, 15000)
-	NodeConfig.SetDefault(CfgMonitorWebBindAddress, "localhost:4434")
-	NodeConfig.SetDefault(CfgMonitorAPIBindAddress, "localhost:4433")
+	flag.String(CfgMonitorTangleMonitorPath, "tanglemonitor/frontend", "path to the tanglemonitor web assets")
+	flag.String(CfgMonitorDomain, "", "the domain from which the tanglemonitor is served from")
+	flag.String(CfgMonitorWebSocketURI, "", "the websocket URI to use (optional)")
+	flag.Int(CfgMonitorRemoteAPIPort, 4433, "the remote API port")
+	flag.Int(CfgMonitorInitialTransactions, 15000, "the initial amount of tx to load")
+	flag.String(CfgMonitorWebBindAddress, "localhost:4434", "the bind address on which the monitor can be access from")
+	flag.String(CfgMonitorAPIBindAddress, "localhost:4433", "the bind address on which the API listens on")
 }

--- a/pkg/config/mqtt_config.go
+++ b/pkg/config/mqtt_config.go
@@ -1,10 +1,14 @@
 package config
 
+import (
+	flag "github.com/spf13/pflag"
+)
+
 const (
 	// path to the MQTT broker config file
 	CfgMQTTConfig = "mqtt.config"
 )
 
 func init() {
-	NodeConfig.SetDefault(CfgMQTTConfig, "mqtt_config.json")
+	flag.String(CfgMQTTConfig, "mqtt_config.json", "path to the MQTT broker config file")
 }

--- a/pkg/config/network_config.go
+++ b/pkg/config/network_config.go
@@ -1,5 +1,9 @@
 package config
 
+import (
+	flag "github.com/spf13/pflag"
+)
+
 // PeerConfig holds the initial information about peers.
 type PeerConfig struct {
 	ID         string `json:"identity" mapstructure:"identity"`
@@ -39,26 +43,27 @@ const (
 )
 
 func init() {
+
 	// gossip
-	NodeConfig.SetDefault(CfgNetPreferIPv6, false)
-	NodeConfig.SetDefault(CfgNetGossipBindAddress, "0.0.0.0:15600")
-	NodeConfig.SetDefault(CfgNetGossipReconnectAttemptIntervalSeconds, 60)
+	flag.Bool(CfgNetPreferIPv6, false, "defines if IPv6 is preferred for peers added through the API")
+	flag.String(CfgNetGossipBindAddress, "0.0.0.0:15600", "the bind address of the gossip TCP server")
+	flag.Int(CfgNetGossipReconnectAttemptIntervalSeconds, 60, "the number of seconds to wait before trying to reconnect to a disconnected peer")
 
 	// peering
-	PeeringConfig.SetDefault(CfgPeeringAcceptAnyConnection, false)
-	PeeringConfig.SetDefault(CfgPeeringMaxPeers, 5)
+	flag.Bool(CfgPeeringAcceptAnyConnection, false, "enable inbound connections from unknown peers")
+	flag.Int(CfgPeeringMaxPeers, 5, "set the maximum number of peers")
 	PeeringConfig.SetDefault(CfgPeers, []PeerConfig{})
 
 	// autopeering
-	NodeConfig.SetDefault(CfgNetAutopeeringEntryNodes, []string{
+	flag.StringSlice(CfgNetAutopeeringEntryNodes, []string{
 		"LehlDBPJ6kfcfLOK6kAU4nD7B/BdR7SJhai7yFCbCCM=@enter.hornet.zone:14626",
 		"zEiNuQMDfZ6F8QDisa1ndX32ykBTyYCxbtkO0vkaWd0=@enter.manapotion.io:18626",
 		"npLI53UCxBvOJaV0xv/mzWuV+f+pduc6GzE83jM/5uo=@entrynode.tanglebay.org:14626",
-	})
-	NodeConfig.SetDefault(CfgNetAutopeeringBindAddr, "0.0.0.0:14626")
-	NodeConfig.SetDefault(CfgNetAutopeeringSeed, nil)
-	NodeConfig.SetDefault(CfgNetAutopeeringRunAsEntryNode, false)
-	NodeConfig.SetDefault(CfgNetAutopeeringInboundPeers, 2)
-	NodeConfig.SetDefault(CfgNetAutopeeringOutboundPeers, 2)
-	NodeConfig.SetDefault(CfgNetAutopeeringSaltLifetime, 30)
+	}, "list of autopeering entry nodes to use")
+	flag.String(CfgNetAutopeeringBindAddr, "0.0.0.0:14626", "bind address for global services such as autopeering and gossip")
+	flag.String(CfgNetAutopeeringSeed, "", "private key seed used to derive the node identity; optional Base64 encoded 256-bit string")
+	flag.Bool(CfgNetAutopeeringRunAsEntryNode, false, "whether the node should act as an autopeering entry node")
+	flag.Int(CfgNetAutopeeringInboundPeers, 2, "the number of inbound autopeers")
+	flag.Int(CfgNetAutopeeringOutboundPeers, 2, "the number of outbound autopeers")
+	flag.Int(CfgNetAutopeeringSaltLifetime, 30, "lifetime (in minutes) of the private and public local salt")
 }

--- a/pkg/config/node_config.go
+++ b/pkg/config/node_config.go
@@ -1,5 +1,9 @@
 package config
 
+import (
+	flag "github.com/spf13/pflag"
+)
+
 const (
 	// CfgNodeAlias set an alias to identify a node
 	CfgNodeAlias = "node.alias"
@@ -8,6 +12,6 @@ const (
 )
 
 func init() {
-	NodeConfig.SetDefault(CfgNodeAlias, "")
-	NodeConfig.SetDefault(CfgNodeShowAliasInGetNodeInfo, false)
+	flag.String(CfgNodeAlias, "", "set an alias to identify a node")
+	flag.Bool(CfgNodeShowAliasInGetNodeInfo, false, "defines whether to show the alias in getNodeInfo")
 }

--- a/pkg/config/profiling_config.go
+++ b/pkg/config/profiling_config.go
@@ -1,10 +1,14 @@
 package config
 
+import (
+	flag "github.com/spf13/pflag"
+)
+
 const (
 	// the bind address on which the profiler listens on
 	CfgProfilingBindAddress = "profiling.bindAddress"
 )
 
 func init() {
-	NodeConfig.SetDefault(CfgProfilingBindAddress, "localhost:6060")
+	flag.String(CfgProfilingBindAddress, "localhost:6060", "the bind address on which the profiler listens on")
 }

--- a/pkg/config/prometheus_config.go
+++ b/pkg/config/prometheus_config.go
@@ -1,5 +1,9 @@
 package config
 
+import (
+	flag "github.com/spf13/pflag"
+)
+
 const (
 	// the bind address on which the Prometheus exporter listens on
 	CfgPrometheusBindAddress = "prometheus.bindAddress"
@@ -12,8 +16,8 @@ const (
 )
 
 func init() {
-	NodeConfig.SetDefault(CfgPrometheusBindAddress, "localhost:9311")
-	NodeConfig.SetDefault(CfgPrometheusGoMetrics, false)
-	NodeConfig.SetDefault(CfgPrometheusProcessMetrics, false)
-	NodeConfig.SetDefault(CfgPrometheusPromhttpMetrics, false)
+	flag.String(CfgPrometheusBindAddress, "localhost:9311", "the bind address on which the Prometheus exporter listens on")
+	flag.Bool(CfgPrometheusGoMetrics, false, "include go metrics")
+	flag.Bool(CfgPrometheusProcessMetrics, false, "include process metrics")
+	flag.Bool(CfgPrometheusPromhttpMetrics, false, "include promhttp metrics")
 }

--- a/pkg/config/snapshot_config.go
+++ b/pkg/config/snapshot_config.go
@@ -1,5 +1,9 @@
 package config
 
+import (
+	flag "github.com/spf13/pflag"
+)
+
 const (
 	// which snapshot type to load. 'local' or 'global'
 	CfgSnapshotLoadType = "snapshots.loadType"
@@ -28,20 +32,20 @@ const (
 )
 
 func init() {
-	NodeConfig.SetDefault(CfgSnapshotLoadType, "local")
-	NodeConfig.SetDefault(CfgLocalSnapshotsDepth, 50)
-	NodeConfig.SetDefault(CfgLocalSnapshotsIntervalSynced, 50)
-	NodeConfig.SetDefault(CfgLocalSnapshotsIntervalUnsynced, 1000)
-	NodeConfig.SetDefault(CfgLocalSnapshotsPath, "export.bin")
-	NodeConfig.SetDefault(CfgLocalSnapshotsDownloadURL, "")
-	NodeConfig.SetDefault(CfgGlobalSnapshotPath, "snapshotMainnet.txt")
-	NodeConfig.SetDefault(CfgGlobalSnapshotSpentAddressesPaths, []string{
+	flag.String(CfgSnapshotLoadType, "local", "which snapshot type to load. 'local' or 'global'")
+	flag.Int(CfgLocalSnapshotsDepth, 50, "the depth, respectively the starting point, at which a local snapshot of the ledger is generated")
+	flag.Int(CfgLocalSnapshotsIntervalSynced, 50, "interval, in milestone transactions, at which snapshot files are created if the ledger is fully synchronized")
+	flag.Int(CfgLocalSnapshotsIntervalUnsynced, 1000, "interval, in milestone transactions, at which snapshot files are created if the ledger is not fully synchronized")
+	flag.String(CfgLocalSnapshotsPath, "export.bin", "path to the local snapshot file")
+	flag.String(CfgLocalSnapshotsDownloadURL, "", "URL to load the local snapshot file from")
+	flag.String(CfgGlobalSnapshotPath, "snapshotMainnet.txt", "path to the global snapshot file containing the ledger state")
+	flag.StringSlice(CfgGlobalSnapshotSpentAddressesPaths, []string{
 		"previousEpochsSpentAddresses1.txt",
 		"previousEpochsSpentAddresses2.txt",
 		"previousEpochsSpentAddresses3.txt",
-	})
-	NodeConfig.SetDefault(CfgGlobalSnapshotIndex, 1050000)
-	NodeConfig.SetDefault(CfgPruningEnabled, true)
-	NodeConfig.SetDefault(CfgPruningDelay, 40000)
-	NodeConfig.SetDefault(CfgSpentAddressesEnabled, true)
+	}, "paths to the spent addresses files")
+	flag.Int(CfgGlobalSnapshotIndex, 1050000, "milestone index of the global snapshot")
+	flag.Bool(CfgPruningEnabled, true, "whether to delete old transaction data from the database")
+	flag.Int(CfgPruningDelay, 40000, "amount of milestone transactions to keep in the database")
+	flag.Bool(CfgSpentAddressesEnabled, true, "enable support for wereAddressesSpentFrom (needed for Trinity, but local snapshots are much bigger)")
 }

--- a/pkg/config/spammer_config.go
+++ b/pkg/config/spammer_config.go
@@ -1,5 +1,9 @@
 package config
 
+import (
+	flag "github.com/spf13/pflag"
+)
+
 const (
 	// the target address of the spam
 	CfgSpammerAddress = "spammer.address"
@@ -22,11 +26,13 @@ const (
 )
 
 func init() {
-	NodeConfig.SetDefault(CfgSpammerAddress, "HORNET99INTEGRATED99SPAMMER999999999999999999999999999999999999999999999999999999")
-	NodeConfig.SetDefault(CfgSpammerMessage, "Spamming with HORNET tipselect")
-	NodeConfig.SetDefault(CfgSpammerTag, "HORNET99SPAMMER999999999999")
-	NodeConfig.SetDefault(CfgSpammerDepth, 3)
-	NodeConfig.SetDefault(CfgSpammerCPUMaxUsage, 0.50)
-	NodeConfig.SetDefault(CfgSpammerTPSRateLimit, 0.10)
-	NodeConfig.SetDefault(CfgSpammerWorkers, 1)
+	flag.String(CfgSpammerAddress, "HORNET99INTEGRATED99SPAMMER999999999999999999999999999999999999999999999999999999", "the target address of the spam")
+	flag.String(CfgSpammerMessage, "Spamming with HORNET tipselect", "the message to embed within the spam transactions")
+	flag.String(CfgSpammerTag, "HORNET99SPAMMER999999999999", "the tag of the transaction")
+	flag.Int(CfgSpammerDepth, 3, "the depth to use for tip-selection")
+	flag.Float64(CfgSpammerCPUMaxUsage, 0.50, "workers remains idle for a while when cpu usage gets over this limit (0 = disable)")
+	flag.Float64(CfgSpammerTPSRateLimit, 0.10, "the rate limit for the spammer (0 = no limit)")
+	flag.Int(CfgSpammerBundleSize, 1, "the size of the spam bundles")
+	flag.Bool(CfgSpammerValueSpam, false, "should be spammed with value bundles")
+	flag.Int(CfgSpammerWorkers, 1, "the amount of parallel running spammers")
 }

--- a/pkg/config/tangle_config.go
+++ b/pkg/config/tangle_config.go
@@ -1,5 +1,9 @@
 package config
 
+import (
+	flag "github.com/spf13/pflag"
+)
+
 const (
 	// the path to the database folder
 	CfgDatabasePath = "db.path"
@@ -8,5 +12,6 @@ const (
 )
 
 func init() {
-	NodeConfig.SetDefault(CfgDatabasePath, "mainnetdb")
+	flag.String(CfgDatabasePath, "mainnetdb", "the path to the database folder")
+	flag.Bool(CfgDatabaseDebug, false, "ignore the check for corrupted databases (should only be used for debug reasons)")
 }

--- a/pkg/config/tipsel_config.go
+++ b/pkg/config/tipsel_config.go
@@ -1,5 +1,9 @@
 package config
 
+import (
+	flag "github.com/spf13/pflag"
+)
+
 const (
 	// the max allowed depth to be used as the starting point for tip-selection
 	CfgTipSelMaxDepth = "tipsel.maxDepth"
@@ -9,6 +13,7 @@ const (
 )
 
 func init() {
-	NodeConfig.SetDefault(CfgTipSelMaxDepth, 3)
-	NodeConfig.SetDefault(CfgTipSelBelowMaxDepthTransactionLimit, 20000)
+	flag.Int(CfgTipSelMaxDepth, 3, "the max allowed depth to be used as the starting point for tip-selection")
+	flag.Int(CfgTipSelBelowMaxDepthTransactionLimit, 20000, "the limit defining the max amount of transactions to traverse in order to check "+
+		"whether a transaction references a transaction below max depth")
 }

--- a/pkg/config/webapi_config.go
+++ b/pkg/config/webapi_config.go
@@ -1,5 +1,9 @@
 package config
 
+import (
+	flag "github.com/spf13/pflag"
+)
+
 const (
 	// the bind address on which the HTTP API listens on
 	CfgWebAPIBindAddress = "httpAPI.bindAddress"
@@ -28,8 +32,8 @@ const (
 )
 
 func init() {
-	NodeConfig.SetDefault(CfgWebAPIBindAddress, "0.0.0.0:14265")
-	NodeConfig.SetDefault(CfgWebAPIPermitRemoteAccess,
+	flag.String(CfgWebAPIBindAddress, "0.0.0.0:14265", "the bind address on which the HTTP API listens on")
+	flag.StringSlice(CfgWebAPIPermitRemoteAccess,
 		[]string{
 			"getNodeInfo",
 			"getBalances",
@@ -42,15 +46,15 @@ func init() {
 			"findTransactions",
 			"storeTransactions",
 			"getTrytes",
-		})
-	NodeConfig.SetDefault(CfgWebAPIWhitelistedAddresses, []string{})
-	NodeConfig.SetDefault(CfgWebAPIExcludeHealthCheckFromAuth, false)
-	NodeConfig.SetDefault(CfgWebAPIBasicAuthEnabled, false)
-	NodeConfig.SetDefault(CfgWebAPIBasicAuthUsername, "")
-	NodeConfig.SetDefault(CfgWebAPIBasicAuthPasswordHash, "")
-	NodeConfig.SetDefault(CfgWebAPIBasicAuthPasswordSalt, "")
-	NodeConfig.SetDefault(CfgWebAPILimitsMaxGetTrytes, 1000)
-	NodeConfig.SetDefault(CfgWebAPILimitsMaxRequestsList, 1000)
-	NodeConfig.SetDefault(CfgWebAPILimitsMaxFindTransactions, 1000)
-	NodeConfig.SetDefault(CfgWebAPILimitsMaxBodyLengthBytes, 1000000)
+		}, "the allowed HTTP API calls which can be called from non whitelisted addresses")
+	flag.StringSlice(CfgWebAPIWhitelistedAddresses, []string{}, "the whitelist of addresses which are allowed to access the HTTP API")
+	flag.Bool(CfgWebAPIExcludeHealthCheckFromAuth, false, "whether to allow the health check route anyways")
+	flag.Bool(CfgWebAPIBasicAuthEnabled, false, "whether to use HTTP basic auth for the HTTP API")
+	flag.String(CfgWebAPIBasicAuthUsername, "", "the username of the HTTP basic auth")
+	flag.String(CfgWebAPIBasicAuthPasswordHash, "", "the HTTP basic auth password+salt as a sha256 hash")
+	flag.String(CfgWebAPIBasicAuthPasswordSalt, "", "the HTTP basic auth salt used for hashing the password")
+	flag.Int(CfgWebAPILimitsMaxBodyLengthBytes, 1000000, "the maximum number of characters that the body of an API call may contain")
+	flag.Int(CfgWebAPILimitsMaxFindTransactions, 1000, "the maximum number of transactions that may be returned by the findTransactions endpoint")
+	flag.Int(CfgWebAPILimitsMaxGetTrytes, 1000, "the maximum number of trytes that may be returned by the getTrytes endpoint")
+	flag.Int(CfgWebAPILimitsMaxRequestsList, 1000, "the maximum number of parameters in an API call")
 }

--- a/pkg/config/zmq_config.go
+++ b/pkg/config/zmq_config.go
@@ -1,5 +1,9 @@
 package config
 
+import (
+	flag "github.com/spf13/pflag"
+)
+
 const (
 	// protocol used to connect to the zmq feed [unix, tcp, udp, inproc]
 	CfgZMQBindAddress = "zmq.bindAddress"
@@ -8,6 +12,6 @@ const (
 )
 
 func init() {
-	NodeConfig.SetDefault(CfgZMQProtocol, "tcp")
-	NodeConfig.SetDefault(CfgZMQBindAddress, "localhost:5556")
+	flag.String(CfgZMQProtocol, "tcp", "protocol used to connect to the zmq feed [unix, tcp, udp, inproc]")
+	flag.String(CfgZMQBindAddress, "localhost:5556", "the bind address of the ZMQ feed")
 }

--- a/pkg/profile/parameters.go
+++ b/pkg/profile/parameters.go
@@ -1,7 +1,0 @@
-package profile
-
-import flag "github.com/spf13/pflag"
-
-func init() {
-	flag.StringP("useProfile", "p", "auto", "Sets the profile with which the node runs")
-}

--- a/pkg/profile/profile.go
+++ b/pkg/profile/profile.go
@@ -7,17 +7,20 @@ import (
 	"sync"
 
 	"github.com/shirou/gopsutil/mem"
+	flag "github.com/spf13/pflag"
 
 	"github.com/gohornet/hornet/pkg/config"
 )
 
 const (
+	// AutoProfileName is the name of the automatic profile.
 	AutoProfileName = "auto"
-	CfgUseProfile   = "useProfile"
+	// CfgUseProfile is the key to set the profile to use.
+	CfgUseProfile = "useProfile"
 )
 
 func init() {
-	config.NodeConfig.SetDefault(CfgUseProfile, AutoProfileName)
+	flag.StringP(CfgUseProfile, "p", AutoProfileName, "Sets the profile with which the node runs")
 }
 
 var (

--- a/plugins/cli/cli.go
+++ b/plugins/cli/cli.go
@@ -50,7 +50,6 @@ func PrintConfig() {
 // PrintVersion prints out the HORNET version
 func PrintVersion() {
 	version := flag.BoolP("version", "v", false, "Prints the HORNET version")
-	flag.Parse()
 	if *version {
 		fmt.Println(AppName + " " + AppVersion)
 		os.Exit(0)


### PR DESCRIPTION
Instead of using `NodeConfig.SetDefault(...)`, all config opts are defined now via `pflags`. This allows a user to pass in config via CLI instead of having to supply a config.json with adjusted opts. `--help` will still only print the most relevant CLI flags.