### PR TITLE
Adding automatic PPA update when release

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -31,4 +31,3 @@ Please describe the tests that you ran to verify your changes. Provide instructi
 - [ ] I have commented my code, particularly in hard-to-understand areas
 - [ ] I have made corresponding changes to the documentation
 - [ ] I have tested my code extensively
-- [ ] I have selected the `develop` branch as the target branch

--- a/.github/workflows/build_HORNET.yml
+++ b/.github/workflows/build_HORNET.yml
@@ -1,10 +1,10 @@
 name: Build HORNET
+
 on:
   push:
     branches:
       - master
-      - develop
-  pull_request:
+    pull_request:
 
 jobs:
   build:

--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -17,31 +17,12 @@ jobs:
         run: docker build . -f docker/Dockerfile.dev -t iotaledger/hornet:$(git rev-parse --short "$GITHUB_SHA") 
 
       - name: Test HORNET Docker image
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-        run: docker run --rm --name hornet hornet:latest --version 2>/dev/null | grep -q "HORNET"
-=======
-        run: docker run --rm --name hornet sadjy/hornet:latest --help 2>/dev/null | grep -q "help requested"
-=======
-        run: docker run --rm --name hornet iotaledger/hornet:latest --help 2>/dev/null | grep -q "help requested"
->>>>>>> PR preparation
-=======
-        run: docker run --rm --name hornet iotaledger/hornet:$(git rev-parse --short "$GITHUB_SHA") --help 2>/dev/null | grep -q "help requested"
->>>>>>> correcting mistakes build_docker
+        run: docker run --rm --name hornet iotaledger/hornet:$(git rev-parse --short "$GITHUB_SHA") --version 2>/dev/null | grep -q "HORNET"
 
       - name: Docker login
         run: docker login -u ${{ secrets.DOCKER_USERNAME }} -p ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Docker push
-<<<<<<< HEAD
-<<<<<<< HEAD
-        run: docker push sadjy/hornet:$(git rev-parse --short "$GITHUB_SHA")
->>>>>>> pushing changes
-=======
-        run: docker push iotaledger/hornet:$(git rev-parse --short "$GITHUB_SHA")
->>>>>>> PR preparation
-=======
         run: docker push iotaledger/hornet:$(git rev-parse --short "$GITHUB_SHA")
 
       - name: Docker push - Release
@@ -52,4 +33,3 @@ jobs:
           docker push iotaledger/hornet:$RELEASE_VERSION
           docker push iotaledger/hornet:latest
         if: startsWith(github.ref, 'refs/tags/v')        
->>>>>>> fix GHA PR

--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -1,13 +1,9 @@
 name: Build Docker
+
 on:
   push:
-    paths:
-      - "docker/Dockerfile"
-      - "docker-compose.yml"
-  pull_request:
-    paths:
-      - "docker/Dockerfile"
-      - "docker-compose.yml"
+    branch:
+      - master
 
 jobs:
   build:
@@ -18,7 +14,42 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Build HORNET Docker image
-        run: docker build . --file docker/Dockerfile --tag hornet:latest
+        run: docker build . -f docker/Dockerfile.dev -t iotaledger/hornet:$(git rev-parse --short "$GITHUB_SHA") 
 
       - name: Test HORNET Docker image
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
         run: docker run --rm --name hornet hornet:latest --version 2>/dev/null | grep -q "HORNET"
