### PR TITLE
Fix: Improve tryte distribution of tools/rand-seed

### DIFF
--- a/tools/rand-seed/rand_seed.go
+++ b/tools/rand-seed/rand_seed.go
@@ -5,18 +5,19 @@ import (
 	"fmt"
 
 	"github.com/iotaledger/iota.go/consts"
+	"github.com/iotaledger/iota.go/kerl"
 )
 
 func main() {
-	b := make([]byte, consts.HashTrytesSize)
+	b := make([]byte, consts.HashBytesSize)
 	if _, err := rand.Read(b); err != nil {
 		panic(err)
 	}
 
-	tryteAlphabetLength := len(consts.TryteAlphabet)
-	var seed string
-	for _, randByte := range b {
-		seed += string(consts.TryteAlphabet[randByte%byte(tryteAlphabetLength)])
+	// convert to trytes and set the last trit to zero
+	seed, err := kerl.KerlBytesToTrytes(b)
+	if err != nil {
+		panic(err)
 	}
 
 	fmt.Println(seed)


### PR DESCRIPTION
# Description

The trytes of the seed generated with `tools/rand-seed` are not uniformly distributed since 256 is not divisible by 27 (`tryteAlphabetLength`). This slightly reduces the security of the seed.
This PR proposes to use `KerlBytesToTrytes` instead, which works on the entire 48-byte entropy and not on individual trytes. It also assures that the 243rd (last) trit of the hash is always zero, which is a requirement for the key derivation functions implemented in `iotaledger/iota.go`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have tested my code extensively
- [x] I have selected the `develop` branch as the target branch
