### PR TITLE
fix GHA PR #6

### DIFF
--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -24,3 +24,12 @@ jobs:
 
       - name: Docker push
         run: docker push iotaledger/hornet:$(git rev-parse --short "$GITHUB_SHA")
+
+      - name: Docker push - Release
+        run: |
+          export RELEASE_VERSION=${GITHUB_REF#refs/*/}
+          docker tag iotaledger/hornet:$(git rev-parse --short "$GITHUB_SHA") iotaledger/hornet:$RELEASE_VERSION
+          docker tag iotaledger/hornet:$(git rev-parse --short "$GITHUB_SHA") iotaledger/hornet:latest
+          docker push iotaledger/hornet:$RELEASE_VERSION
+          docker push iotaledger/hornet:latest
+        if: startsWith(github.ref, 'refs/tags/v')        

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -68,19 +68,6 @@ builds:
     goarch:
       - amd64
 
-# Docker
-dockers:
-  # Docker AMD64
-  - goos: linux
-    goarch: amd64
-    image_templates:
-      - "iotaledger/hornet:latest"
-      - "iotaledger/hornet:{{ .Tag }}"
-    binaries:
-      - hornet
-    dockerfile: docker/Dockerfile.dev
-    skip_push: auto
-
 # Archives
 archives:
   - format: tar.gz


### PR DESCRIPTION
I am opening a follow-up PR to https://github.com/iotaledger/hornet/pull/6 that I merged because once merged and the `test_release` pipeline triggered (the one that tries to build the docker image with `Dockerfile.dev` via the `goreleaser`), it failed.
I didn't catch that up on my tests because I was mistakenly testing while feeding `Dockerfile.goreleaser` to the `goreleaser`.

It seems that the `goreleaser` does not copy the source working directory in prior to building the image with `Dockerfile.dev`. As a result, the ensuing commands that leveraged those files (for instance `COPY go.mod` or even `go build ...`) failed.

The immediate solution to that is to try using the `extra_files` flag in the `dockers:` section of `.goreleaser.yml` and to tell the `goreleaser` to keep all those files ([documentation here](https://goreleaser.com/customization/docker/)). 
However this flag doesn't accept wildcards.

As a solution, I went down with the alternative discussed with @karimodm here: https://github.com/iotaledger/hornet/pull/6#discussion_r461496081
Now the release workflow is working as such:
- Manually create a release named HORNET-X.X.X and tagged with the version vX.X.X, add the changelog for said version and publish it. 
- This triggers the release job that completes this very release by *ONLY* adding binaries
- The `build_docker` job is also triggered upon that tag, and publishes the official image to iotaledger/hornet:vX.X.X