### PR TITLE
Fix transaction root snapshot indexes calculation

### DIFF
--- a/config_comnet.json
+++ b/config_comnet.json
@@ -106,7 +106,7 @@
   },
   "tipsel": {
     "maxDeltaTxYoungestRootSnapshotIndexToLSMI": 2,
-    "maxDeltaTxApproveesOldestRootSnapshotIndexToLSMI": 7,
+    "maxDeltaTxOldestRootSnapshotIndexToLSMI": 7,
     "belowMaxDepth": 15,
     "nonLazy": {
       "retentionRulesTipsLimit": 100,

--- a/config_devnet.json
+++ b/config_devnet.json
@@ -106,7 +106,7 @@
   },
   "tipsel": {
     "maxDeltaTxYoungestRootSnapshotIndexToLSMI": 2,
-    "maxDeltaTxApproveesOldestRootSnapshotIndexToLSMI": 7,
+    "maxDeltaTxOldestRootSnapshotIndexToLSMI": 7,
     "belowMaxDepth": 15,
     "nonLazy": {
       "retentionRulesTipsLimit": 100,

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/google/go-querystring v1.0.0 // indirect
 	github.com/gorilla/websocket v1.4.2
 	github.com/hashicorp/go-version v1.2.1 // indirect
-	github.com/iotaledger/hive.go v0.0.0-20200813085723-4e83638e6e5f
+	github.com/iotaledger/hive.go v0.0.0-20200817231853-1c598e8496d7
 	github.com/iotaledger/iota.go v1.0.0-beta.15.0.20200622064951-7fa4854396b2
 	github.com/labstack/echo/v4 v4.1.16
 	github.com/labstack/gommon v0.3.0
@@ -36,8 +36,8 @@ require (
 	go.etcd.io/bbolt v1.3.5
 	go.uber.org/atomic v1.6.0
 	golang.org/x/crypto v0.0.0-20200728195943-123391ffb6de
-	golang.org/x/sys v0.0.0-20200812155832-6a926be9bd1d // indirect
+	golang.org/x/sys v0.0.0-20200817155316-9781c653f443 // indirect
 	golang.org/x/text v0.3.3 // indirect
-	google.golang.org/genproto v0.0.0-20200812160120-2e714abc8b50 // indirect
+	google.golang.org/genproto v0.0.0-20200815001618-f69a88009b70 // indirect
 	google.golang.org/grpc v1.31.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -213,8 +213,8 @@ github.com/hashicorp/serf v0.8.2/go.mod h1:6hOLApaqBFA1NXqRQAsxw9QxuDEvNxSQRwA/J
 github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
-github.com/iotaledger/hive.go v0.0.0-20200813085723-4e83638e6e5f h1:aWu8yTVM5wcVnQeabjDBKSujTTH9xWaE/iFv5Js+foI=
-github.com/iotaledger/hive.go v0.0.0-20200813085723-4e83638e6e5f/go.mod h1:tLI+HS0amqY5YqClfFZDHlFM7eeIZjoU25Oj1u9jCzQ=
+github.com/iotaledger/hive.go v0.0.0-20200817231853-1c598e8496d7 h1:urlBMszzezap+GumUGsLzlCZ/xG9GyQKbw4i+slkZvc=
+github.com/iotaledger/hive.go v0.0.0-20200817231853-1c598e8496d7/go.mod h1:tLI+HS0amqY5YqClfFZDHlFM7eeIZjoU25Oj1u9jCzQ=
 github.com/iotaledger/iota.go v1.0.0-beta.15/go.mod h1:Rn6v5hLAn8YBaJlRu1ZQdPAgKlshJR1PTeLQaft2778=
 github.com/iotaledger/iota.go v1.0.0-beta.15.0.20200622064951-7fa4854396b2 h1:6SPLL98DbdHUH+DHuPwYPkgZK5QwpXu9wdOiFdXb3Ps=
 github.com/iotaledger/iota.go v1.0.0-beta.15.0.20200622064951-7fa4854396b2/go.mod h1:Rn6v5hLAn8YBaJlRu1ZQdPAgKlshJR1PTeLQaft2778=
@@ -559,8 +559,8 @@ golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd h1:xhmwyvizuTgC2qz7ZlMluP20u
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200615200032-f1bc736245b1 h1:ogLJMz+qpzav7lGMh10LMvAkM/fAoGlaiiHYiFYdm80=
 golang.org/x/sys v0.0.0-20200615200032-f1bc736245b1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200812155832-6a926be9bd1d h1:QQrM/CCYEzTs91GZylDCQjGHudbPTxF/1fvXdVh5lMo=
-golang.org/x/sys v0.0.0-20200812155832-6a926be9bd1d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200817155316-9781c653f443 h1:X18bCaipMcoJGm27Nv7zr4XYPKGUy92GtqboKC2Hxaw=
+golang.org/x/sys v0.0.0-20200817155316-9781c653f443/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=
@@ -618,8 +618,8 @@ google.golang.org/genproto v0.0.0-20190911173649-1774047e7e51/go.mod h1:IbNlFCBr
 google.golang.org/genproto v0.0.0-20191108220845-16a3f7862a1a h1:Ob5/580gVHBJZgXnff1cZDbG+xLtMVE5mDRTe+nIsX4=
 google.golang.org/genproto v0.0.0-20191108220845-16a3f7862a1a/go.mod h1:n3cpQtvxv34hfy77yVDNjmbRyujviMdxYliBSkLhpCc=
 google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013/go.mod h1:NbSheEEYHJ7i3ixzK3sjbqSGDJWnxyFXZblF3eUsNvo=
-google.golang.org/genproto v0.0.0-20200812160120-2e714abc8b50 h1:l2NG22m/r5lXIXYE8DRj5Qnqx5RO90HC7qOYCpaA04U=
-google.golang.org/genproto v0.0.0-20200812160120-2e714abc8b50/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
+google.golang.org/genproto v0.0.0-20200815001618-f69a88009b70 h1:wboULUXGF3c5qdUnKp+6gLAccE6PRpa/czkYvQ4UXv8=
+google.golang.org/genproto v0.0.0-20200815001618-f69a88009b70/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.20.1/go.mod h1:10oTOabMzJvdu6/UiuZezV6QK5dSlG84ov/aaiqXj38=
 google.golang.org/grpc v1.21.0/go.mod h1:oYelfM1adQP15Ek0mdvEgi9Df8B9CZIaU1084ijfRaM=

--- a/pkg/config/tipsel_config.go
+++ b/pkg/config/tipsel_config.go
@@ -6,13 +6,13 @@ import (
 
 const (
 	// CfgTipSelMaxDeltaTxYoungestRootSnapshotIndexToLSMI is the maximum allowed delta
-	// value for the YTRSI of a given transaction in relation to the current LSMI.
+	// value for the YTRSI of a given transaction in relation to the current LSMI before it gets lazy.
 	CfgTipSelMaxDeltaTxYoungestRootSnapshotIndexToLSMI = "tipsel.maxDeltaTxYoungestRootSnapshotIndexToLSMI"
-	// CfgTipSelMaxDeltaTxApproveesOldestRootSnapshotIndexToLSMI is the maximum allowed delta
-	// value between OTRSI of the approvees of a given transaction in relation to the current LSMI.
-	CfgTipSelMaxDeltaTxApproveesOldestRootSnapshotIndexToLSMI = "tipsel.maxDeltaTxApproveesOldestRootSnapshotIndexToLSMI"
-	// CfgTipSelBelowMaxDepth is a threshold value which indicates that a transaction
-	// is not relevant in relation to the recent parts of the tangle.
+	// CfgTipSelMaxDeltaTxOldestRootSnapshotIndexToLSMI is the maximum allowed delta
+	// value between OTRSI of a given transaction in relation to the current LSMI before it gets semi-lazy.
+	CfgTipSelMaxDeltaTxOldestRootSnapshotIndexToLSMI = "tipsel.maxDeltaTxOldestRootSnapshotIndexToLSMI"
+	// CfgTipSelBelowMaxDepth is the maximum allowed delta
+	// value between OTRSI of a given transaction in relation to the current LSMI before it gets lazy.
 	CfgTipSelBelowMaxDepth = "tipsel.belowMaxDepth"
 	// the config group used for the non-lazy tip-pool
 	CfgTipSelNonLazy = "tipsel.nonLazy."
@@ -32,11 +32,11 @@ const (
 
 func init() {
 	flag.Int(CfgTipSelMaxDeltaTxYoungestRootSnapshotIndexToLSMI, 2, "the maximum allowed delta "+
-		"value for the YTRSI of a given transaction in relation to the current LSMI")
-	flag.Int(CfgTipSelMaxDeltaTxApproveesOldestRootSnapshotIndexToLSMI, 7, "the maximum allowed delta "+
-		"value between OTRSI of the approvees of a given transaction in relation to the current LSMI")
-	flag.Int(CfgTipSelBelowMaxDepth, 15, "threshold value which indicates that a transaction "+
-		"is not relevant in relation to the recent parts of the tangle")
+		"value for the YTRSI of a given transaction in relation to the current LSMI before it gets lazy")
+	flag.Int(CfgTipSelMaxDeltaTxOldestRootSnapshotIndexToLSMI, 7, "the maximum allowed delta "+
+		"value between OTRSI of a given transaction in relation to the current LSMI before it gets semi-lazy")
+	flag.Int(CfgTipSelBelowMaxDepth, 15, "the maximum allowed delta "+
+		"value for the OTRSI of a given transaction in relation to the current LSMI before it gets lazy")
 	flag.Int(CfgTipSelNonLazy+CfgTipSelRetentionRulesTipsLimit, 100, "the maximum number of current tips for which the retention rules are checked (non-lazy)")
 	flag.Int(CfgTipSelNonLazy+CfgTipSelMaxReferencedTipAgeSeconds, 3, "the maximum time a tip remains in the tip pool "+
 		"after it was referenced by the first transaction (non-lazy)")

--- a/pkg/dag/transaction_root_snapshot_indexes.go
+++ b/pkg/dag/transaction_root_snapshot_indexes.go
@@ -31,8 +31,6 @@ func GetTransactionRootSnapshotIndexes(cachedTxMeta *tangle.CachedMetadata, lsmi
 		return yrtsi, ortsi
 	}
 
-	snapshotInfo := tangle.GetSnapshotInfo()
-
 	youngestTxRootSnapshotIndex = 0
 	oldestTxRootSnapshotIndex = 0
 
@@ -100,7 +98,9 @@ func GetTransactionRootSnapshotIndexes(cachedTxMeta *tangle.CachedMetadata, lsmi
 		},
 		// called on solid entry points
 		func(txHash hornet.Hash) {
-			updateIndexes(snapshotInfo.EntryPointIndex, snapshotInfo.EntryPointIndex)
+			// if the approvee is a solid entry point, use the index of the solid entry point as ORTSI
+			entryPointIndex, _ := tangle.SolidEntryPointsIndex(txHash)
+			updateIndexes(entryPointIndex, entryPointIndex)
 		}, true, false, false, nil); err != nil {
 		if err == tangle.ErrTransactionNotFound {
 			indexesValid = false

--- a/plugins/urts/plugin.go
+++ b/plugins/urts/plugin.go
@@ -33,7 +33,7 @@ func configure(plugin *node.Plugin) {
 
 	TipSelector = tipselect.New(
 		config.NodeConfig.GetInt(config.CfgTipSelMaxDeltaTxYoungestRootSnapshotIndexToLSMI),
-		config.NodeConfig.GetInt(config.CfgTipSelMaxDeltaTxApproveesOldestRootSnapshotIndexToLSMI),
+		config.NodeConfig.GetInt(config.CfgTipSelMaxDeltaTxOldestRootSnapshotIndexToLSMI),
 		config.NodeConfig.GetInt(config.CfgTipSelBelowMaxDepth),
 
 		config.NodeConfig.GetInt(config.CfgTipSelNonLazy+config.CfgTipSelRetentionRulesTipsLimit),

--- a/plugins/webapi/debug.go
+++ b/plugins/webapi/debug.go
@@ -222,8 +222,6 @@ func searchEntryPoints(i interface{}, c *gin.Context, _ <-chan struct{}) {
 	_, startTxConfirmedAt := cachedStartTxMeta.GetMetadata().GetConfirmed()
 	defer cachedStartTxMeta.Release(true)
 
-	snapshotInfo := tangle.GetSnapshotInfo()
-
 	dag.TraverseApprovees(cachedStartTxMeta.GetMetadata().GetTxHash(),
 		// traversal stops if no more transactions pass the given condition
 		// Caution: condition func is not in DFS order
@@ -258,7 +256,8 @@ func searchEntryPoints(i interface{}, c *gin.Context, _ <-chan struct{}) {
 		func(approveeHash hornet.Hash) error { return nil },
 		// called on solid entry points
 		func(txHash hornet.Hash) {
-			result.EntryPoints = append(result.EntryPoints, &EntryPoint{TxHash: txHash.Trytes(), ConfirmedByMilestoneIndex: snapshotInfo.EntryPointIndex})
+			entryPointIndex, _ := tangle.SolidEntryPointsIndex(txHash)
+			result.EntryPoints = append(result.EntryPoints, &EntryPoint{TxHash: txHash.Trytes(), ConfirmedByMilestoneIndex: entryPointIndex})
 		}, true, false, false, nil)
 
 	result.TanglePathLength = len(result.TanglePath)


### PR DESCRIPTION
This PR fixes using the wrong index for the solid entry points in the OTRSI, YTRSI calculation for URTS of the nodes and BMD of the COO.

It also simplifies the score calculation of URTS.