### PR TITLE
Fix below max depth for SolidEntryPoints

### DIFF
--- a/pkg/model/coordinator/coordinator.go
+++ b/pkg/model/coordinator/coordinator.go
@@ -140,6 +140,10 @@ func (coo *Coordinator) InitState(bootstrap bool, startIndex milestone.Index) er
 			}
 			latestMilestoneHash = cachedBndl.GetBundle().GetTailHash()
 			cachedBndl.Release()
+		} else {
+			// If we start with a new network, we have to mark thegenesis tx as a SEP,
+			// otherwise the tipselection for the coordinator won't work.
+			tangle.SolidEntryPointsAdd(hornet.NullHashBytes, 0)
 		}
 
 		// create a new coordinator state to bootstrap the network

--- a/pkg/model/coordinator/coordinator.go
+++ b/pkg/model/coordinator/coordinator.go
@@ -140,10 +140,6 @@ func (coo *Coordinator) InitState(bootstrap bool, startIndex milestone.Index) er
 			}
 			latestMilestoneHash = cachedBndl.GetBundle().GetTailHash()
 			cachedBndl.Release()
-		} else {
-			// If we start with a new network, we have to mark thegenesis tx as a SEP,
-			// otherwise the tipselection for the coordinator won't work.
-			tangle.SolidEntryPointsAdd(hornet.NullHashBytes, 0)
 		}
 
 		// create a new coordinator state to bootstrap the network

--- a/pkg/model/hornet/solid_entry_points.go
+++ b/pkg/model/hornet/solid_entry_points.go
@@ -36,6 +36,11 @@ func (s *SolidEntryPoints) Contains(txHash Hash) bool {
 	return exists
 }
 
