### PR TITLE
Fix revalidation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/google/go-querystring v1.0.0 // indirect
 	github.com/gorilla/websocket v1.4.2
 	github.com/hashicorp/go-version v1.2.1 // indirect
-	github.com/iotaledger/hive.go v0.0.0-20200808164905-1dbaafdaa846
+	github.com/iotaledger/hive.go v0.0.0-20200810103552-94bbf59c54fa
 	github.com/iotaledger/iota.go v1.0.0-beta.15.0.20200622064951-7fa4854396b2
 	github.com/labstack/echo/v4 v4.1.16
 	github.com/labstack/gommon v0.3.0
@@ -36,8 +36,8 @@ require (
 	go.etcd.io/bbolt v1.3.5
 	go.uber.org/atomic v1.6.0
 	golang.org/x/crypto v0.0.0-20200728195943-123391ffb6de
-	golang.org/x/sys v0.0.0-20200806125547-5acd03effb82 // indirect
+	golang.org/x/sys v0.0.0-20200808120158-1030fc2bf1d9 // indirect
 	golang.org/x/text v0.3.3 // indirect
-	google.golang.org/genproto v0.0.0-20200806141610-86f49bd18e98 // indirect
+	google.golang.org/genproto v0.0.0-20200808173500-a06252235341 // indirect
 	google.golang.org/grpc v1.31.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -213,8 +213,8 @@ github.com/hashicorp/serf v0.8.2/go.mod h1:6hOLApaqBFA1NXqRQAsxw9QxuDEvNxSQRwA/J
 github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
-github.com/iotaledger/hive.go v0.0.0-20200808164905-1dbaafdaa846 h1:ufAo/4RPNb/Erx1ChHqxeoFxEUD7pVJMlqSSWtidJBA=
-github.com/iotaledger/hive.go v0.0.0-20200808164905-1dbaafdaa846/go.mod h1:tLI+HS0amqY5YqClfFZDHlFM7eeIZjoU25Oj1u9jCzQ=
+github.com/iotaledger/hive.go v0.0.0-20200810103552-94bbf59c54fa h1:mvOuUWh/5OWtO9j3gHgtAuYhvFtTn9XljreNMuaTpsA=
+github.com/iotaledger/hive.go v0.0.0-20200810103552-94bbf59c54fa/go.mod h1:tLI+HS0amqY5YqClfFZDHlFM7eeIZjoU25Oj1u9jCzQ=
 github.com/iotaledger/iota.go v1.0.0-beta.15/go.mod h1:Rn6v5hLAn8YBaJlRu1ZQdPAgKlshJR1PTeLQaft2778=
 github.com/iotaledger/iota.go v1.0.0-beta.15.0.20200622064951-7fa4854396b2 h1:6SPLL98DbdHUH+DHuPwYPkgZK5QwpXu9wdOiFdXb3Ps=
 github.com/iotaledger/iota.go v1.0.0-beta.15.0.20200622064951-7fa4854396b2/go.mod h1:Rn6v5hLAn8YBaJlRu1ZQdPAgKlshJR1PTeLQaft2778=
@@ -559,8 +559,8 @@ golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd h1:xhmwyvizuTgC2qz7ZlMluP20u
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200615200032-f1bc736245b1 h1:ogLJMz+qpzav7lGMh10LMvAkM/fAoGlaiiHYiFYdm80=
 golang.org/x/sys v0.0.0-20200615200032-f1bc736245b1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200806125547-5acd03effb82 h1:6cBnXxYO+CiRVrChvCosSv7magqTPbyAgz1M8iOv5wM=
-golang.org/x/sys v0.0.0-20200806125547-5acd03effb82/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200808120158-1030fc2bf1d9 h1:yi1hN8dcqI9l8klZfy4B8mJvFmmAxJEePIQQFNSd7Cs=
+golang.org/x/sys v0.0.0-20200808120158-1030fc2bf1d9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=
@@ -618,8 +618,8 @@ google.golang.org/genproto v0.0.0-20190911173649-1774047e7e51/go.mod h1:IbNlFCBr
 google.golang.org/genproto v0.0.0-20191108220845-16a3f7862a1a h1:Ob5/580gVHBJZgXnff1cZDbG+xLtMVE5mDRTe+nIsX4=
 google.golang.org/genproto v0.0.0-20191108220845-16a3f7862a1a/go.mod h1:n3cpQtvxv34hfy77yVDNjmbRyujviMdxYliBSkLhpCc=
 google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013/go.mod h1:NbSheEEYHJ7i3ixzK3sjbqSGDJWnxyFXZblF3eUsNvo=
-google.golang.org/genproto v0.0.0-20200806141610-86f49bd18e98 h1:LCO0fg4kb6WwkXQXRQQgUYsFeFb5taTX5WAx5O/Vt28=
-google.golang.org/genproto v0.0.0-20200806141610-86f49bd18e98/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
+google.golang.org/genproto v0.0.0-20200808173500-a06252235341 h1:Kceb+1TNS2X7Cj/A+IUTljNerF/4wOFjlFJ0RGHYKKE=
+google.golang.org/genproto v0.0.0-20200808173500-a06252235341/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.20.1/go.mod h1:10oTOabMzJvdu6/UiuZezV6QK5dSlG84ov/aaiqXj38=
 google.golang.org/grpc v1.21.0/go.mod h1:oYelfM1adQP15Ek0mdvEgi9Df8B9CZIaU1084ijfRaM=

--- a/pkg/model/tangle/address_storage.go
+++ b/pkg/model/tangle/address_storage.go
@@ -94,7 +94,7 @@ func GetTransactionHashesForAddress(address hornet.Hash, valueOnly bool, forceRe
 	return txHashes
 }
 
-// AddressConsumer consumes the given address during looping though all addresses in the persistence layer.
+// AddressConsumer consumes the given address during looping through all addresses in the persistence layer.
 type AddressConsumer func(address hornet.Hash, txHash hornet.Hash, isValue bool) bool
 
 // ForEachAddress loops over all addresses.

--- a/pkg/model/tangle/address_storage.go
+++ b/pkg/model/tangle/address_storage.go
@@ -105,16 +105,8 @@ func ForEachAddress(consumer AddressConsumer, skipCache bool) {
 
 // address +1
 func StoreAddress(address hornet.Hash, txHash hornet.Hash, isValue bool) *CachedAddress {
-
 	addressObj := hornet.NewAddress(address, txHash, isValue)
-
-	cachedObj := addressesStorage.ComputeIfAbsent(addressObj.ObjectStorageKey(), func(key []byte) objectstorage.StorableObject { // address +1
-		addressObj.Persist()
-		addressObj.SetModified()
-		return addressObj
-	})
-
-	return &CachedAddress{CachedObject: cachedObj}
+	return &CachedAddress{CachedObject: addressesStorage.Store(addressObj)}
 }
 
 // address +-0

--- a/pkg/model/tangle/address_storage.go
+++ b/pkg/model/tangle/address_storage.go
@@ -93,6 +93,16 @@ func GetTransactionHashesForAddress(address hornet.Hash, valueOnly bool, forceRe
 	return txHashes
 }
 
+// AddressConsumer consumes the given address during looping though all addresses in the persistence layer.
+type AddressConsumer func(address hornet.Hash, txHash hornet.Hash, isValue bool) bool
+
+// ForEachAddress loops over all addresses.
+func ForEachAddress(consumer AddressConsumer, skipCache bool) {
+	addressesStorage.ForEachKeyOnly(func(key []byte) bool {
+		return consumer(key[:49], key[50:99], key[49] == hornet.AddressTxIsValue)
+	}, skipCache)
+}
+
 // address +1
 func StoreAddress(address hornet.Hash, txHash hornet.Hash, isValue bool) *CachedAddress {
 

--- a/pkg/model/tangle/address_storage.go
+++ b/pkg/model/tangle/address_storage.go
@@ -60,6 +60,7 @@ func configureAddressesStorage(store kvstore.KVStore, opts profile.CacheOpts) {
 		objectstorage.PersistenceEnabled(true),
 		objectstorage.PartitionKey(49, 1, 49),
 		objectstorage.KeysOnly(true),
+		objectstorage.StoreOnCreation(true),
 		objectstorage.LeakDetectionEnabled(opts.LeakDetectionOptions.Enabled,
 			objectstorage.LeakDetectionOptions{
 				MaxConsumersPerObject: opts.LeakDetectionOptions.MaxConsumersPerObject,

--- a/pkg/model/tangle/approvers_storage.go
+++ b/pkg/model/tangle/approvers_storage.go
@@ -73,7 +73,7 @@ func GetApproverHashes(txHash hornet.Hash, forceRelease bool, maxFind ...int) ho
 	return approverHashes
 }
 
-// ApproverConsumer consumes the given approver during looping though all approvers in the persistence layer.
+// ApproverConsumer consumes the given approver during looping through all approvers in the persistence layer.
 type ApproverConsumer func(txHash hornet.Hash, approverHash hornet.Hash) bool
 
 // ForEachApprover loops over all approvers.

--- a/pkg/model/tangle/approvers_storage.go
+++ b/pkg/model/tangle/approvers_storage.go
@@ -84,23 +84,13 @@ func ForEachApprover(consumer ApproverConsumer, skipCache bool) {
 
 // approvers +1
 func StoreApprover(txHash hornet.Hash, approverHash hornet.Hash) *CachedApprover {
-
 	approver := hornet.NewApprover(txHash, approverHash)
-
-	cachedObj := approversStorage.ComputeIfAbsent(approver.ObjectStorageKey(), func(key []byte) objectstorage.StorableObject { // approvers +1
-		approver.Persist()
-		approver.SetModified()
-		return approver
-	})
-
-	return &CachedApprover{CachedObject: cachedObj}
+	return &CachedApprover{CachedObject: approversStorage.Store(approver)}
 }
 
 // approvers +-0
 func DeleteApprover(txHash hornet.Hash, approverHash hornet.Hash) {
-
 	approver := hornet.NewApprover(txHash, approverHash)
-
 	approversStorage.Delete(approver.ObjectStorageKey())
 }
 

--- a/pkg/model/tangle/approvers_storage.go
+++ b/pkg/model/tangle/approvers_storage.go
@@ -72,6 +72,16 @@ func GetApproverHashes(txHash hornet.Hash, forceRelease bool, maxFind ...int) ho
 	return approverHashes
 }
 
+// ApproverConsumer consumes the given approver during looping though all approvers in the persistence layer.
+type ApproverConsumer func(txHash hornet.Hash, approverHash hornet.Hash) bool
+
+// ForEachApprover loops over all approvers.
+func ForEachApprover(consumer ApproverConsumer, skipCache bool) {
+	approversStorage.ForEachKeyOnly(func(key []byte) bool {
+		return consumer(key[:49], key[49:98])
+	}, skipCache)
+}
+
 // approvers +1
 func StoreApprover(txHash hornet.Hash, approverHash hornet.Hash) *CachedApprover {
 

--- a/pkg/model/tangle/approvers_storage.go
+++ b/pkg/model/tangle/approvers_storage.go
@@ -46,6 +46,7 @@ func configureApproversStorage(store kvstore.KVStore, opts profile.CacheOpts) {
 		objectstorage.PersistenceEnabled(true),
 		objectstorage.PartitionKey(49, 49),
 		objectstorage.KeysOnly(true),
+		objectstorage.StoreOnCreation(true),
 		objectstorage.LeakDetectionEnabled(opts.LeakDetectionOptions.Enabled,
 			objectstorage.LeakDetectionOptions{
 				MaxConsumersPerObject: opts.LeakDetectionOptions.MaxConsumersPerObject,

--- a/pkg/model/tangle/bundle_storage.go
+++ b/pkg/model/tangle/bundle_storage.go
@@ -197,7 +197,7 @@ func GetStoredBundleOrNil(tailTxHash hornet.Hash) *Bundle {
 	return storedBundle.(*Bundle)
 }
 
-// BundleHashConsumer consumes the given tailTxHash during looping though all bundles in the persistence layer.
+// BundleHashConsumer consumes the given tailTxHash during looping through all bundles in the persistence layer.
 type BundleHashConsumer func(txHash hornet.Hash) bool
 
 // ForEachBundleHash loops over all bundle hashes.

--- a/pkg/model/tangle/bundle_storage.go
+++ b/pkg/model/tangle/bundle_storage.go
@@ -42,6 +42,7 @@ func configureBundleStorage(store kvstore.KVStore, opts profile.CacheOpts) {
 		bundleFactory,
 		objectstorage.CacheTime(time.Duration(opts.CacheTimeMs)*time.Millisecond),
 		objectstorage.PersistenceEnabled(true),
+		objectstorage.StoreOnCreation(false),
 		objectstorage.LeakDetectionEnabled(opts.LeakDetectionOptions.Enabled,
 			objectstorage.LeakDetectionOptions{
 				MaxConsumersPerObject: opts.LeakDetectionOptions.MaxConsumersPerObject,

--- a/pkg/model/tangle/bundle_storage.go
+++ b/pkg/model/tangle/bundle_storage.go
@@ -187,11 +187,23 @@ func GetCachedBundleOrNil(tailTxHash hornet.Hash) *CachedBundle {
 	return &CachedBundle{CachedObject: cachedBundle}
 }
 
+// GetStoredBundleOrNil returns a bundle object without accessing the cache layer.
+func GetStoredBundleOrNil(tailTxHash hornet.Hash) *Bundle {
+	storedBundle := bundleStorage.LoadObjectFromStore(tailTxHash)
+	if storedBundle == nil {
+		return nil
+	}
+	return storedBundle.(*Bundle)
+}
+
+// BundleHashConsumer consumes the given tailTxHash during looping though all bundles in the persistence layer.
+type BundleHashConsumer func(txHash hornet.Hash) bool
+
 // ForEachBundleHash loops over all bundle hashes.
-func ForEachBundleHash(consumer TransactionHashBytesConsumer) {
+func ForEachBundleHash(consumer BundleHashConsumer, skipCache bool) {
 	bundleStorage.ForEachKeyOnly(func(tailTxHash []byte) bool {
 		return consumer(tailTxHash)
-	}, false)
+	}, skipCache)
 }
 
 // bundle +-0

--- a/pkg/model/tangle/bundle_transaction_storage.go
+++ b/pkg/model/tangle/bundle_transaction_storage.go
@@ -197,6 +197,16 @@ func GetBundleTailTransactionHashes(bundleHash hornet.Hash, forceRelease bool, m
 	return bundleTransactionHashes
 }
 
+// BundleTransactionConsumer consumes the given bundle transaction during looping though all bundle transactions in the persistence layer.
+type BundleTransactionConsumer func(bundleHash hornet.Hash, txHash hornet.Hash, isTail bool) bool
+
+// ForEachBundleTransaction loops over all bundle transactions.
+func ForEachBundleTransaction(consumer BundleTransactionConsumer, skipCache bool) {
+	bundleTransactionsStorage.ForEachKeyOnly(func(key []byte) bool {
+		return consumer(key[:49], key[50:99], key[49] == BundleTxIsTail)
+	}, skipCache)
+}
+
 // bundleTx +-0
 func ContainsBundleTransaction(bundleHash hornet.Hash, txHash hornet.Hash, isTail bool) bool {
 	return bundleTransactionsStorage.Contains(databaseKeyForBundleTransaction(bundleHash, txHash, isTail))

--- a/pkg/model/tangle/bundle_transaction_storage.go
+++ b/pkg/model/tangle/bundle_transaction_storage.go
@@ -59,6 +59,7 @@ func configureBundleTransactionsStorage(store kvstore.KVStore, opts profile.Cach
 		objectstorage.PersistenceEnabled(true),
 		objectstorage.PartitionKey(49, 1, 49), // BundleHash, IsTail, TxHash
 		objectstorage.KeysOnly(true),
+		objectstorage.StoreOnCreation(true),
 		objectstorage.LeakDetectionEnabled(opts.LeakDetectionOptions.Enabled,
 			objectstorage.LeakDetectionOptions{
 				MaxConsumersPerObject: opts.LeakDetectionOptions.MaxConsumersPerObject,

--- a/pkg/model/tangle/bundle_transaction_storage.go
+++ b/pkg/model/tangle/bundle_transaction_storage.go
@@ -198,7 +198,7 @@ func GetBundleTailTransactionHashes(bundleHash hornet.Hash, forceRelease bool, m
 	return bundleTransactionHashes
 }
 
-// BundleTransactionConsumer consumes the given bundle transaction during looping though all bundle transactions in the persistence layer.
+// BundleTransactionConsumer consumes the given bundle transaction during looping through all bundle transactions in the persistence layer.
 type BundleTransactionConsumer func(bundleHash hornet.Hash, txHash hornet.Hash, isTail bool) bool
 
 // ForEachBundleTransaction loops over all bundle transactions.

--- a/pkg/model/tangle/bundle_transaction_storage.go
+++ b/pkg/model/tangle/bundle_transaction_storage.go
@@ -214,20 +214,12 @@ func ContainsBundleTransaction(bundleHash hornet.Hash, txHash hornet.Hash, isTai
 
 // bundleTx +1
 func StoreBundleTransaction(bundleHash hornet.Hash, txHash hornet.Hash, isTail bool) *CachedBundleTransaction {
-
 	bundleTx := &BundleTransaction{
 		BundleHash: bundleHash,
 		IsTail:     isTail,
 		TxHash:     txHash,
 	}
-
-	cachedObj := bundleTransactionsStorage.ComputeIfAbsent(bundleTx.ObjectStorageKey(), func(key []byte) objectstorage.StorableObject { // bundleTx +1
-		bundleTx.Persist()
-		bundleTx.SetModified()
-		return bundleTx
-	})
-
-	return &CachedBundleTransaction{CachedObject: cachedObj}
+	return &CachedBundleTransaction{CachedObject: bundleTransactionsStorage.Store(bundleTx)}
 }
 
 // bundleTx +-0

--- a/pkg/model/tangle/ledger_db.go
+++ b/pkg/model/tangle/ledger_db.go
@@ -175,6 +175,16 @@ func GetLedgerDiffForMilestoneWithoutLocking(index milestone.Index, abortSignal 
 	return diff, nil
 }
 
+// LedgerDiffHashConsumer consumes the given ledger diff addresses during looping through all ledger diffs in the persistence layer.
+type LedgerDiffHashConsumer func(msIndex milestone.Index, address hornet.Hash) bool
+
+// ForEachLedgerDiffHash loops over all ledger diffs.
+func ForEachLedgerDiffHash(consumer LedgerDiffHashConsumer, skipCache bool) {
+	ledgerDiffStore.IterateKeys([]byte{}, func(key kvstore.Key) bool {
+		return consumer(milestone.Index(binary.LittleEndian.Uint32(key[:4])), key[4:53])
+	})
+}
+
 func GetLedgerDiffForMilestone(index milestone.Index, abortSignal <-chan struct{}) (map[string]int64, error) {
 
 	ReadLockLedger()

--- a/pkg/model/tangle/milestones_storage.go
+++ b/pkg/model/tangle/milestones_storage.go
@@ -44,6 +44,7 @@ func configureMilestoneStorage(store kvstore.KVStore, opts profile.CacheOpts) {
 		milestoneFactory,
 		objectstorage.CacheTime(time.Duration(opts.CacheTimeMs)*time.Millisecond),
 		objectstorage.PersistenceEnabled(true),
+		objectstorage.StoreOnCreation(true),
 		objectstorage.LeakDetectionEnabled(opts.LeakDetectionOptions.Enabled,
 			objectstorage.LeakDetectionOptions{
 				MaxConsumersPerObject: opts.LeakDetectionOptions.MaxConsumersPerObject,

--- a/pkg/model/tangle/milestones_storage.go
+++ b/pkg/model/tangle/milestones_storage.go
@@ -124,10 +124,10 @@ func SearchLatestMilestoneIndexInStore() milestone.Index {
 	return latestMilestoneIndex
 }
 
-// MilestoneIndexConsumer consumes the given index during looping though all milestones in the persistence layer.
+// MilestoneIndexConsumer consumes the given index during looping through all milestones in the persistence layer.
 type MilestoneIndexConsumer func(index milestone.Index) bool
 
-// ForEachMilestoneIndex loops though all milestones in the persistence layer.
+// ForEachMilestoneIndex loops through all milestones in the persistence layer.
 func ForEachMilestoneIndex(consumer MilestoneIndexConsumer, skipCache bool) {
 	milestoneStorage.ForEachKeyOnly(func(key []byte) bool {
 		return consumer(milestoneIndexFromDatabaseKey(key))

--- a/pkg/model/tangle/milestones_storage.go
+++ b/pkg/model/tangle/milestones_storage.go
@@ -127,10 +127,10 @@ func SearchLatestMilestoneIndexInStore() milestone.Index {
 type MilestoneIndexConsumer func(index milestone.Index) bool
 
 // ForEachMilestoneIndex loops though all milestones in the persistence layer.
-func ForEachMilestoneIndex(consumer MilestoneIndexConsumer) {
+func ForEachMilestoneIndex(consumer MilestoneIndexConsumer, skipCache bool) {
 	milestoneStorage.ForEachKeyOnly(func(key []byte) bool {
 		return consumer(milestoneIndexFromDatabaseKey(key))
-	}, false)
+	}, skipCache)
 }
 
 // milestone +1

--- a/pkg/model/tangle/spent_addresses_storage.go
+++ b/pkg/model/tangle/spent_addresses_storage.go
@@ -85,13 +85,10 @@ func MarkAddressAsSpentWithoutLocking(address hornet.Hash) bool {
 
 	spentAddress, _, _ := spentAddressFactory(address)
 
-	newlyAdded := false
-	spentAddressesStorage.ComputeIfAbsent(spentAddress.ObjectStorageKey(), func(key []byte) objectstorage.StorableObject {
-		newlyAdded = true
-		spentAddress.Persist()
-		spentAddress.SetModified()
-		return spentAddress
-	}).Release(true)
+	cachedSpentAddress, newlyAdded := spentAddressesStorage.StoreIfAbsent(spentAddress)
+	if cachedSpentAddress != nil {
+		cachedSpentAddress.Release(true)
+	}
 
 	return newlyAdded
 }

--- a/pkg/model/tangle/spent_addresses_storage.go
+++ b/pkg/model/tangle/spent_addresses_storage.go
@@ -59,6 +59,7 @@ func configureSpentAddressesStorage(store kvstore.KVStore, opts profile.CacheOpt
 		objectstorage.CacheTime(time.Duration(opts.CacheTimeMs)*time.Millisecond),
 		objectstorage.PersistenceEnabled(true),
 		objectstorage.KeysOnly(true),
+		objectstorage.StoreOnCreation(true),
 		objectstorage.LeakDetectionEnabled(opts.LeakDetectionOptions.Enabled,
 			objectstorage.LeakDetectionOptions{
 				MaxConsumersPerObject: opts.LeakDetectionOptions.MaxConsumersPerObject,

--- a/pkg/model/tangle/tags_storage.go
+++ b/pkg/model/tangle/tags_storage.go
@@ -73,6 +73,16 @@ func GetTagHashes(txTag hornet.Hash, forceRelease bool, maxFind ...int) hornet.H
 	return tagHashes
 }
 
+// TagConsumer consumes the given tag during looping though all tags in the persistence layer.
+type TagConsumer func(txTag hornet.Hash, txHash hornet.Hash) bool
+
+// ForEachTag loops over all tags.
+func ForEachTag(consumer TagConsumer, skipCache bool) {
+	tagsStorage.ForEachKeyOnly(func(key []byte) bool {
+		return consumer(key[:17], key[17:66])
+	}, skipCache)
+}
+
 // tag +1
 func StoreTag(txTag hornet.Hash, txHash hornet.Hash) *CachedTag {
 

--- a/pkg/model/tangle/tags_storage.go
+++ b/pkg/model/tangle/tags_storage.go
@@ -85,16 +85,8 @@ func ForEachTag(consumer TagConsumer, skipCache bool) {
 
 // tag +1
 func StoreTag(txTag hornet.Hash, txHash hornet.Hash) *CachedTag {
-
 	tag := hornet.NewTag(txTag[:17], txHash[:49])
-
-	cachedObj := tagsStorage.ComputeIfAbsent(tag.ObjectStorageKey(), func(key []byte) objectstorage.StorableObject { // tag +1
-		tag.Persist()
-		tag.SetModified()
-		return tag
-	})
-
-	return &CachedTag{CachedObject: cachedObj}
+	return &CachedTag{CachedObject: tagsStorage.Store(tag)}
 }
 
 // tag +-0

--- a/pkg/model/tangle/tags_storage.go
+++ b/pkg/model/tangle/tags_storage.go
@@ -47,6 +47,7 @@ func configureTagsStorage(store kvstore.KVStore, opts profile.CacheOpts) {
 		objectstorage.PersistenceEnabled(true),
 		objectstorage.PartitionKey(17, 49),
 		objectstorage.KeysOnly(true),
+		objectstorage.StoreOnCreation(true),
 		objectstorage.LeakDetectionEnabled(opts.LeakDetectionOptions.Enabled,
 			objectstorage.LeakDetectionOptions{
 				MaxConsumersPerObject: opts.LeakDetectionOptions.MaxConsumersPerObject,

--- a/pkg/model/tangle/tags_storage.go
+++ b/pkg/model/tangle/tags_storage.go
@@ -74,7 +74,7 @@ func GetTagHashes(txTag hornet.Hash, forceRelease bool, maxFind ...int) hornet.H
 	return tagHashes
 }
 
-// TagConsumer consumes the given tag during looping though all tags in the persistence layer.
+// TagConsumer consumes the given tag during looping through all tags in the persistence layer.
 type TagConsumer func(txTag hornet.Hash, txHash hornet.Hash) bool
 
 // ForEachTag loops over all tags.

--- a/pkg/model/tangle/transaction_storage.go
+++ b/pkg/model/tangle/transaction_storage.go
@@ -113,6 +113,7 @@ func configureTransactionStorage(store kvstore.KVStore, opts profile.CacheOpts) 
 		transactionFactory,
 		objectstorage.CacheTime(time.Duration(opts.CacheTimeMs)*time.Millisecond),
 		objectstorage.PersistenceEnabled(true),
+		objectstorage.StoreOnCreation(true),
 		objectstorage.LeakDetectionEnabled(opts.LeakDetectionOptions.Enabled,
 			objectstorage.LeakDetectionOptions{
 				MaxConsumersPerObject: opts.LeakDetectionOptions.MaxConsumersPerObject,
@@ -125,6 +126,7 @@ func configureTransactionStorage(store kvstore.KVStore, opts profile.CacheOpts) 
 		metadataFactory,
 		objectstorage.CacheTime(time.Duration(opts.CacheTimeMs)*time.Millisecond),
 		objectstorage.PersistenceEnabled(true),
+		objectstorage.StoreOnCreation(false),
 		objectstorage.LeakDetectionEnabled(opts.LeakDetectionOptions.Enabled,
 			objectstorage.LeakDetectionOptions{
 				MaxConsumersPerObject: opts.LeakDetectionOptions.MaxConsumersPerObject,

--- a/pkg/model/tangle/transaction_storage.go
+++ b/pkg/model/tangle/transaction_storage.go
@@ -227,7 +227,7 @@ func ForEachTransaction(consumer TransactionConsumer) {
 	})
 }
 
-// TransactionHashConsumer consumes the given transaction hash during looping though all transactions in the persistence layer.
+// TransactionHashConsumer consumes the given transaction hash during looping through all transactions in the persistence layer.
 type TransactionHashConsumer func(txHash hornet.Hash) bool
 
 // ForEachTransactionHash loops over all transaction hashes.

--- a/pkg/model/tangle/transaction_storage.go
+++ b/pkg/model/tangle/transaction_storage.go
@@ -192,20 +192,7 @@ func StoreTransactionIfAbsent(transaction *hornet.Transaction) (cachedTx *Cached
 		newlyAdded = true
 
 		metadata, _, _ := metadataFactory(transaction.GetTxHash())
-
-		metaCreated := false
-		cachedMeta = metadataStorage.ComputeIfAbsent(metadata.ObjectStorageKey(), func(key []byte) objectstorage.StorableObject { // meta +1
-			metaCreated = true
-			metadata.Persist()
-			metadata.SetModified()
-			return metadata
-		})
-
-		if !metaCreated {
-			// this can only happen if the database was unclean
-			// we have to reset the metadata
-			cachedMeta.Get().(*hornet.TransactionMetadata).Reset()
-		}
+		cachedMeta = metadataStorage.Store(metadata) // meta +1
 
 		transaction.Persist()
 		transaction.SetModified()

--- a/pkg/model/tangle/unconfirmed_tx_storage.go
+++ b/pkg/model/tangle/unconfirmed_tx_storage.go
@@ -75,16 +75,8 @@ func GetUnconfirmedTxHashes(msIndex milestone.Index, forceRelease bool) hornet.H
 
 // unconfirmedTx +1
 func StoreUnconfirmedTx(msIndex milestone.Index, txHash hornet.Hash) *CachedUnconfirmedTx {
-
 	unconfirmedTx := hornet.NewUnconfirmedTx(msIndex, txHash)
-
-	cachedObj := unconfirmedTxStorage.ComputeIfAbsent(unconfirmedTx.ObjectStorageKey(), func(key []byte) objectstorage.StorableObject { // unconfirmedTx +1
-		unconfirmedTx.Persist()
-		unconfirmedTx.SetModified()
-		return unconfirmedTx
-	})
-
-	return &CachedUnconfirmedTx{CachedObject: cachedObj}
+	return &CachedUnconfirmedTx{CachedObject: unconfirmedTxStorage.Store(unconfirmedTx)}
 }
 
 // DeleteUnconfirmedTxs deletes unconfirmed transaction entries.

--- a/pkg/model/tangle/unconfirmed_tx_storage.go
+++ b/pkg/model/tangle/unconfirmed_tx_storage.go
@@ -49,6 +49,7 @@ func configureUnconfirmedTxStorage(store kvstore.KVStore, opts profile.CacheOpts
 		objectstorage.PersistenceEnabled(true),
 		objectstorage.PartitionKey(4, 49),
 		objectstorage.KeysOnly(true),
+		objectstorage.StoreOnCreation(true),
 		objectstorage.LeakDetectionEnabled(opts.LeakDetectionOptions.Enabled,
 			objectstorage.LeakDetectionOptions{
 				MaxConsumersPerObject: opts.LeakDetectionOptions.MaxConsumersPerObject,

--- a/pkg/protocol/processor/processor.go
+++ b/pkg/protocol/processor/processor.go
@@ -54,6 +54,7 @@ func New(requestQueue rqueue.Queue, peerManager *peering.Manager, opts *Options)
 		objectstorage.CacheTime(time.Duration(wuCacheOpts.CacheTimeMs)),
 		objectstorage.PersistenceEnabled(false),
 		objectstorage.KeysOnly(true),
+		objectstorage.StoreOnCreation(false),
 		objectstorage.LeakDetectionEnabled(wuCacheOpts.LeakDetectionOptions.Enabled,
 			objectstorage.LeakDetectionOptions{
 				MaxConsumersPerObject: wuCacheOpts.LeakDetectionOptions.MaxConsumersPerObject,

--- a/plugins/tangle/revalidation.go
+++ b/plugins/tangle/revalidation.go
@@ -51,6 +51,8 @@ var (
 //
 func revalidateDatabase() error {
 
+	start := time.Now()
+
 	snapshotInfo := tangle.GetSnapshotInfo()
 	if snapshotInfo == nil {
 		return ErrSnapshotInfoMissing
@@ -65,7 +67,7 @@ func revalidateDatabase() error {
 	log.Infof("reverting database state back to local snapshot %d...", snapshotInfo.SnapshotIndex)
 
 	// delete milestone data newer than the local snapshot
-	if err := cleanMilestones(snapshotInfo); err != nil {
+	if err := cleanupMilestones(snapshotInfo); err != nil {
 		return err
 	}
 
@@ -74,8 +76,33 @@ func revalidateDatabase() error {
 		return err
 	}
 
-	// clean up bundles of which their tail tx doesn't exist in the database anymore
+	// deletes all transaction metadata where the tx doesn't exist in the database anymore.
+	if err := cleanupTransactionMetadata(); err != nil {
+		return err
+	}
+
+	// deletes all bundles where a single tx of the bundle doesn't exist in the database anymore.
 	if err := cleanupBundles(); err != nil {
+		return err
+	}
+
+	// deletes all bundles transactions where the tx doesn't exist in the database anymore.
+	if err := cleanupBundleTransactions(); err != nil {
+		return err
+	}
+
+	// deletes all approvers where the tx doesn't exist in the database anymore.
+	if err := cleanupApprovers(); err != nil {
+		return err
+	}
+
+	// deletes all tags where the tx doesn't exist in the database anymore.
+	if err := cleanupTags(); err != nil {
+		return err
+	}
+
+	// deletes all addresses where the tx doesn't exist in the database anymore.
+	if err := cleanupAddresses(); err != nil {
 		return err
 	}
 
@@ -99,23 +126,31 @@ func revalidateDatabase() error {
 	// Set the valid solid milestone index
 	tangle.OverwriteSolidMilestoneIndex(snapshotInfo.SnapshotIndex)
 
+	log.Infof("reverted state back to local snapshot %d, took %v", snapshotInfo.SnapshotIndex, time.Since(start).Truncate(time.Millisecond))
+
 	return nil
 }
 
 // deletes milestones above the given snapshot's milestone index.
-func cleanMilestones(info *tangle.SnapshotInfo) error {
-	milestonesToDelete := map[milestone.Index]struct{}{}
+func cleanupMilestones(info *tangle.SnapshotInfo) error {
 
+	start := time.Now()
+
+	var milestonesCounter int64
+	var deletionCounter int64
 	tangle.ForEachMilestoneIndex(func(msIndex milestone.Index) bool {
-		if msIndex > info.SnapshotIndex {
-			milestonesToDelete[msIndex] = struct{}{}
-		}
-		return true
-	})
+		milestonesCounter++
 
-	for msIndex := range milestonesToDelete {
-		if daemon.IsStopped() {
-			return tangle.ErrOperationAborted
+		if (milestonesCounter % 1000) == 0 {
+			if daemon.IsStopped() {
+				return false
+			}
+			log.Infof("analyzed %d milestones", milestonesCounter)
+		}
+
+		// do not delete older milestones
+		if msIndex <= info.SnapshotIndex {
+			return true
 		}
 
 		tangle.DeleteUnconfirmedTxs(msIndex)
@@ -123,108 +158,110 @@ func cleanMilestones(info *tangle.SnapshotInfo) error {
 			panic(err)
 		}
 
-		milestone := tangle.GetCachedMilestoneOrNil(msIndex) // milestone +1
-		if milestone == nil {
-			return ErrMilestoneNotFound
-		}
-		msHash := milestone.GetMilestone().Hash
-		milestone.Release(true) // milestone -1
-
-		// delete the bundle of the milestone, so the milestone will be created again during syncing
-		tangle.DeleteBundle(msHash)
 		tangle.DeleteMilestone(msIndex)
-	}
-
-	return nil
-}
-
-// deletes all transactions (and their bundle, first seen tx, etc.) which are not confirmed,
-// not solid, their confirmation milestone is newer/ of which their solidification time is younger
-// than the last local snapshot's milestone.
-func cleanupTransactions(info *tangle.SnapshotInfo) error {
-	txsToDelete := map[string]struct{}{}
-
-	start := time.Now()
-	var txCounter int64
-	tangle.ForEachTransactionHash(func(txHash hornet.Hash) bool {
-		txCounter++
-
-		if (txCounter % 50000) == 0 {
-			if daemon.IsStopped() {
-				return false
-			}
-			log.Infof("analyzed %d transactions", txCounter)
-		}
-
-		storedTxMeta := tangle.GetStoredMetadataOrNil(txHash)
-
-		// delete transaction if no metadata
-		if storedTxMeta == nil {
-			txsToDelete[string(txHash)] = struct{}{}
-			return true
-		}
-
-		// not solid
-		if !storedTxMeta.IsSolid() {
-			txsToDelete[string(txHash)] = struct{}{}
-			return true
-		}
-
-		if confirmed, by := storedTxMeta.GetConfirmed(); !confirmed || by > info.SnapshotIndex {
-			txsToDelete[string(txHash)] = struct{}{}
-		}
+		deletionCounter++
 
 		return true
-	})
+	}, true)
 
 	if daemon.IsStopped() {
 		return tangle.ErrOperationAborted
 	}
 
-	var deletionCounter float64
-	total := float64(len(txsToDelete))
-	lastPercentage := 0
-	for txHashToDelete := range txsToDelete {
-		if daemon.IsStopped() {
-			return tangle.ErrOperationAborted
-		}
-
-		percentage := int((deletionCounter / total) * 100)
-		if lastPercentage+5 <= percentage {
-			lastPercentage = percentage
-			log.Infof("reverting (this might take a while)...%d/%d (%d%%)", int(deletionCounter), len(txsToDelete), percentage)
-		}
-
-		storedTx := tangle.GetStoredTransactionOrNil(hornet.Hash(txHashToDelete))
-		if storedTx == nil {
-			continue
-		}
-
-		deletionCounter++
-
-		// No need to safely remove the transactions from the bundle,
-		// since reattachment txs confirmed by another milestone wouldn't be
-		// pruned anyway if they are confirmed before snapshot index.
-		tangle.DeleteBundleTransaction(storedTx.GetBundleHash(), storedTx.GetTxHash(), true)
-		tangle.DeleteBundleTransaction(storedTx.GetBundleHash(), storedTx.GetTxHash(), false)
-		tangle.DeleteBundle(storedTx.GetTxHash())
-
-		// Delete the reference in the approvees
-		tangle.DeleteApprover(storedTx.GetTrunkHash(), storedTx.GetTxHash())
-		tangle.DeleteApprover(storedTx.GetBranchHash(), storedTx.GetTxHash())
-
-		tangle.DeleteTag(storedTx.GetTag(), storedTx.GetTxHash())
-		tangle.DeleteAddress(storedTx.GetAddress(), storedTx.GetTxHash())
-		tangle.DeleteApprovers(storedTx.GetTxHash())
-		tangle.DeleteTransaction(storedTx.GetTxHash())
-	}
-
-	log.Infof("reverted state back to local snapshot %d, %d transactions deleted, took %v", info.SnapshotIndex, int(deletionCounter), time.Since(start))
+	log.Infof("%d milestones deleted, took %v", deletionCounter, time.Since(start).Truncate(time.Millisecond))
 
 	return nil
 }
 
-// deletes all bundles of which their tail tx doesn't exist in the database anymore.
+// deletes all transactions which are not confirmed, not solid or
+// their confirmation milestone is newer than the last local snapshot's milestone.
+func cleanupTransactions(info *tangle.SnapshotInfo) error {
+
+	start := time.Now()
+
+	var txsCounter int64
+	var deletionCounter int64
+	tangle.ForEachTransactionHash(func(txHash hornet.Hash) bool {
+		txsCounter++
+
+		if (txsCounter % 50000) == 0 {
+			if daemon.IsStopped() {
+				return false
+			}
+			log.Infof("analyzed %d transactions", txsCounter)
+		}
+
+		storedTxMeta := tangle.GetStoredMetadataOrNil(txHash)
+
+		// delete transaction if metadata doesn't exist
+		if storedTxMeta == nil {
+			tangle.DeleteTransaction(txHash)
+			deletionCounter++
+			return true
+		}
+
+		// not solid
+		if !storedTxMeta.IsSolid() {
+			tangle.DeleteTransaction(txHash)
+			deletionCounter++
+			return true
+		}
+
+		// not confirmed or above snapshot index
+		if confirmed, by := storedTxMeta.GetConfirmed(); !confirmed || by > info.SnapshotIndex {
+			tangle.DeleteTransaction(txHash)
+			deletionCounter++
+			return true
+		}
+
+		return true
+	}, true)
+
+	if daemon.IsStopped() {
+		return tangle.ErrOperationAborted
+	}
+
+	log.Infof("%d transactions deleted, took %v", deletionCounter, time.Since(start).Truncate(time.Millisecond))
+
+	return nil
+}
+
+// deletes all transaction metadata where the tx doesn't exist in the database anymore.
+func cleanupTransactionMetadata() error {
+
+	start := time.Now()
+
+	var metadataCounter int64
+	var deletionCounter int64
+	tangle.ForEachTransactionMetadataHash(func(txHash hornet.Hash) bool {
+		metadataCounter++
+
+		if (metadataCounter % 50000) == 0 {
+			if daemon.IsStopped() {
+				return false
+			}
+			log.Infof("analyzed %d transaction metadata", metadataCounter)
+		}
+
+		// delete metadata if transaction doesn't exist
+		if !tangle.TransactionExistsInStore(txHash) {
+			tangle.DeleteTransactionMetadata(txHash)
+			deletionCounter++
+		}
+
+		return true
+	}, true)
+
+	if daemon.IsStopped() {
+		return tangle.ErrOperationAborted
+	}
+
+	log.Infof("%d transaction metadata deleted, took %v", deletionCounter, time.Since(start).Truncate(time.Millisecond))
+
+	return nil
+}
+
+// deletes all bundles where a single tx of the bundle doesn't exist in the database anymore.
 func cleanupBundles() error {
 
 	start := time.Now()
@@ -234,10 +271,6 @@ func cleanupBundles() error {
 	tangle.ForEachBundleHash(func(tailTxHash hornet.Hash) bool {
 		bundleCounter++
 
-		if daemon.IsStopped() {
-			return false
-		}
-
 		if (bundleCounter % 50000) == 0 {
 			if daemon.IsStopped() {
 				return false
@@ -245,23 +278,174 @@ func cleanupBundles() error {
 			log.Infof("analyzed %d bundles", bundleCounter)
 		}
 
-		storedTx := tangle.GetStoredTransactionOrNil(tailTxHash)
-
-		// delete bundle if transaction doesn't exist
-		if storedTx == nil {
-			tangle.DeleteBundle(tailTxHash)
-			deletionCounter++
+		bundle := tangle.GetStoredBundleOrNil(tailTxHash)
+		if bundle == nil {
 			return true
 		}
 
+		for _, txHash := range bundle.GetTxHashes() {
+			// delete bundle if a single transaction of the bundle doesn't exist
+			if !tangle.TransactionExistsInStore(txHash) {
+				tangle.DeleteBundle(tailTxHash)
+				deletionCounter++
+				return true
+			}
+		}
+
 		return true
-	})
+	}, true)
 
 	if daemon.IsStopped() {
 		return tangle.ErrOperationAborted
 	}
 
-	log.Infof("%d bundles deleted, took %v", deletionCounter, time.Since(start))
+	log.Infof("%d bundles deleted, took %v", deletionCounter, time.Since(start).Truncate(time.Millisecond))
+
+	return nil
+}
+
+// deletes all bundles transactions where the tx doesn't exist in the database anymore.
+func cleanupBundleTransactions() error {
+
+	start := time.Now()
+
+	var bundleTxsCounter int64
+	var deletionCounter int64
+	tangle.ForEachBundleTransaction(func(bundleHash hornet.Hash, txHash hornet.Hash, isTail bool) bool {
+		bundleTxsCounter++
+
+		if (bundleTxsCounter % 50000) == 0 {
+			if daemon.IsStopped() {
+				return false
+			}
+			log.Infof("analyzed %d bundle transactions", bundleTxsCounter)
+		}
+
+		// delete bundle transaction if transaction doesn't exist
+		if !tangle.TransactionExistsInStore(txHash) {
+			tangle.DeleteBundleTransaction(bundleHash, txHash, isTail)
+			deletionCounter++
+		}
+
+		return true
+	}, true)
+
+	if daemon.IsStopped() {
+		return tangle.ErrOperationAborted
+	}
+
+	log.Infof("%d bundle transactions deleted, took %v", deletionCounter, time.Since(start).Truncate(time.Millisecond))
+
+	return nil
+}
+
+// deletes all approvers where the tx doesn't exist in the database anymore.
+func cleanupApprovers() error {
+
+	start := time.Now()
+
+	var approverCounter int64
+	var deletionCounter int64
+	tangle.ForEachApprover(func(txHash hornet.Hash, approverHash hornet.Hash) bool {
+		approverCounter++
+
+		if (approverCounter % 50000) == 0 {
+			if daemon.IsStopped() {
+				return false
+			}
+			log.Infof("analyzed %d approvers", approverCounter)
+		}
+
+		// delete approver if transaction doesn't exist
+		if !tangle.TransactionExistsInStore(txHash) {
+			tangle.DeleteApprover(txHash, approverHash)
+			deletionCounter++
+		}
+
+		// delete approver if approver transaction doesn't exist
+		if !tangle.TransactionExistsInStore(approverHash) {
+			tangle.DeleteApprover(txHash, approverHash)
+			deletionCounter++
+		}
+
+		return true
+	}, true)
+
+	if daemon.IsStopped() {
+		return tangle.ErrOperationAborted
+	}
+
+	log.Infof("%d approvers deleted, took %v", deletionCounter, time.Since(start).Truncate(time.Millisecond))
+
+	return nil
+}
+
+// deletes all tags where the tx doesn't exist in the database anymore.
+func cleanupTags() error {
+
+	start := time.Now()
+
+	var tagsCounter int64
+	var deletionCounter int64
+	tangle.ForEachTag(func(txTag hornet.Hash, txHash hornet.Hash) bool {
+		tagsCounter++
+
+		if (tagsCounter % 50000) == 0 {
+			if daemon.IsStopped() {
+				return false
+			}
+			log.Infof("analyzed %d tags", tagsCounter)
+		}
+
+		// delete tag if transaction doesn't exist
+		if !tangle.TransactionExistsInStore(txHash) {
+			tangle.DeleteTag(txTag, txHash)
+			deletionCounter++
+		}
+
+		return true
+	}, true)
+
+	if daemon.IsStopped() {
+		return tangle.ErrOperationAborted
+	}
+
+	log.Infof("%d tags deleted, took %v", deletionCounter, time.Since(start).Truncate(time.Millisecond))
+
+	return nil
+}
+
+// deletes all addresses where the tx doesn't exist in the database anymore.
+func cleanupAddresses() error {
+
+	start := time.Now()
+
+	var addressesCounter int64
+	var deletionCounter int64
+	tangle.ForEachAddress(func(address hornet.Hash, txHash hornet.Hash, isValue bool) bool {
+		addressesCounter++
+
+		if (addressesCounter % 50000) == 0 {
+			if daemon.IsStopped() {
+				return false
+			}
+			log.Infof("analyzed %d addresses", addressesCounter)
+		}
+
+		// delete address if transaction doesn't exist
+		if !tangle.TransactionExistsInStore(txHash) {
+			tangle.DeleteAddress(address, txHash)
+			deletionCounter++
+		}
+
+		return true
+	}, true)
+
+	if daemon.IsStopped() {
+		return tangle.ErrOperationAborted
+	}
+
+	log.Infof("%d addresses deleted, took %v", deletionCounter, time.Since(start).Truncate(time.Millisecond))
 
 	return nil
 }


### PR DESCRIPTION
This PR finally fixes the re-validation (hopefully) :)

Revalidation was broken because we didn't loop over all different storages/caches, but only over transaction cache/storage. The result was that we deleted only the objects that were connected to the existing txs, but it could happen that a tx was not there, but all the other info attached to it, which lead to an unclean state after revalidation.