### PR TITLE
Adds the ability to let the Prometheus plugin create a 'file service discovery' file

### DIFF
--- a/pkg/config/prometheus_config.go
+++ b/pkg/config/prometheus_config.go
@@ -13,7 +13,7 @@ const (
 	CfgPrometheusProcessMetrics = "prometheus.processMetrics"
 	// include promhttp metrics
 	CfgPrometheusPromhttpMetrics = "prometheus.promhttpMetrics"
-	// "whether the plugin should write a Prometheus 'file SD' file"
+	// whether the plugin should write a Prometheus 'file SD' file
 	CfgPrometheusFileServiceDiscoveryEnabled = "prometheus.fileServiceDiscovery.enabled"
 	// the path where to write the 'file SD' file to
 	CfgPrometheusFileServiceDiscoveryPath = "prometheus.fileServiceDiscovery.path"
@@ -27,6 +27,6 @@ func init() {
 	flag.Bool(CfgPrometheusProcessMetrics, false, "include process metrics")
 	flag.Bool(CfgPrometheusPromhttpMetrics, false, "include promhttp metrics")
 	flag.Bool(CfgPrometheusFileServiceDiscoveryEnabled, false, "whether the plugin should write a Prometheus 'file SD' file")
-	flag.String(CfgPrometheusFileServiceDiscoveryPath, "./target.json", "the path where to write the 'file SD' file to")
-	flag.String(CfgPrometheusFileServiceDiscoveryTarget, "127.0.0.1:9311", "the target to write into the 'file SD' file")
+	flag.String(CfgPrometheusFileServiceDiscoveryPath, "target.json", "the path where to write the 'file SD' file to")
+	flag.String(CfgPrometheusFileServiceDiscoveryTarget, "localhost:9311", "the target to write into the 'file SD' file")
 }

--- a/pkg/config/prometheus_config.go
+++ b/pkg/config/prometheus_config.go
@@ -13,6 +13,12 @@ const (
 	CfgPrometheusProcessMetrics = "prometheus.processMetrics"
 	// include promhttp metrics
 	CfgPrometheusPromhttpMetrics = "prometheus.promhttpMetrics"
+	// "whether the plugin should write a Prometheus 'file SD' file"
+	CfgPrometheusFileServiceDiscoveryEnabled = "prometheus.fileServiceDiscovery.enabled"
+	// the path where to write the 'file SD' file to
+	CfgPrometheusFileServiceDiscoveryPath = "prometheus.fileServiceDiscovery.path"
+	// the target to write into the 'file SD' file
+	CfgPrometheusFileServiceDiscoveryTarget = "prometheus.fileServiceDiscovery.target"
 )
 
 func init() {
@@ -20,4 +26,7 @@ func init() {
 	flag.Bool(CfgPrometheusGoMetrics, false, "include go metrics")
 	flag.Bool(CfgPrometheusProcessMetrics, false, "include process metrics")
 	flag.Bool(CfgPrometheusPromhttpMetrics, false, "include promhttp metrics")
+	flag.Bool(CfgPrometheusFileServiceDiscoveryEnabled, false, "whether the plugin should write a Prometheus 'file SD' file")
+	flag.String(CfgPrometheusFileServiceDiscoveryPath, "./target.json", "the path where to write the 'file SD' file to")
+	flag.String(CfgPrometheusFileServiceDiscoveryTarget, "127.0.0.1:9311", "the target to write into the 'file SD' file")
 }

--- a/plugins/prometheus/data.go
+++ b/plugins/prometheus/data.go
@@ -23,10 +23,10 @@ func init() {
 
 	registry.MustRegister(dataSizes)
 
-	addCollect(colectData)
+	addCollect(collectData)
 }
 
-func colectData() {
+func collectData() {
 	dataSizes.Reset()
 	dbSize, err := directorySize(config.NodeConfig.GetString(config.CfgDatabasePath))
 	if err == nil {

--- a/plugins/prometheus/plugin.go
+++ b/plugins/prometheus/plugin.go
@@ -2,6 +2,8 @@ package prometheus
 
 import (
 	"context"
+	"encoding/json"
+	"io/ioutil"
 	"net/http"
 	"time"
 
@@ -42,8 +44,35 @@ func addCollect(collect func()) {
 	collects = append(collects, collect)
 }
 
+type fileservicediscovery struct {
+	Targets []string          `json:"targets"`
+	Labels  map[string]string `json:"labels"`
+}
+
+func writeFileServiceDiscoveryFile() {
+	path := config.NodeConfig.GetString(config.CfgPrometheusFileServiceDiscoveryPath)
+	d := []fileservicediscovery{{
+		Targets: []string{config.NodeConfig.GetString(config.CfgPrometheusFileServiceDiscoveryTarget)},
+		Labels:  make(map[string]string),
+	}}
+	j, err := json.MarshalIndent(d, "", "  ")
+	if err != nil {
+		log.Panic("unable to marshal file service discovery JSON:", err)
+		return
+	}
+
+	// this truncates an existing file
+	if err := ioutil.WriteFile(path, j, 0666); err != nil {
+		log.Panic("unable to write file service discovery file:", err)
+	}
+}
+
 func run(plugin *node.Plugin) {
 	log.Info("Starting Prometheus exporter ...")
+
+	if config.NodeConfig.GetBool(config.CfgPrometheusFileServiceDiscoveryEnabled) {
+		writeFileServiceDiscoveryFile()
+	}
 
 	daemon.BackgroundWorker("Prometheus exporter", func(shutdownSignal <-chan struct{}) {
 		log.Info("Starting Prometheus exporter ... done")

--- a/plugins/prometheus/plugin.go
+++ b/plugins/prometheus/plugin.go
@@ -65,6 +65,8 @@ func writeFileServiceDiscoveryFile() {
 	if err := ioutil.WriteFile(path, j, 0666); err != nil {
 		log.Panic("unable to write file service discovery file:", err)
 	}
+
+	log.Infof("Wrote 'file service discovery' content to %s", path)
 }
 
 func run(plugin *node.Plugin) {


### PR DESCRIPTION
The config opts are not exposed in config.json as they are rather exotic and not meant for the normal use case.