### PR TITLE
Adding automatic PPA update when release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,7 @@ jobs:
         run: goreleaser --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Upload to PPA
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -32,7 +33,6 @@ jobs:
           AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
         run: |
-          echo $SHELL
           mkdir -p ~/.gnupg && apt-key adv --keyserver pool.sks-keyservers.net --recv-keys ED75B5A4483DA07C
           echo "deb http://repo.aptly.info/ squeeze main" >> /etc/apt/sources.list
           apt update && apt install aptly moreutils jq -y

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,8 +19,26 @@ jobs:
         env:
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-        run: docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD      
+        run: docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
+
       - name: Release HORNET
         run: goreleaser --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload to PPA
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+        run: |
+          echo $SHELL
+          mkdir -p ~/.gnupg && apt-key adv --keyserver pool.sks-keyservers.net --recv-keys ED75B5A4483DA07C
+          echo "deb http://repo.aptly.info/ squeeze main" >> /etc/apt/sources.list
+          apt update && apt install aptly moreutils jq -y
+          aptly repo create hornet
+          aptly repo add hornet dist/hornet_*_amd64.deb 
+          jq '.S3PublishEndpoints += { "ppa-bucket" : { "region" : "${{ secrets.AWS_DEFAULT_REGION }}", "bucket" : "${{ secrets.AWS_BUCKET_NAME }}", "acl" : "public-read" } }' ~/.aptly.conf | sponge ~/.aptly.conf
+          echo "${{ secrets.GPG_PRIVATE_KEY }}" > /tmp/private.key 
+          echo "${{ secrets.GPG_PASSPHRASE }}" | gpg --batch --yes --passphrase-fd 0 --import /tmp/private.key
+          aptly publish repo -distribution="stable" -passphrase="$GPG_PASSPHRASE" -batch hornet s3:ppa-bucket:hornet


### PR DESCRIPTION
As stated in the title.

Our Debian PPA will be hosted at https://ppa.iota.org.
The modifications below aim to update this PPA for Hornet at every release we do.

Both the software install + update on Debian/Ubuntu and the GHA automatic update of the PPA have been tested.

Note: Already manually put Hornet 0.4.2 in the PPA.