### PR TITLE
Self-contained Dockerfile.dev now properly compiles and run Hornet

### DIFF
--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -27,9 +27,7 @@ RUN CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build -tags="pow_avx" \
 ############################
 # Image
 ############################
-# using static nonroot image
-# user:group is nonroot:nonroot, uid:gid = 65532:65532
-FROM gcr.io/distroless/static@sha256:23aa732bba4c8618c0d97c26a72a32997363d591807b0d4c31b0bbc8a774bddf
+FROM alpine:latest
 
 EXPOSE 8081/tcp
 EXPOSE 14265/tcp
@@ -44,5 +42,12 @@ COPY ./config_devnet.json /app/config_devnet.json
 COPY ./peering.json /app/peering.json
 COPY ./profiles.json /app/profiles.json
 COPY ./mqtt_config.json /app/mqtt_config.json
+
+RUN addgroup --gid 39999 hornet \
+ && adduser -h /app -s /bin/sh -G hornet -u 39999 -D hornet \
+ && chown hornet:hornet -R /app
+
+WORKDIR "/app"
+USER hornet
 
 ENTRYPOINT ["/app/hornet"]


### PR DESCRIPTION
# Description

This PR provides a self-contained way to compile and package Hornet code in a docker image, with proper permissions and runtime configs and db folders.
The base image has been changed to `alpine:latest` since otherwise we don't have a shell to create the user Hornet is running under and the corresponding folders with the right permissions that the code expects.
This is the Dockerfile that IMHO should be used in the CD pipelines.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

# How Has This Been Tested?

Syncing from fresh image generated with the amended Dockerfile.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have tested my code extensively
