### PR TITLE
Disable timestamp validation to allow permanode migration

### DIFF
--- a/pkg/protocol/processor/processor.go
+++ b/pkg/protocol/processor/processor.go
@@ -351,21 +351,8 @@ func (proc *Processor) processWorkUnit(wu *WorkUnit, p *peer.Peer) {
 	wu.replyToAllRequests(proc.requestQueue)
 }
 
-// checks whether the given transaction's timestamp is valid.
-// the timestamp is automatically valid if the transaction is a solid entry point.
-// the timestamp should be in the range of +/- 10 minutes to current time.
+// timestamp is always valid so we can import old transactions
+// we don't care about broadcasting them later in this version
 func (proc *Processor) ValidateTimestamp(hornetTx *hornet.Transaction) (valid, broadcast bool) {
-	snapshotTimestamp := tangle.GetSnapshotInfo().Timestamp
-	txTimestamp := hornetTx.GetTimestamp()
-
-	pastTime := time.Now().Add(-10 * time.Minute).Unix()
-	futureTime := time.Now().Add(10 * time.Minute).Unix()
-
-	// we need to accept all txs since the snapshot timestamp for synchronization
-	if txTimestamp >= snapshotTimestamp && txTimestamp < futureTime {
-		return true, txTimestamp >= pastTime
-	}
-
-	// ignore invalid timestamps for solid entry points
-	return tangle.SolidEntryPointsContain(hornetTx.GetTxHash()), false
+	return true, false
 }


### PR DESCRIPTION
# Description

We disable timestamp validation so that old transactions that are broadcasted to the node are not rejected by it.
We disable forwarding the transactions after receiving them because there is no need.

*This should not be merged to master. It should be an alternate temporary version.*
After migration the user can switch to normal Hornet.

Fixes #4 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

# How Has This Been Tested?

Run migration and saw that hornet accepts old data.
No errors appeared

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have tested my code extensively
