### PR TITLE
Fix synchronization with IRI nodes

### DIFF
--- a/pkg/peering/peering.go
+++ b/pkg/peering/peering.go
@@ -20,6 +20,7 @@ import (
 	"github.com/gohornet/hornet/pkg/peering/peer"
 	"github.com/gohornet/hornet/pkg/protocol"
 	"github.com/gohornet/hornet/pkg/protocol/handshake"
+	"github.com/gohornet/hornet/pkg/protocol/sting"
 )
 
 var (
@@ -260,6 +261,22 @@ func (m *Manager) ForAllConnected(f PeerConsumerFunc) {
 			break
 		}
 	}
+}
+
+// AnySTINGPeerConnected returns true if any of the connected, handshaked peers supports the STING protocol.
+func (m *Manager) AnySTINGPeerConnected() bool {
+	stingPeerConnected := false
+
+	m.ForAllConnected(func(p *peer.Peer) bool {
+		if !p.Protocol.Supports(sting.FeatureSet) {
+			return false
+		}
+
+		stingPeerConnected = true
+		return true
+	})
+
+	return stingPeerConnected
 }
 
 // PeerInfos returns snapshots of the currently connected and in the reconnect pool residing peers.

--- a/pkg/protocol/processor/work_unit.go
+++ b/pkg/protocol/processor/work_unit.go
@@ -129,13 +129,6 @@ func (wu *WorkUnit) replyToAllRequests(requestQueue rqueue.Queue) {
 		// if requested transaction hash is equal to the hash of the received transaction
 		// it means that the given peer is synchronized
 		isPeerSynced := bytes.Equal(wu.receivedTxHash, peerRequest.requestedTxHash)
-		request := requestQueue.Next()
-
-		// if the peer is synced  and we have no request ourselves,
-		// we don't need to reply
-		if isPeerSynced && request == nil {
-			continue
-		}
 
 		var cachedTxToSend *tangle.CachedTransaction
 
@@ -148,6 +141,14 @@ func (wu *WorkUnit) replyToAllRequests(requestQueue rqueue.Queue) {
 			}
 
 			cachedTxToSend = tangle.GetCachedTransactionOrNil(hornet.Hash(peerRequest.requestedTxHash)) // tx +1
+		}
+
+		request := requestQueue.Next()
+
+		// if the peer is synced  and we have no request ourselves,
+		// we don't need to reply
+		if isPeerSynced && request == nil {
+			continue
 		}
 
 		if cachedTxToSend == nil {
@@ -171,7 +172,7 @@ func (wu *WorkUnit) replyToAllRequests(requestQueue rqueue.Queue) {
 
 		// if we have no request ourselves, we use the hash of the transaction which we
 		// send in order to signal that we are synchronized.
-		var ownRequestHash []byte
+		var ownRequestHash hornet.Hash
 		if request == nil {
 			ownRequestHash = cachedTxToSend.GetTransaction().GetTxHash()
 		} else {

--- a/plugins/tangle/solidifier.go
+++ b/plugins/tangle/solidifier.go
@@ -287,8 +287,6 @@ func solidifyMilestone(newMilestoneIndex milestone.Index, force bool) {
 	- Everytime a request queue gets empty, start the solidifier for the next known non-solid milestone
 	- If tx are missing, they are requested by the solidifier
 	- The traversion can be aborted with a signal and restarted
-	- If we miss more than WARP_SYNC_THRESHOLD milestones in our requests, request them via warp sync
-
 	*/
 
 	if !force {
@@ -297,6 +295,14 @@ func solidifyMilestone(newMilestoneIndex milestone.Index, force bool) {
 				- newMilestoneIndex==0 (triggersignal) and solidifierMilestoneIndex==0 (no ongoing solidification)
 				- newMilestoneIndex==solidMilestoneIndex+1 (next milestone)
 				- newMilestoneIndex!=0 (new milestone received) and solidifierMilestoneIndex!=0 (ongoing solidification) and newMilestoneIndex<solidifierMilestoneIndex (milestone older than ongoing solidification)
+
+			The following events trigger the solidifier in the node:
+				- new valid milestone was processed (newMilestoneIndex=index, force=false)
+				- a milestone was missing in the cone at solidifier run (newMilestoneIndex=0, force=true)
+				- WebAPI call (newMilestoneIndex=0, force=true)
+				- milestones in warp sync range were already in database at warpsync startup (newMilestoneIndex==0, force=true)
+				- another milestone was successfully solidified (newMilestoneIndex=0, force=false)
+				- request queue gets empty and node is not synced (newMilestoneIndex=0, force=true)
 		*/
 
 		solidifierMilestoneIndexLock.RLock()

--- a/plugins/tangle/solidifier.go
+++ b/plugins/tangle/solidifier.go
@@ -295,6 +295,7 @@ func solidifyMilestone(newMilestoneIndex milestone.Index, force bool) {
 				- newMilestoneIndex==0 (triggersignal) and solidifierMilestoneIndex==0 (no ongoing solidification)
 				- newMilestoneIndex==solidMilestoneIndex+1 (next milestone)
 				- newMilestoneIndex!=0 (new milestone received) and solidifierMilestoneIndex!=0 (ongoing solidification) and newMilestoneIndex<solidifierMilestoneIndex (milestone older than ongoing solidification)
+				- newMilestoneIndex!=0 (new milestone received) and solidifierMilestoneIndex==0 (no ongoing solidification) and RequestQueue().Empty() (request queue is already empty)
 
 			The following events trigger the solidifier in the node:
 				- new valid milestone was processed (newMilestoneIndex=index, force=false)
@@ -309,7 +310,8 @@ func solidifyMilestone(newMilestoneIndex milestone.Index, force bool) {
 		triggerSignal := (newMilestoneIndex == 0) && (solidifierMilestoneIndex == 0)
 		nextMilestoneSignal := newMilestoneIndex == tangle.GetSolidMilestoneIndex()+1
 		olderMilestoneDetected := (newMilestoneIndex != 0) && ((solidifierMilestoneIndex != 0) && (newMilestoneIndex < solidifierMilestoneIndex))
-		if !(triggerSignal || nextMilestoneSignal || olderMilestoneDetected) {
+		newMilestoneReqQueueEmptySignal := (solidifierMilestoneIndex == 0) && (newMilestoneIndex != 0) && gossip.RequestQueue().Empty()
+		if !(triggerSignal || nextMilestoneSignal || olderMilestoneDetected || newMilestoneReqQueueEmptySignal) {
 			// Do not run solidifier
 			solidifierMilestoneIndexLock.RUnlock()
 			return


### PR DESCRIPTION
This PR fixes syncing problems if HORNET wants to sync with IRI neighbors only.

There was a problem in the request queue if requests got dequeued from the list, and were not sent to a neighbor, the request was ignored for the next 1.5 seconds, until it got enqueued again. This made syncing impossible.

Since all requests are dequeued periodically in the "STINGRequester" background worker, the queue was drained all the time if there was no STING neighbor. The dequeued requests were not sent to IRI since it doesn't support the STING protocol.

Now we only dequeue a request from the request queue, if it really was sent to one of our neighbors.