+=======
+        run: docker run --rm --name hornet sadjy/hornet:latest --help 2>/dev/null | grep -q "help requested"
+=======
+        run: docker run --rm --name hornet iotaledger/hornet:latest --help 2>/dev/null | grep -q "help requested"
+>>>>>>> PR preparation
+=======
+        run: docker run --rm --name hornet iotaledger/hornet:$(git rev-parse --short "$GITHUB_SHA") --help 2>/dev/null | grep -q "help requested"
+>>>>>>> correcting mistakes build_docker
+
+      - name: Docker login
+        run: docker login -u ${{ secrets.DOCKER_USERNAME }} -p ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Docker push
+<<<<<<< HEAD
+<<<<<<< HEAD
+        run: docker push sadjy/hornet:$(git rev-parse --short "$GITHUB_SHA")
+>>>>>>> pushing changes
+=======
+        run: docker push iotaledger/hornet:$(git rev-parse --short "$GITHUB_SHA")
+>>>>>>> PR preparation
+=======
+        run: docker push iotaledger/hornet:$(git rev-parse --short "$GITHUB_SHA")
+
+      - name: Docker push - Release
+        run: |
+          export RELEASE_VERSION=${GITHUB_REF#refs/*/}
+          docker tag iotaledger/hornet:$(git rev-parse --short "$GITHUB_SHA") iotaledger/hornet:$RELEASE_VERSION
+          docker tag iotaledger/hornet:$(git rev-parse --short "$GITHUB_SHA") iotaledger/hornet:latest
+          docker push iotaledger/hornet:$RELEASE_VERSION
+          docker push iotaledger/hornet:latest
+        if: startsWith(github.ref, 'refs/tags/v')        
+>>>>>>> fix GHA PR

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,6 +1,7 @@
 name: GolangCIlint
 
-on: [pull_request]
+on:
+  pull_request:
 
 jobs:
   golangci-lint:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,8 +5,8 @@ on:
     types: [published]
 
 jobs:
-  Release:
-    name: Release
+  release:
+    name: release
     runs-on: [ubuntu-latest]
     container:
       image: iotmod/goreleaser-cgo-cross-compiler:1.14.4
@@ -19,7 +19,7 @@ jobs:
         env:
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-        run: docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
+        run: docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD      
       - name: Release HORNET
         run: goreleaser --rm-dist
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,8 +37,6 @@ jobs:
           apt update && apt install aptly moreutils jq -y
           aptly repo create hornet
           aptly repo add hornet dist/hornet_*_amd64.deb 
-          aptly repo list
-          aptly repo show hornet
           jq '.S3PublishEndpoints += { "ppa-bucket" : { "region" : "${{ secrets.AWS_DEFAULT_REGION }}", "bucket" : "${{ secrets.AWS_BUCKET_NAME }}", "acl" : "public-read" } }' ~/.aptly.conf | sponge ~/.aptly.conf
           echo "${{ secrets.GPG_PRIVATE_KEY }}" > /tmp/private.key 
           echo "${{ secrets.GPG_PASSPHRASE }}" | gpg --batch --yes --passphrase-fd 0 --import /tmp/private.key

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,3 +24,22 @@ jobs:
         run: goreleaser --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          
+      - name: Upload to PPA
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+        run: |
+          mkdir -p ~/.gnupg && apt-key adv --keyserver pool.sks-keyservers.net --recv-keys ED75B5A4483DA07C
+          echo "deb http://repo.aptly.info/ squeeze main" >> /etc/apt/sources.list
+          apt update && apt install aptly moreutils jq -y
+          aptly repo create hornet
+          aptly repo add hornet dist/hornet_*_amd64.deb 
+          aptly repo list
+          aptly repo show hornet
+          jq '.S3PublishEndpoints += { "ppa-bucket" : { "region" : "${{ secrets.AWS_DEFAULT_REGION }}", "bucket" : "${{ secrets.AWS_BUCKET_NAME }}", "acl" : "public-read" } }' ~/.aptly.conf | sponge ~/.aptly.conf
+          echo "${{ secrets.GPG_PRIVATE_KEY }}" > /tmp/private.key 
+          echo "${{ secrets.GPG_PASSPHRASE }}" | gpg --batch --yes --passphrase-fd 0 --import /tmp/private.key
+          aptly publish repo -distribution="stable" -passphrase="$GPG_PASSPHRASE" -batch hornet s3:ppa-bucket:hornet

--- a/.github/workflows/snyk-monitor-golang.yml
+++ b/.github/workflows/snyk-monitor-golang.yml
@@ -1,8 +1,10 @@
 name: Monitor Golang dependencies with Snyk
+
 on:
   push:
     branches:
-      - develop
+      - master
+
 jobs:
   security:
     runs-on: ubuntu-latest
@@ -14,5 +16,5 @@ jobs:
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
-          args: --org=gohornet
+          args: --org=iotaledger
           command: monitor

--- a/.github/workflows/snyk-test-golang.yml
+++ b/.github/workflows/snyk-test-golang.yml
@@ -1,5 +1,11 @@
 name: Test Golang dependencies with Snyk
-on: [push, pull_request]
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
 jobs:
   security:
     # Only run on push events or PRs from gohornet/hornet, skip on PRs from forks
@@ -14,4 +20,4 @@ jobs:
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
-          args: --org=gohornet
+          args: --org=iotaledger

--- a/.github/workflows/test_HORNET.yml
+++ b/.github/workflows/test_HORNET.yml
@@ -1,9 +1,9 @@
 name: Test HORNET
+
 on:
   push:
     branches:
       - master
-      - develop
   pull_request:
 
 jobs:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -15,7 +15,7 @@ builds:
     env:
       - CGO_ENABLED=1
     ldflags:
-      - -s -w -X github.com/gohornet/hornet/plugins/cli.AppVersion={{.Version}}
+      - -s -w -X github.com/iotaledger/hornet/plugins/cli.AppVersion={{.Version}}
     flags:
       - -tags=pow_avx
     main: main.go
@@ -30,7 +30,7 @@ builds:
       - CGO_ENABLED=1
       - CC=aarch64-linux-musl-gcc
     ldflags:
-      - -s -w -X github.com/gohornet/hornet/plugins/cli.AppVersion={{.Version}}
+      - -s -w -X github.com/iotaledger/hornet/plugins/cli.AppVersion={{.Version}}
       - -w -extldflags "-static"
     flags:
       - -tags=pow_arm_c128
@@ -47,7 +47,7 @@ builds:
       - CC=x86_64-w64-mingw32-gcc
       - CXX=x86_64-w64-mingw32-g++
     ldflags:
-      - -s -w -X github.com/gohornet/hornet/plugins/cli.AppVersion={{.Version}}
+      - -s -w -X github.com/iotaledger/hornet/plugins/cli.AppVersion={{.Version}}
     flags:
       - -tags=pow_avx
     main: main.go
@@ -61,25 +61,12 @@ builds:
     env:
       - CGO_ENABLED=0
     ldflags:
-      - -s -w -X github.com/gohornet/hornet/plugins/cli.AppVersion={{.Version}}
+      - -s -w -X github.com/iotaledger/hornet/plugins/cli.AppVersion={{.Version}}
     main: main.go
     goos:
       - darwin
     goarch:
       - amd64
-
-# Docker
-dockers:
-  # Docker AMD64
-  - goos: linux
-    goarch: amd64
-    image_templates:
-      - "gohornet/hornet:latest"
-      - "gohornet/hornet:{{ .Tag }}"
-    binaries:
-      - hornet
-    dockerfile: docker/Dockerfile.goreleaser
-    skip_push: auto
 
 # Archives
 archives:
@@ -112,8 +99,8 @@ nfpms:
     file_name_template: '{{ tolower .ProjectName }}_{{ replace .Version "v" "" }}_{{ .Arch }}'
     vendor: GoReleaser
     license: Apache 2.0
-    maintainer: GoHORNET
-    homepage: https://github.com/gohornet/hornet
+    maintainer: iotaledger
+    homepage: https://github.com/iotaledger/hornet
     description: HORNET is a powerful IOTA fullnode software.
     formats:
       - deb
@@ -166,5 +153,5 @@ release:
   prerelease: auto
   name_template: "{{.ProjectName}}-{{.Version}}"
   github:
-    owner: gohornet
+    owner: iotaledger
     name: hornet

--- a/config.json
+++ b/config.json
@@ -51,11 +51,15 @@
       "intervalSynced": 50,
       "intervalUnsynced": 1000,
       "path": "snapshots/mainnet/export.bin",
+<<<<<<< HEAD
       "downloadURLs": [
         "https://ls.manapotion.io/export.bin",
         "https://x-vps.com/export.bin",
         "https://dbfiles.iota.org/mainnet/hornet/latest-export.bin"
       ]
+=======
+      "downloadURL": "https://dbfiles.iota.org/mainnet/hornet/latest-export.bin"
+>>>>>>> change snapshot url to dbfiles (#1)
     },
     "global": {
       "path": "snapshotMainnet.txt",

--- a/config.json
+++ b/config.json
@@ -51,15 +51,9 @@
       "intervalSynced": 50,
       "intervalUnsynced": 1000,
       "path": "snapshots/mainnet/export.bin",
-<<<<<<< HEAD
       "downloadURLs": [
-        "https://ls.manapotion.io/export.bin",
-        "https://x-vps.com/export.bin",
         "https://dbfiles.iota.org/mainnet/hornet/latest-export.bin"
       ]
-=======
-      "downloadURL": "https://dbfiles.iota.org/mainnet/hornet/latest-export.bin"
->>>>>>> change snapshot url to dbfiles (#1)
     },
     "global": {
       "path": "snapshotMainnet.txt",

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,15 +1,15 @@
 FROM alpine:latest
 
-ARG REPO="gohornet/hornet"
+ARG REPO="iotaledger/hornet"
 ARG TAG=latest
 ARG ARCH=x86_64
 ARG OS=Linux
 
 LABEL org.label-schema.description="HORNET - The IOTA community node"
-LABEL org.label-schema.name="gohornet/hornet"
+LABEL org.label-schema.name="iotaledger/hornet"
 LABEL org.label-schema.schema-version="1.0"
-LABEL org.label-schema.vcs-url="https://github.com/gohornet/hornet"
-LABEL org.label-schema.usage="https://github.com/gohornet/hornet/blob/master/DOCKER.md"
+LABEL org.label-schema.vcs-url="https://github.com/iotaledger/hornet"
+LABEL org.label-schema.usage="https://github.com/iotaledger/hornet/blob/master/DOCKER.md"
 
 WORKDIR /app
 

--- a/docker/Dockerfile.arm64
+++ b/docker/Dockerfile.arm64
@@ -1,15 +1,15 @@
 FROM alpine:latest
 
-ARG REPO="gohornet/hornet"
+ARG REPO="iotaledger/hornet"
 ARG TAG=latest
 ARG ARCH=ARM64
 ARG OS=Linux
 
 LABEL org.label-schema.description="HORNET - The IOTA community node"
-LABEL org.label-schema.name="gohornet/hornet"
+LABEL org.label-schema.name="iotaledger/hornet"
 LABEL org.label-schema.schema-version="1.0"
-LABEL org.label-schema.vcs-url="https://github.com/gohornet/hornet"
-LABEL org.label-schema.usage="https://github.com/gohornet/hornet/blob/master/DOCKER.md"
+LABEL org.label-schema.vcs-url="https://github.com/iotaledger/hornet"
+LABEL org.label-schema.usage="https://github.com/iotaledger/hornet/blob/master/DOCKER.md"
 
 WORKDIR /app
 

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -27,9 +27,7 @@ RUN CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build -tags="pow_avx" \
 ############################
 # Image
 ############################
-# using static nonroot image
-# user:group is nonroot:nonroot, uid:gid = 65532:65532
-FROM gcr.io/distroless/static@sha256:23aa732bba4c8618c0d97c26a72a32997363d591807b0d4c31b0bbc8a774bddf
+FROM alpine:latest
 
 EXPOSE 8081/tcp
 EXPOSE 14265/tcp
@@ -44,5 +42,12 @@ COPY ./config_devnet.json /app/config_devnet.json
 COPY ./peering.json /app/peering.json
 COPY ./profiles.json /app/profiles.json
 COPY ./mqtt_config.json /app/mqtt_config.json
+
+RUN addgroup --gid 39999 hornet \
+ && adduser -h /app -s /bin/sh -G hornet -u 39999 -D hornet \
+ && chown hornet:hornet -R /app
+
+WORKDIR "/app"
+USER hornet
 
 ENTRYPOINT ["/app/hornet"]

--- a/docker/Dockerfile.goreleaser
+++ b/docker/Dockerfile.goreleaser
@@ -2,10 +2,10 @@ FROM alpine:latest
 WORKDIR /app
 
 LABEL org.label-schema.description="HORNET - The IOTA community node"
-LABEL org.label-schema.name="gohornet/hornet"
+LABEL org.label-schema.name="iotaledger/hornet"
 LABEL org.label-schema.schema-version="1.0"
-LABEL org.label-schema.vcs-url="https://github.com/gohornet/hornet"
-LABEL org.label-schema.usage="https://github.com/gohornet/hornet/blob/master/DOCKER.md"
+LABEL org.label-schema.vcs-url="https://github.com/iotaledger/hornet"
+LABEL org.label-schema.usage="https://github.com/iotaledger/hornet/blob/master/DOCKER.md"
 
 COPY ["hornet", "/app/"]
 RUN apk --no-cache add ca-certificates gnupg wget tini\


### PR DESCRIPTION
As stated in the title.

Our Debian PPA will be hosted at https://ppa.iota.org.
The modifications below aim to update this PPA for Hornet at every release we do.

Both the software install + update on Debian/Ubuntu and the GHA automatic update of the PPA have been tested.

Note: Already manually put Hornet 0.4.2 in the PPA.  