### PR TITLE
Mainnet & Devnet configs for Chrysalis Pt1 episode 2

### DIFF
--- a/config.json
+++ b/config.json
@@ -34,7 +34,7 @@
   "dashboard": {
     "bindAddress": "localhost:8081",
     "theme": "default",
-    "dev": false,
+    "dev": true,
     "basicAuth": {
       "enabled": false,
       "username": "",
@@ -45,7 +45,6 @@
   "snapshots": {
     "loadType": "local",
     "local": {
-      "depth": 50,
       "intervalSynced": 50,
       "intervalUnsynced": 1000,
       "path": "snapshots/mainnet/export.bin",
@@ -72,24 +71,6 @@
   "spentAddresses": {
     "enabled": true
   },
-  "coordinator": {
-    "address": "UDYXTZBE9GZGPM9SSQV9LTZNDLJIZMPUVVXYXFYVBLIEUHLSEWFTKZZLXYRHHWVQV9MNNX9KZC9D9UZWZ",
-    "securityLevel": 2,
-    "merkleTreeDepth": 24,
-    "mwm": 14,
-    "stateFilePath": "coordinator.state",
-    "merkleTreeFilePath": "coordinator.tree",
-    "intervalSeconds": 15,
-    "checkpoints": {
-      "maxTrackedTails": 10000
-    },
-    "tipsel": {
-      "minHeaviestBranchUnconfirmedTransactionsThreshold": 20,
-      "maxHeaviestBranchTipsPerCheckpoint": 10,
-      "randomTipsPerCheckpoint": 3,
-      "heaviestBranchSelectionDeadlineMilliseconds": 100
-    }
-  },
   "network": {
     "preferIPv6": false,
     "gossip": {
@@ -109,21 +90,6 @@
       "seed": ""
     }
   },
-  "tipsel": {
-    "maxDeltaTxYoungestRootSnapshotIndexToLSMI": 8,
-    "maxDeltaTxApproveesOldestRootSnapshotIndexToLSMI": 13,
-    "belowMaxDepth": 15,
-    "nonLazy": {
-      "retentionRulesTipsLimit": 100,
-      "maxReferencedTipAgeSeconds": 3,
-      "maxApprovers": 2
-    },
-    "semiLazy": {
-      "retentionRulesTipsLimit": 20,
-      "maxReferencedTipAgeSeconds": 3,
-      "maxApprovers": 2
-    }
-  },
   "node": {
     "alias": "",
     "showAliasInGetNodeInfo": false,
@@ -138,9 +104,6 @@
       "stdout"
     ]
   },
-  "warpsync": {
-    "advancementRange": 50
-  },
   "spammer": {
     "address": "HORNET99INTEGRATED99SPAMMER999999999999999999999999999999999999999999999999999999",
     "message": "Spamming with HORNET tipselect",
@@ -152,28 +115,6 @@
     "valueSpam": false,
     "workers": 0,
     "semiLazyTipsLimit": 30
-  },
-  "graph": {
-    "webRootPath": "IOTAtangle/webroot",
-    "domain": "",
-    "webSocket": {
-      "uri": ""
-    },
-    "bindAddress": "localhost:8083",
-    "networkName": "meets HORNET",
-    "explorerTxLink": "http://0.0.0.0:8081/explorer/tx/",
-    "explorerBundleLink": "http://0.0.0.0:8081/explorer/bundle/"
-  },
-  "monitor": {
-    "tangleMonitorPath": "tanglemonitor/frontend",
-    "domain": "",
-    "initialTransactions": 15000,
-    "remoteApiPort": 4433,
-    "webBindAddress": "localhost:4434",
-    "apiBindAddress": "localhost:4433",
-    "webSocket": {
-      "uri": ""
-    }
   },
   "mqtt": {
     "config": "mqtt_config.json"

--- a/config.json
+++ b/config.json
@@ -34,7 +34,6 @@
   "dashboard": {
     "bindAddress": "localhost:8081",
     "theme": "default",
-    "dev": true,
     "basicAuth": {
       "enabled": false,
       "username": "",

--- a/config.json
+++ b/config.json
@@ -95,14 +95,6 @@
     "disablePlugins": [],
     "enablePlugins": []
   },
-  "logger": {
-    "level": "info",
-    "disableCaller": true,
-    "encoding": "console",
-    "outputPaths": [
-      "stdout"
-    ]
-  },
   "spammer": {
     "address": "HORNET99INTEGRATED99SPAMMER999999999999999999999999999999999999999999999999999999",
     "message": "Spamming with HORNET tipselect",

--- a/config.json
+++ b/config.json
@@ -34,6 +34,7 @@
   "dashboard": {
     "bindAddress": "localhost:8081",
     "theme": "default",
+    "dev": false,
     "basicAuth": {
       "enabled": false,
       "username": "",
@@ -44,6 +45,7 @@
   "snapshots": {
     "loadType": "local",
     "local": {
+      "depth": 50,
       "intervalSynced": 50,
       "intervalUnsynced": 1000,
       "path": "snapshots/mainnet/export.bin",
@@ -70,6 +72,24 @@
   "spentAddresses": {
     "enabled": true
   },
+  "coordinator": {
+    "address": "UDYXTZBE9GZGPM9SSQV9LTZNDLJIZMPUVVXYXFYVBLIEUHLSEWFTKZZLXYRHHWVQV9MNNX9KZC9D9UZWZ",
+    "securityLevel": 2,
+    "merkleTreeDepth": 24,
+    "mwm": 14,
+    "stateFilePath": "coordinator.state",
+    "merkleTreeFilePath": "coordinator.tree",
+    "intervalSeconds": 15,
+    "checkpoints": {
+      "maxTrackedTails": 10000
+    },
+    "tipsel": {
+      "minHeaviestBranchUnconfirmedTransactionsThreshold": 20,
+      "maxHeaviestBranchTipsPerCheckpoint": 10,
+      "randomTipsPerCheckpoint": 3,
+      "heaviestBranchSelectionDeadlineMilliseconds": 100
+    }
+  },
   "network": {
     "preferIPv6": false,
     "gossip": {
@@ -89,11 +109,37 @@
       "seed": ""
     }
   },
+  "tipsel": {
+    "maxDeltaTxYoungestRootSnapshotIndexToLSMI": 8,
+    "maxDeltaTxApproveesOldestRootSnapshotIndexToLSMI": 13,
+    "belowMaxDepth": 15,
+    "nonLazy": {
+      "retentionRulesTipsLimit": 100,
+      "maxReferencedTipAgeSeconds": 3,
+      "maxApprovers": 2
+    },
+    "semiLazy": {
+      "retentionRulesTipsLimit": 20,
+      "maxReferencedTipAgeSeconds": 3,
+      "maxApprovers": 2
+    }
+  },
   "node": {
     "alias": "",
     "showAliasInGetNodeInfo": false,
     "disablePlugins": [],
     "enablePlugins": []
+  },
+  "logger": {
+    "level": "info",
+    "disableCaller": true,
+    "encoding": "console",
+    "outputPaths": [
+      "stdout"
+    ]
+  },
+  "warpsync": {
+    "advancementRange": 50
   },
   "spammer": {
     "address": "HORNET99INTEGRATED99SPAMMER999999999999999999999999999999999999999999999999999999",
@@ -106,6 +152,31 @@
     "valueSpam": false,
     "workers": 0,
     "semiLazyTipsLimit": 30
+  },
+  "graph": {
+    "webRootPath": "IOTAtangle/webroot",
+    "domain": "",
+    "webSocket": {
+      "uri": ""
+    },
+    "bindAddress": "localhost:8083",
+    "networkName": "meets HORNET",
+    "explorerTxLink": "http://0.0.0.0:8081/explorer/tx/",
+    "explorerBundleLink": "http://0.0.0.0:8081/explorer/bundle/"
+  },
+  "monitor": {
+    "tangleMonitorPath": "tanglemonitor/frontend",
+    "domain": "",
+    "initialTransactions": 15000,
+    "remoteApiPort": 4433,
+    "webBindAddress": "localhost:4434",
+    "apiBindAddress": "localhost:4433",
+    "webSocket": {
+      "uri": ""
+    }
+  },
+  "mqtt": {
+    "config": "mqtt_config.json"
   },
   "zmq": {
     "bindAddress": "localhost:5556"

--- a/config.json
+++ b/config.json
@@ -115,9 +115,6 @@
     "workers": 0,
     "semiLazyTipsLimit": 30
   },
-  "mqtt": {
-    "config": "mqtt_config.json"
-  },
   "zmq": {
     "bindAddress": "localhost:5556"
   },

--- a/config_devnet.json
+++ b/config_devnet.json
@@ -52,16 +52,9 @@
       "intervalSynced": 50,
       "intervalUnsynced": 1000,
       "path": "snapshots/devnet/export.bin",
-      "downloadURL": "https://dbfiles.iota.org/devnet/hornet/latest-export.bin"
+      "downloadURLs": ["https://dbfiles.iota.org/devnet/hornet/latest-export.bin"]
     },
     "global": {
-      "path": "snapshotDevnet.txt",
-      "spentAddressesPaths": [
-        "previousEpochsSpentAddresses1.txt",
-        "previousEpochsSpentAddresses2.txt",
-        "previousEpochsSpentAddresses3.txt"
-      ],
-      "index": 1050000
     },
     "pruning": {
       "enabled": true,
@@ -78,7 +71,7 @@
     "mwm": 9,
     "stateFilePath": "coordinator.state",
     "merkleTreeFilePath": "coordinator.tree",
-    "intervalSeconds": 60,
+    "intervalSeconds": 30,
     "checkpoints": {
       "maxTrackedTails": 10000
     },
@@ -134,7 +127,7 @@
     ]
   },
   "warpsync": {
-    "advancementRange": 200
+    "advancementRange": 50
   },
   "spammer": {
     "address": "HORNET99INTEGRATED99SPAMMER999999999999999999999999999999999999999999999999999999",
@@ -147,6 +140,28 @@
     "valueSpam": false,
     "workers": 0,
     "semiLazyTipsLimit": 30
+  },
+  "graph": {
+    "webRootPath": "IOTAtangle/webroot",
+    "domain": "",
+    "webSocket": {
+      "uri": ""
+    },
+    "bindAddress": "localhost:8083",
+    "networkName": "meets HORNET",
+    "explorerTxLink": "http://0.0.0.0:8081/explorer/tx/",
+    "explorerBundleLink": "http://0.0.0.0:8081/explorer/bundle/"
+  },
+  "monitor": {
+    "tangleMonitorPath": "tanglemonitor/frontend",
+    "domain": "",
+    "initialTransactions": 15000,
+    "remoteApiPort": 4433,
+    "webBindAddress": "localhost:4434",
+    "apiBindAddress": "localhost:4433",
+    "webSocket": {
+      "uri": ""
+    }
   },
   "mqtt": {
     "config": "mqtt_config.json"

--- a/config_devnet.json
+++ b/config_devnet.json
@@ -126,9 +126,6 @@
       "stdout"
     ]
   },
-  "warpsync": {
-    "advancementRange": 50
-  },
   "spammer": {
     "address": "HORNET99INTEGRATED99SPAMMER999999999999999999999999999999999999999999999999999999",
     "message": "Spamming with HORNET tipselect",
@@ -140,28 +137,6 @@
     "valueSpam": false,
     "workers": 0,
     "semiLazyTipsLimit": 30
-  },
-  "graph": {
-    "webRootPath": "IOTAtangle/webroot",
-    "domain": "",
-    "webSocket": {
-      "uri": ""
-    },
-    "bindAddress": "localhost:8083",
-    "networkName": "meets HORNET",
-    "explorerTxLink": "http://0.0.0.0:8081/explorer/tx/",
-    "explorerBundleLink": "http://0.0.0.0:8081/explorer/bundle/"
-  },
-  "monitor": {
-    "tangleMonitorPath": "tanglemonitor/frontend",
-    "domain": "",
-    "initialTransactions": 15000,
-    "remoteApiPort": 4433,
-    "webBindAddress": "localhost:4434",
-    "apiBindAddress": "localhost:4433",
-    "webSocket": {
-      "uri": ""
-    }
   },
   "mqtt": {
     "config": "mqtt_config.json"

--- a/config_devnet.json
+++ b/config_devnet.json
@@ -117,15 +117,7 @@
     "showAliasInGetNodeInfo": false,
     "disablePlugins": [],
     "enablePlugins": []
-  },
-  "logger": {
-    "level": "info",
-    "disableCaller": true,
-    "encoding": "console",
-    "outputPaths": [
-      "stdout"
-    ]
-  },
+  },  
   "spammer": {
     "address": "HORNET99INTEGRATED99SPAMMER999999999999999999999999999999999999999999999999999999",
     "message": "Spamming with HORNET tipselect",
@@ -137,9 +129,6 @@
     "valueSpam": false,
     "workers": 0,
     "semiLazyTipsLimit": 30
-  },
-  "mqtt": {
-    "config": "mqtt_config.json"
   },
   "zmq": {
     "bindAddress": "localhost:5556"

--- a/pkg/config/coordinator_config.go
+++ b/pkg/config/coordinator_config.go
@@ -46,11 +46,11 @@ func init() {
 		"increasing this number by 1 will result in proof of work that is 3 times as hard.")
 	flag.String(CfgCoordinatorStateFilePath, "coordinator.state", "the path to the state file of the coordinator")
 	flag.String(CfgCoordinatorMerkleTreeFilePath, "coordinator.tree", "the path to the Merkle tree of the coordinator")
-	flag.Int(CfgCoordinatorIntervalSeconds, 60, "the interval milestones are issued")
+	flag.Int(CfgCoordinatorIntervalSeconds, 15, "the interval milestones are issued")
 	flag.String(CfgCoordinatorMilestoneMerkleTreeHashFunc, "BLAKE2b-512", "the hash function the coordinator will use to calculate milestone merkle tree hash (see RFC-0012)")
 	flag.Int(CfgCoordinatorCheckpointsMaxTrackedTails, 10000, "maximum amount of known bundle tails for milestone tipselection")
 	flag.Int(CfgCoordinatorTipselectMinHeaviestBranchUnconfirmedTransactionsThreshold, 20, "minimum threshold of unconfirmed transactions in the heaviest branch")
 	flag.Int(CfgCoordinatorTipselectMaxHeaviestBranchTipsPerCheckpoint, 10, "maximum amount of checkpoint transactions with heaviest branch tips")
-	flag.Int(CfgCoordinatorTipselectRandomTipsPerCheckpoint, 2, "amount of checkpoint transactions with random tips")
+	flag.Int(CfgCoordinatorTipselectRandomTipsPerCheckpoint, 3, "amount of checkpoint transactions with random tips")
 	flag.Int(CfgCoordinatorTipselectHeaviestBranchSelectionDeadlineMilliseconds, 100, "the maximum duration to select the heaviest branch tips in milliseconds")
 }

--- a/pkg/config/tipsel_config.go
+++ b/pkg/config/tipsel_config.go
@@ -31,9 +31,9 @@ const (
 )
 
 func init() {
-	flag.Int(CfgTipSelMaxDeltaTxYoungestRootSnapshotIndexToLSMI, 2, "the maximum allowed delta "+
+	flag.Int(CfgTipSelMaxDeltaTxYoungestRootSnapshotIndexToLSMI, 8, "the maximum allowed delta "+
 		"value for the YTRSI of a given transaction in relation to the current LSMI")
-	flag.Int(CfgTipSelMaxDeltaTxApproveesOldestRootSnapshotIndexToLSMI, 7, "the maximum allowed delta "+
+	flag.Int(CfgTipSelMaxDeltaTxApproveesOldestRootSnapshotIndexToLSMI, 13, "the maximum allowed delta "+
 		"value between OTRSI of the approvees of a given transaction in relation to the current LSMI")
 	flag.Int(CfgTipSelBelowMaxDepth, 15, "threshold value which indicates that a transaction "+
 		"is not relevant in relation to the recent parts of the tangle")

--- a/pkg/config/warpsync_config.go
+++ b/pkg/config/warpsync_config.go
@@ -10,5 +10,5 @@ const (
 )
 
 func init() {
-	flag.Int(CfgWarpSyncAdvancementRange, 50, "the used advancement range per warpsync checkpoint")
+	flag.Int(CfgWarpSyncAdvancementRange, 200, "the used advancement range per warpsync checkpoint")
 }

--- a/pkg/config/warpsync_config.go
+++ b/pkg/config/warpsync_config.go
@@ -10,5 +10,5 @@ const (
 )
 
 func init() {
-	flag.Int(CfgWarpSyncAdvancementRange, 200, "the used advancement range per warpsync checkpoint")
+	flag.Int(CfgWarpSyncAdvancementRange, 50, "the used advancement range per warpsync checkpoint")
 }


### PR DESCRIPTION
## Description
Here are the proposed config files for DevNet and MainNet for Chrysalis Pt1 vol 2. **Stolen from Andrea's PR.** 
Configuration blocks that do not set specific values relevant for tipselection or coordinator has been selected with sane defaults for end-user usability.

## Rationale for MainNet values
- intervalSeconds: 15 we want to be fast to confirm quickly and avoid attacks by denying creation of big side-tangles.
- `C1`: `8` -> Regular tipselection will reduce the amount of non-lazy tips, as we select a pretty big value here.
- `C2`: `13` -> If your device is slow, allow a certain "grace" period for new tips to be considered semi-lazy, having more than a - minute (`C2` - `C1`) window buffer to be narrowed by spammers.
- `BMD`: `15` -> Way too slow, sorry. The amount of PoW needed to confirm too far past this point is undoable.
- `maxHeaviestBranchTipsPerCheckpoint`: `10` -> Let's try to confirm as many tips as possible; assuming a pretty slow and geographically-distributed network with high(ish) lambda we try to collect quite a few tips.
- `randomTipsPerCheckpoint`: `3` -> Keep this choice of values quite fluid by allowing a good portion of randomness in the heaviest tipsel.