+func (s *SolidEntryPoints) Index(txHash Hash) (bool, milestone.Index) {
+	index, exists := s.entryPointsMap[string(txHash)]
+	return exists, index
+}
+
 func (s *SolidEntryPoints) Add(txHash Hash, milestoneIndex milestone.Index) {
 	if _, exists := s.entryPointsMap[string(txHash)]; !exists {
 		s.entryPointsMap[string(txHash)] = milestoneIndex

--- a/pkg/model/hornet/solid_entry_points.go
+++ b/pkg/model/hornet/solid_entry_points.go
@@ -36,9 +36,9 @@ func (s *SolidEntryPoints) Contains(txHash Hash) bool {
 	return exists
 }
 
-func (s *SolidEntryPoints) Index(txHash Hash) (bool, milestone.Index) {
+func (s *SolidEntryPoints) Index(txHash Hash) (milestone.Index, bool) {
 	index, exists := s.entryPointsMap[string(txHash)]
-	return exists, index
+	return index, exists
 }
 
 func (s *SolidEntryPoints) Add(txHash Hash, milestoneIndex milestone.Index) {

--- a/pkg/model/tangle/ledger_db.go
+++ b/pkg/model/tangle/ledger_db.go
@@ -297,7 +297,7 @@ func ApplyLedgerDiffWithoutLocking(diff map[string]int64, index milestone.Index)
 	return nil
 }
 
-func DeleteLedgerBalancesInDatabase() error {
+func StoreLedgerBalancesInDatabase(balances map[string]uint64, index milestone.Index) error {
 
 	WriteLockLedger()
 	defer WriteUnlockLedger()
@@ -306,14 +306,6 @@ func DeleteLedgerBalancesInDatabase() error {
 	if err := ledgerBalanceStore.Clear(); err != nil {
 		return errors.Wrap(NewDatabaseError(err), "failed to delete ledger balances")
 	}
-
-	return nil
-}
-
-func StoreLedgerBalancesInDatabase(balances map[string]uint64, index milestone.Index) error {
-
-	WriteLockLedger()
-	defer WriteUnlockLedger()
 
 	balanceBatch := ledgerBalanceStore.Batched()
 

--- a/pkg/model/tangle/solid_entry_points.go
+++ b/pkg/model/tangle/solid_entry_points.go
@@ -66,6 +66,16 @@ func SolidEntryPointsContain(txHash hornet.Hash) bool {
 	return solidEntryPoints.Contains(txHash)
 }
 
+func SolidEntryPointsIndex(txHash hornet.Hash) (bool, milestone.Index) {
+	ReadLockSolidEntryPoints()
+	defer ReadUnlockSolidEntryPoints()
+
+	if solidEntryPoints == nil {
+		panic(ErrSolidEntryPointsNotInitialized)
+	}
+	return solidEntryPoints.Index(txHash)
+}
+
 // WriteLockSolidEntryPoints must be held while entering this function
 func SolidEntryPointsAdd(txHash hornet.Hash, milestoneIndex milestone.Index) {
 	if solidEntryPoints == nil {

--- a/pkg/model/tangle/solid_entry_points.go
+++ b/pkg/model/tangle/solid_entry_points.go
@@ -66,7 +66,7 @@ func SolidEntryPointsContain(txHash hornet.Hash) bool {
 	return solidEntryPoints.Contains(txHash)
 }
 
-func SolidEntryPointsIndex(txHash hornet.Hash) (bool, milestone.Index) {
+func SolidEntryPointsIndex(txHash hornet.Hash) (milestone.Index, bool) {
 	ReadLockSolidEntryPoints()
 	defer ReadUnlockSolidEntryPoints()
 

--- a/plugins/snapshot/global_snapshot.go
+++ b/plugins/snapshot/global_snapshot.go
@@ -53,6 +53,11 @@ func loadSpentAddresses(filePathSpent string) (int, error) {
 
 func loadSnapshotFromTextfiles(filePathLedger string, filePathsSpent []string, snapshotIndex milestone.Index) error {
 
+	latestMilestoneFromDatabase := tangle.SearchLatestMilestoneIndexInStore()
+	if latestMilestoneFromDatabase > snapshotIndex {
+		return errors.Wrapf(ErrSnapshotImportFailed, "Milestone in database (%d) newer than snapshot milestone (%d)", latestMilestoneFromDatabase, snapshotIndex)
+	}
+
 	tangle.WriteLockSolidEntryPoints()
 	tangle.ResetSolidEntryPoints()
 

--- a/plugins/snapshot/global_snapshot.go
+++ b/plugins/snapshot/global_snapshot.go
@@ -56,7 +56,8 @@ func loadSnapshotFromTextfiles(filePathLedger string, filePathsSpent []string, s
 	tangle.WriteLockSolidEntryPoints()
 	tangle.ResetSolidEntryPoints()
 
-	// Genesis transaction
+	// Genesis transaction must be marked as SEP with snapshot index during loading a global snapshot,
+	// because coordinator bootstraps the network by referencing the genesis tx
 	tangle.SolidEntryPointsAdd(hornet.NullHashBytes, snapshotIndex)
 	tangle.StoreSolidEntryPoints()
 	tangle.WriteUnlockSolidEntryPoints()

--- a/plugins/snapshot/local_snapshot.go
+++ b/plugins/snapshot/local_snapshot.go
@@ -621,9 +621,6 @@ func LoadSnapshotFromFile(filePath string) error {
 	tangle.WriteLockSolidEntryPoints()
 	tangle.ResetSolidEntryPoints()
 
-	// Genesis transaction
-	tangle.SolidEntryPointsAdd(hornet.NullHashBytes, 0)
-
 	var msIndex int32
 	var msTimestamp int64
 	var solidEntryPointsCount, seenMilestonesCount, ledgerEntriesCount, spentAddrsCount int32

--- a/plugins/snapshot/local_snapshot.go
+++ b/plugins/snapshot/local_snapshot.go
@@ -201,7 +201,6 @@ func shouldTakeSnapshot(solidMilestoneIndex milestone.Index) bool {
 func getSolidEntryPoints(targetIndex milestone.Index, abortSignal <-chan struct{}) (map[string]milestone.Index, error) {
 
 	solidEntryPoints := make(map[string]milestone.Index)
-	solidEntryPoints[string(hornet.NullHashBytes)] = targetIndex
 
 	// HINT: Check if "old solid entry points are still valid" is skipped in HORNET,
 	//		 since they should all be found by iterating the milestones to a certain depth under targetIndex, because the tipselection for COO was changed.

--- a/plugins/snapshot/plugin.go
+++ b/plugins/snapshot/plugin.go
@@ -232,7 +232,7 @@ func PruneDatabaseByTargetIndex(targetIndex milestone.Index) error {
 }
 
 func installGenesisTransaction() {
-	// ensure genesis transaction exists
+	// ensure genesis transaction exists for legacy gossip
 	genesisTxTrits := make(trinary.Trits, consts.TransactionTrinarySize)
 	genesis, _ := transaction.ParseTransaction(genesisTxTrits, true)
 	genesis.Hash = consts.NullHashTrytes

--- a/plugins/snapshot/plugin.go
+++ b/plugins/snapshot/plugin.go
@@ -35,6 +35,7 @@ var (
 	log    *logger.Logger
 
 	overwriteCooAddress = pflag.Bool("overwriteCooAddress", false, "apply new coordinator address from config file to database")
+	forceGlobalSnapshot = pflag.Bool("forceGlobalSnapshot", false, "force loading of a global snapshot, even if a database already exists")
 
 	ErrNoSnapshotSpecified             = errors.New("no snapshot file was specified in the config")
 	ErrNoSnapshotDownloadURL           = fmt.Errorf("no download URL given for local snapshot under config option '%s", config.CfgLocalSnapshotsDownloadURL)
@@ -104,15 +105,22 @@ func configure(plugin *node.Plugin) {
 			tangle.SetSnapshotInfo(snapshotInfo)
 		}
 
-		// Check the ledger state
-		tangle.GetLedgerStateForLSMI(nil)
-		return
+		if !*forceGlobalSnapshot {
+			// If we don't enforce loading of a global snapshot,
+			// we can check the ledger state of current database and start the node.
+			tangle.GetLedgerStateForLSMI(nil)
+			return
+		}
+	}
+
+	snapshotTypeToLoad := strings.ToLower(config.NodeConfig.GetString(config.CfgSnapshotLoadType))
+
+	if *forceGlobalSnapshot && snapshotTypeToLoad != "global" {
+		log.Fatalf("global snapshot enforced but wrong snapshot type under config option '%s': %s", config.CfgSnapshotLoadType, config.NodeConfig.GetString(config.CfgSnapshotLoadType))
 	}
 
 	var err = ErrNoSnapshotSpecified
-
-	snapshotTypeToLoad := config.NodeConfig.GetString(config.CfgSnapshotLoadType)
-	switch strings.ToLower(snapshotTypeToLoad) {
+	switch snapshotTypeToLoad {
 	case "global":
 		if path := config.NodeConfig.GetString(config.CfgGlobalSnapshotPath); path != "" {
 			err = LoadGlobalSnapshot(path,
@@ -144,7 +152,7 @@ func configure(plugin *node.Plugin) {
 			err = LoadSnapshotFromFile(path)
 		}
 	default:
-		log.Fatalf("invalid snapshot type under config option '%s': %s", config.CfgSnapshotLoadType, snapshotTypeToLoad)
+		log.Fatalf("invalid snapshot type under config option '%s': %s", config.CfgSnapshotLoadType, config.NodeConfig.GetString(config.CfgSnapshotLoadType))
 	}
 
 	if err != nil {

--- a/plugins/snapshot/pruning.go
+++ b/plugins/snapshot/pruning.go
@@ -1,9 +1,8 @@
 package snapshot
 
 import (
+	"bytes"
 	"time"
-
-	"github.com/iotaledger/iota.go/consts"
 
 	"github.com/gohornet/hornet/pkg/model/hornet"
 	"github.com/gohornet/hornet/pkg/model/milestone"
@@ -85,7 +84,7 @@ func pruneTransactions(txsToCheckMap map[string]struct{}) int {
 
 	for txHashToDelete := range txsToDeleteMap {
 
-		if txHashToDelete == consts.NullHashTrytes {
+		if bytes.Equal(hornet.Hash(txHashToDelete), hornet.NullHashBytes) {
 			// do not delete genesis transaction
 			continue
 		}

--- a/plugins/tangle/depth.go
+++ b/plugins/tangle/depth.go
@@ -60,12 +60,12 @@ var BelowDepthMemoizationCache = belowDepthMemoizationCache{memoizationCache: ma
 // within the range of allowed milestones. if not, it is checked whether any referenced (directly/indirectly) tx
 // is confirmed by a milestone below the allowed threshold until a limit is reached of analyzed txs, in which case
 // the given tail transaction is also deemed being below max depth.
-func IsBelowMaxDepth(cachedTailTx *tangle.CachedTransaction, lowerAllowedSnapshotIndex int, forceRelease bool) bool {
+func IsBelowMaxDepth(cachedTailTx *tangle.CachedTransaction, lowestAllowedSnapshotIndex int, forceRelease bool) bool {
 
 	defer cachedTailTx.Release(forceRelease) // tx -1
 
 	// if the tx is already confirmed we don't need to check it for max depth
-	if confirmed, at := cachedTailTx.GetMetadata().GetConfirmed(); confirmed && int(at) >= lowerAllowedSnapshotIndex {
+	if confirmed, at := cachedTailTx.GetMetadata().GetConfirmed(); confirmed && int(at) >= lowestAllowedSnapshotIndex {
 		return false
 	}
 
@@ -120,7 +120,7 @@ func IsBelowMaxDepth(cachedTailTx *tangle.CachedTransaction, lowerAllowedSnapsho
 			confirmed, at := cachedTx.GetMetadata().GetConfirmed()
 
 			// we are below max depth on this transaction if it is confirmed by a milestone below our threshold
-			if confirmed && int(at) < lowerAllowedSnapshotIndex {
+			if confirmed && int(at) < lowestAllowedSnapshotIndex {
 				BelowDepthMemoizationCache.Set(cachedTailTx.GetTransaction().GetTxHash(), true)
 				cachedTx.Release(forceRelease) // tx -1
 				return true

--- a/plugins/tangle/depth.go
+++ b/plugins/tangle/depth.go
@@ -90,7 +90,7 @@ func IsBelowMaxDepth(cachedTailTx *tangle.CachedTransaction, lowestAllowedSnapsh
 				return true
 			}
 
-			if isSolidEntryPoint, solidEntryPointIndex := tangle.SolidEntryPointsIndex(hornet.Hash(txHash)); isSolidEntryPoint {
+			if solidEntryPointIndex, isSolidEntryPoint := tangle.SolidEntryPointsIndex(hornet.Hash(txHash)); isSolidEntryPoint {
 				if int(solidEntryPointIndex) < lowestAllowedSnapshotIndex {
 					// tx references a solid entry point that is older than lowestAllowedSnapshotIndex
 					BelowDepthMemoizationCache.Set(cachedTailTx.GetTransaction().GetTxHash(), true)

--- a/plugins/tangle/revalidation.go
+++ b/plugins/tangle/revalidation.go
@@ -85,11 +85,6 @@ func revalidateDatabase() error {
 		return ErrSnapshotIndexWrong
 	}
 
-	// Delete the corrupted ledger state
-	if err = tangle.DeleteLedgerBalancesInDatabase(); err != nil {
-		return err
-	}
-
 	// Store the snapshot balances as the current valid ledger
 	if err = tangle.StoreLedgerBalancesInDatabase(snapshotBalances, snapshotIndex); err != nil {
 		return err

--- a/plugins/tipselection/tipselection.go
+++ b/plugins/tipselection/tipselection.go
@@ -63,7 +63,7 @@ func SelectTips(depth uint, reference *hornet.Hash) (hornet.Hashes, *tipselectio
 	walkStats := &tipselection.TipSelStats{EntryPoint: cachedMs.GetBundle().GetTailHash().Trytes(), Depth: uint64(depth)}
 
 	// compute the range in which we allow approvers to reference transactions in
-	lowerAllowedSnapshotIndex := int(math.Max(float64(int(tangle.GetSolidMilestoneIndex())-maxDepth), float64(0)))
+	lowestAllowedSnapshotIndex := int(math.Max(float64(int(tangle.GetSolidMilestoneIndex())-maxDepth), float64(0)))
 
 	diff := map[string]int64{}
 	approved := map[string]struct{}{}
@@ -111,7 +111,7 @@ func SelectTips(depth uint, reference *hornet.Hash) (hornet.Hashes, *tipselectio
 		}
 		cachedRefBundle = cachedBndl
 
-		if tanglePlugin.IsBelowMaxDepth(cachedBndl.GetBundle().GetTail(), lowerAllowedSnapshotIndex, false) { // tx pass +1
+		if tanglePlugin.IsBelowMaxDepth(cachedBndl.GetBundle().GetTail(), lowestAllowedSnapshotIndex, false) { // tx pass +1
 			cachedBndl.Release(true) // bundle -1
 			return nil, nil, errors.Wrap(ErrReferenceNotValid, "transaction is below max depth")
 		}
@@ -224,7 +224,7 @@ func SelectTips(depth uint, reference *hornet.Hash) (hornet.Hashes, *tipselectio
 					continue
 				}
 
-				if tanglePlugin.IsBelowMaxDepth(cachedBndl.GetBundle().GetTail(), lowerAllowedSnapshotIndex, false) { // tx pass +1
+				if tanglePlugin.IsBelowMaxDepth(cachedBndl.GetBundle().GetTail(), lowestAllowedSnapshotIndex, false) { // tx pass +1
 					approverHashes = removeElementWithoutPreservingOrder(approverHashes, candidateIndex)
 					cachedCandidateTx.Release() // tx -1
 					cachedBndl.Release()        // bundle -1

--- a/plugins/webapi/consistency.go
+++ b/plugins/webapi/consistency.go
@@ -54,7 +54,7 @@ func checkConsistency(i interface{}, c *gin.Context, _ <-chan struct{}) {
 	}
 
 	// compute the range in which we allow approvers to reference transactions in
-	lowerAllowedSnapshotIndex := int(math.Max(float64(int(tangle.GetSolidMilestoneIndex())-maxDepth), float64(0)))
+	lowestAllowedSnapshotIndex := int(math.Max(float64(int(tangle.GetSolidMilestoneIndex())-maxDepth), float64(0)))
 
 	diff := map[string]int64{}
 	approved := map[string]struct{}{}
@@ -116,7 +116,7 @@ func checkConsistency(i interface{}, c *gin.Context, _ <-chan struct{}) {
 		}
 
 		// Check below max depth
-		if tanglePlugin.IsBelowMaxDepth(cachedBndl.GetBundle().GetTail(), lowerAllowedSnapshotIndex, true) { // tx pass +1
+		if tanglePlugin.IsBelowMaxDepth(cachedBndl.GetBundle().GetTail(), lowestAllowedSnapshotIndex, true) { // tx pass +1
 			info := fmt.Sprint("tails are not consistent (below max depth): ", t)
 			c.JSON(http.StatusOK, CheckConsistencyReturn{State: false, Info: info})
 			cachedBndl.Release(true) // bundle -1


### PR DESCRIPTION
This PR fixes the "below max depth" calculation for solid entry points.

- SEP index is now checked if we hit a SEP during "below-max-depth" check. If we are below lowestAllowedSnapshotIndex, we are below max depth. If not, we are not.
- Networks must be bootstrapped with global snapshots to mark Genesis tx as SEP with correct index.
- Genesis Tx is not set as SEP anymore by local snapshots.

This PR also introduces a flag to force the loading of a global snapshot even if a database already exists. Old Txs are kept in the database, only SEP's and the ledger state is replaces with the state in the snapshot (snapshot index must be higher than LSMI in DB).