### PR TITLE
fix(dashboard): Clear interval on Neighbors component unmount

### DIFF
--- a/plugins/dashboard/frontend/src/app/components/Neighbors.tsx
+++ b/plugins/dashboard/frontend/src/app/components/Neighbors.tsx
@@ -26,6 +26,7 @@ export class Neighbors extends React.Component<Props, any> {
     }
 
     componentWillUnmount(): void {
+        clearInterval(this.updateInterval);
         this.props.nodeStore.unregisterNeighborTopics();
     }
 


### PR DESCRIPTION
<!---
Hints for a successful PR:
1. It is recommended that before you submit a PR to this repository, to open an issue first and assign yourself.
This way you may get inputs and discover parallel PRs to the one you want to submit.
2. In case of a big PR, consider breaking it up to smaller PRs. This will help getting it merged in an incremental process.
3. Note that a PR should have a *single* area of responsibility. If your PR does more than one thing than it should be split to several PRs!!!!!
-->

# Description

Clears the interval created by `setInterval` on component unmount, as failing to do so may cause a memory leak since `updateTick` will continue being called. This also resolves a potential warning (`Can only update a mounted or mounting component. This usually means you called setState() on an unmounted component`).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested dashboard in dev mode

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have tested my code extensively
- [ ] I have selected the `develop` branch as the target branch
