### PR TITLE
Fix: Do not change default GOMAXPROCS value

### DIFF
--- a/plugins/database/plugin.go
+++ b/plugins/database/plugin.go
@@ -1,10 +1,7 @@
 package database
 
 import (
-	"runtime"
 	"time"
-
-	"github.com/spf13/viper"
 
 	"github.com/iotaledger/hive.go/daemon"
 	"github.com/iotaledger/hive.go/logger"
@@ -25,15 +22,6 @@ var (
 
 func configure(plugin *node.Plugin) {
 	log = logger.NewLogger(plugin.Name)
-
-	viper.BindEnv("GOMAXPROCS")
-	goMaxProcsEnv := viper.GetInt("GOMAXPROCS")
-	if goMaxProcsEnv == 0 {
-		// badger documentation recommends setting a high number for GOMAXPROCS.
-		// this allows Go to observe the full IOPS throughput provided by modern SSDs.
-		// Dgraph uses 128.
-		runtime.GOMAXPROCS(128)
-	}
 
 	tangle.ConfigureDatabases(config.NodeConfig.GetString(config.CfgDatabasePath))
 


### PR DESCRIPTION
# Description

This PR removes the override of the default `GOMAXPROCS` value. When the corresponding environment variable is not set, leaving `GOMAXPROCS` at its default should lead to reasonable behavior on all systems and platforms.

Fixes #675 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- Starting HORNET and then checking its threads with e.g. `cat /proc/<PROCESS_PID>/status | grep Threads` will now return a value closer to the available CPU threads instead of ≥ 128.
- Note, `GOMAXPROCS` only limits the number of active threads. Threads blocked because of IO operations for examples can lead to a higher number of threads. This is intended behavior.
- I did some benchmark syncs on amd64 VPS, leading to similar sync times and reduced CPU loads.

# Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have made corresponding changes to the documentation
- [x] I have tested my code extensively
- [x] I have selected the `develop` branch as the target branch
