### PR TITLE
feature(dashboard): Show database size in GB if size > 1 GB

### DIFF
--- a/plugins/dashboard/frontend/src/app/stores/NodeStore.ts
+++ b/plugins/dashboard/frontend/src/app/stores/NodeStore.ts
@@ -1007,10 +1007,10 @@ export class NodeStore {
         for (let i = 0; i < this.collected_dbsize_metrics.length; i++) {
             let metric: DbSizeMetric = this.collected_dbsize_metrics[i];
             labels.push(dateformat(new Date(metric.ts * 1000), "HH:MM:ss"));
-            tangle.data.push((metric.tangle / 1024 / 1024).toFixed(2));
-            snapshot.data.push((metric.snapshot / 1024 / 1024).toFixed(2));
-            spent.data.push((metric.spent / 1024 / 1024).toFixed(2));
-            total.data.push(((metric.tangle + metric.snapshot + metric.spent) / 1024 / 1024).toFixed(2));
+            tangle.data.push(metric.tangle);
+            snapshot.data.push(metric.snapshot);
+            spent.data.push(metric.spent);
+            total.data.push(metric.tangle + metric.snapshot + metric.spent);
         }
 
         return {


### PR DESCRIPTION
# Description

This PR changes the database size graph so that it shows the size in GB if size > 1 GB. This makes it a bit easier to read compared to MB. 

- Conversion from bytes to MB was removed from `NodeStore`
- New `dbSizeChartOpts` was created to represent size in GB
- The graph will switch from `dbSizeChartOptsMB` (axis and tooltip labels shown in MB) to `dbSizeChartOptsGB`when database size exceeds 1 GB

One consequence of this change is that the spent addresses and snapshot may show as 0.00 GB:
![image](https://user-images.githubusercontent.com/19519564/90320016-5dd38900-df0b-11ea-8ef6-63e8de37a52f.png)

I can show sizes in GB with 3 decimal places (instead of 2) if desired

## Type of change

- [x] Enhancement (non-breaking change which adds functionality)

# How Has This Been Tested?

Tested manually

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my code extensively
- [ ] I have selected the `develop` branch as the target branch
