### PR TITLE
WIP: Adds local snapshot file generation compatible with Chrysalis Phase 2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.15
 require (
 	github.com/Microsoft/go-winio v0.4.14 // indirect
 	github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d // indirect
+	github.com/blang/vfs v1.0.0
 	github.com/cockroachdb/pebble v0.0.0-20200928201937-b5c5df0302e3
 	github.com/dchest/blake2b v1.0.0
 	github.com/docker/distribution v2.7.1+incompatible // indirect
@@ -27,6 +28,7 @@ require (
 	github.com/kr/pretty v0.2.1 // indirect
 	github.com/labstack/echo/v4 v4.1.17
 	github.com/labstack/gommon v0.3.0
+	github.com/luca-moser/iota v0.0.0-20200907161409-c2ea8722f631
 	github.com/mitchellh/mapstructure v1.3.3
 	github.com/mr-tron/base58 v1.2.0
 	github.com/muxxer/iota.go v1.0.0-beta.11.0.20200916213055-851daf436c69

--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,6 @@ require (
 	github.com/kr/pretty v0.2.1 // indirect
 	github.com/labstack/echo/v4 v4.1.17
 	github.com/labstack/gommon v0.3.0
-	github.com/luca-moser/iota v0.0.0-20200907161409-c2ea8722f631
 	github.com/mitchellh/mapstructure v1.3.3
 	github.com/mr-tron/base58 v1.2.0
 	github.com/muxxer/iota.go v1.0.0-beta.11.0.20200916213055-851daf436c69

--- a/integration-tests/tester/docker-compose.yml
+++ b/integration-tests/tester/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3.5"
 services:
   tester:
     container_name: tester
-    image: golang:1.14.4
+    image: golang:1.15.2
     working_dir: /tmp/hornet/integration-tests/tester
     command: /tmp/assets/entrypoint.sh
     environment:

--- a/plugins/snapshot/local_snapshot.go
+++ b/plugins/snapshot/local_snapshot.go
@@ -1,12 +1,10 @@
 package snapshot
 
 import (
-	"bufio"
 	"crypto/sha256"
-	"encoding/binary"
+	"fmt"
 	"io"
 	"os"
-	"path/filepath"
 	"time"
 
 	"github.com/pkg/errors"
@@ -26,11 +24,12 @@ const (
 )
 
 var (
-	SupportedLocalSnapshotFileVersions = []byte{5}
-
-	ErrCritical                 = errors.New("critical error")
+	// Returned when a critical error stops the execution of a task.
+	ErrCritical = errors.New("critical error")
+	// Returned when an unsupported local snapshot file version is read.
 	ErrUnsupportedLSFileVersion = errors.New("unsupported local snapshot file version")
-	ErrChildMsgNotFound         = errors.New("child message not found")
+	// Returned when a child message wasn't found.
+	ErrChildMsgNotFound = errors.New("child message not found")
 )
 
 // isSolidEntryPoint checks whether any direct child of the given message was confirmed by a milestone which is above the target milestone.
@@ -56,7 +55,7 @@ func isSolidEntryPoint(messageID hornet.Hash, targetIndex milestone.Index) bool 
 	return false
 }
 
-// getMilestoneParents traverses a milestone and collects all messages that were confirmed by that milestone or newer
+// getMilestoneParents traverses a milestone and collects all messages that were confirmed by that milestone or newer.
 func getMilestoneParentMessageIDs(milestoneIndex milestone.Index, milestoneMessageID hornet.Hash, abortSignal <-chan struct{}) (hornet.Hashes, error) {
 
 	var parentMessageIDs hornet.Hashes
@@ -185,7 +184,7 @@ func checkSnapshotLimits(targetIndex milestone.Index, snapshotInfo *tangle.Snaps
 	}
 
 	minimumIndex := milestone.Index(SolidEntryPointCheckThresholdPast + 1)
-	maximumIndex := milestone.Index(solidMilestoneIndex - SolidEntryPointCheckThresholdFuture)
+	maximumIndex := solidMilestoneIndex - SolidEntryPointCheckThresholdFuture
 
 	if checkSnapshotIndex && minimumIndex < snapshotInfo.SnapshotIndex+1 {
 		minimumIndex = snapshotInfo.SnapshotIndex + 1
@@ -210,63 +209,20 @@ func checkSnapshotLimits(targetIndex milestone.Index, snapshotInfo *tangle.Snaps
 	return nil
 }
 
-func createSnapshotFile(filePath string, lsh *localSnapshotHeader, abortSignal <-chan struct{}) ([]byte, error) {
-
-	if _, fileErr := os.Stat(filePath); os.IsNotExist(fileErr) {
-		// create dir if it not exists
-		if err := os.MkdirAll(filepath.Dir(filePath), 0700); err != nil {
-			return nil, err
-		}
-	}
-	exportFile, err := os.OpenFile(filePath, os.O_RDWR|os.O_CREATE, 0660)
-	if err != nil {
-		return nil, err
-	}
-	defer exportFile.Close()
-
-	// write into the file with an 8MB buffer
-	fileBufWriter := bufio.NewWriterSize(exportFile, 4096*2)
-
-	// write header, SEPs, seen milestones and ledger
-	if err := lsh.WriteToBuffer(fileBufWriter, abortSignal); err != nil {
-		return nil, err
-	}
-
-	// flush remains of header and content to file
-	if err := fileBufWriter.Flush(); err != nil {
-		return nil, err
-	}
-
-	// seek back to the beginning of the file
-	if _, err := exportFile.Seek(0, 0); err != nil {
-		return nil, err
-	}
-
-	// compute sha256 of file
-	lsHash := sha256.New()
-	if _, err := io.Copy(lsHash, exportFile); err != nil {
-		return nil, err
-	}
-
-	// write sha256 hash into the file
-	sha256Hash := lsHash.Sum(nil)
-	if err := binary.Write(exportFile, binary.LittleEndian, sha256Hash); err != nil {
-		return nil, err
-	}
-
-	return sha256Hash, nil
-}
-
 func setIsSnapshotting(value bool) {
 	statusLock.Lock()
 	isSnapshotting = value
 	statusLock.Unlock()
 }
 
+func CreateLocalSnapshot(targetIndex milestone.Index, filePath string, writeToDatabase bool, abortSignal <-chan struct{}) error {
+	localSnapshotLock.Lock()
+	defer localSnapshotLock.Unlock()
+	return createLocalSnapshotWithoutLocking(targetIndex, filePath, writeToDatabase, abortSignal)
+}
+
 func createLocalSnapshotWithoutLocking(targetIndex milestone.Index, filePath string, writeToDatabase bool, abortSignal <-chan struct{}) error {
-
 	log.Infof("creating local snapshot for targetIndex %d", targetIndex)
-
 	ts := time.Now()
 
 	snapshotInfo := tangle.GetSnapshotInfo()
@@ -287,46 +243,42 @@ func createLocalSnapshotWithoutLocking(targetIndex milestone.Index, filePath str
 	}
 	defer cachedTargetMilestone.Release(true) // milestone -1
 
-	newBalances := make(map[string]uint64)
-	/*
-		newBalances, ledgerIndex, err := tangle.GetLedgerStateForMilestone(targetIndex, abortSignal)
-		if err != nil {
-			if err == tangle.ErrOperationAborted {
-				return err
-			}
-			return errors.Wrap(ErrCritical, err.Error())
-		}
-
-		if ledgerIndex != targetIndex {
-			return errors.Wrapf(ErrCritical, "ledger index wrong! %d/%d", ledgerIndex, targetIndex)
-		}
-	*/
-
-	newSolidEntryPoints, err := getSolidEntryPoints(targetIndex, abortSignal)
-	if err != nil {
-		return err
+	header := &FileHeader{
+		Version:        SupportedFormatVersion,
+		MilestoneIndex: uint64(targetIndex),
+		Timestamp:      uint64(ts.Unix()),
 	}
+	copy(header.MilestoneHash[:], cachedTargetMilestone.GetMilestone().MessageID)
 
-	lsh := &localSnapshotHeader{
-		milestoneMessageID: cachedTargetMilestone.GetMilestone().MessageID,
-		msIndex:            targetIndex,
-		msTimestamp:        cachedTargetMilestone.GetMilestone().Timestamp,
-		solidEntryPoints:   newSolidEntryPoints,
-		balances:           newBalances,
-	}
-
+	// build temp file path
 	filePathTmp := filePath + "_tmp"
+	_ = os.Remove(filePathTmp)
 
-	// Remove old temp file
-	os.Remove(filePathTmp)
-
-	hash, err := createSnapshotFile(filePathTmp, lsh, abortSignal)
+	// create temp file
+	lsFile, err := os.OpenFile(filePathTmp, os.O_RDWR|os.O_CREATE, 0666)
 	if err != nil {
-		return err
+		return fmt.Errorf("unable to create tmp local snapshot file: %w", err)
 	}
 
+	if err := StreamLocalSnapshotDataTo(lsFile, header,
+		func() *[32]byte {
+			// TODO: generate SEP
+			return nil
+		},
+		func() *TransactionOutputs {
+			// TODO: generate UTXO
+			return nil
+		}); err != nil {
+		_ = lsFile.Close()
+		return fmt.Errorf("couldn't generate local snapshot file: %w", err)
+	}
+
+	// rename tmp file to final file name
+	if err := lsFile.Close(); err != nil {
+		return fmt.Errorf("unable to close local snapshot file: %w", err)
+	}
 	if err := os.Rename(filePathTmp, filePath); err != nil {
-		return err
+		return fmt.Errorf("unable to rename temp local snapshot file: %w", err)
 	}
 
 	if writeToDatabase {
@@ -348,260 +300,84 @@ func createLocalSnapshotWithoutLocking(targetIndex milestone.Index, filePath str
 		tanglePlugin.Events.SnapshotMilestoneIndexChanged.Trigger(targetIndex)
 	}
 
-	log.Infof("created local snapshot for target index %d (sha256: %x), took %v", targetIndex, hash, time.Since(ts))
+	// re-read the local snapshot file to compute its hash.
+	// note that this step can only be done after the local snapshot file
+	// has been written since the ls file generation uses seeking.
+	lsFileHash, err := localSnapshotFileHash(filePath)
+	if err != nil {
+		return err
+	}
 
+	log.Infof("created local snapshot for target index %d (sha256: %x), took %v", targetIndex, lsFileHash, time.Since(ts))
 	return nil
 }
 
-func CreateLocalSnapshot(targetIndex milestone.Index, filePath string, writeToDatabase bool, abortSignal <-chan struct{}) error {
-	localSnapshotLock.Lock()
-	defer localSnapshotLock.Unlock()
-	return createLocalSnapshotWithoutLocking(targetIndex, filePath, writeToDatabase, abortSignal)
-}
-
-type localSnapshotHeader struct {
-	milestoneMessageID hornet.Hash
-	msIndex            milestone.Index
-	msTimestamp        time.Time
-	solidEntryPoints   map[string]milestone.Index
-	balances           map[string]uint64
-}
-
-func (ls *localSnapshotHeader) WriteToBuffer(buf io.Writer, abortSignal <-chan struct{}) error {
-	var err error
-
-	if err = binary.Write(buf, binary.LittleEndian, SupportedLocalSnapshotFileVersions[0]); err != nil {
-		return err
+// computes the sha256b hash of the given local snapshot file.
+func localSnapshotFileHash(filePath string) ([]byte, error) {
+	writtenLsFile, err := os.Open(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("unable to open local snapshot file for hash computation: %w", err)
 	}
+	defer writtenLsFile.Close()
 
-	if err = binary.Write(buf, binary.LittleEndian, ls.milestoneMessageID[:32]); err != nil {
-		return err
+	sha256Hash := sha256.New()
+	if _, err := io.Copy(sha256Hash, writtenLsFile); err != nil {
+		return nil, fmt.Errorf("unable to copy local snapshot file content for hash computation: %w", err)
 	}
-
-	if err = binary.Write(buf, binary.LittleEndian, ls.msIndex); err != nil {
-		return err
-	}
-
-	if err = binary.Write(buf, binary.LittleEndian, int64(ls.msTimestamp.Second())); err != nil {
-		return err
-	}
-
-	if err = binary.Write(buf, binary.LittleEndian, int32(len(ls.solidEntryPoints))); err != nil {
-		return err
-	}
-
-	if err = binary.Write(buf, binary.LittleEndian, int32(len(ls.balances))); err != nil {
-		return err
-	}
-
-	for messageID, val := range ls.solidEntryPoints {
-		select {
-		case <-abortSignal:
-			return ErrSnapshotCreationWasAborted
-		default:
-		}
-
-		if err = binary.Write(buf, binary.LittleEndian, hornet.Hash(messageID)[:32]); err != nil {
-			return err
-		}
-
-		if err = binary.Write(buf, binary.LittleEndian, val); err != nil {
-			return err
-		}
-	}
-
-	for addr, val := range ls.balances {
-		select {
-		case <-abortSignal:
-			return ErrSnapshotCreationWasAborted
-		default:
-		}
-
-		if err = binary.Write(buf, binary.LittleEndian, hornet.Hash(addr)[:32]); err != nil {
-			return err
-		}
-
-		if err = binary.Write(buf, binary.LittleEndian, val); err != nil {
-			return err
-		}
-	}
-
-	return nil
+	return sha256Hash.Sum(nil), nil
 }
 
 func LoadSnapshotFromFile(filePath string) error {
-	log.Info("Loading snapshot file...")
+	log.Info("importing snapshot file...")
 
-	// ToDo:
+	lsFile, err := os.Open(filePath)
+	if err != nil {
+		return fmt.Errorf("unable to open local snapshot file for import: %w", err)
+	}
+	defer lsFile.Close()
+
+	var lsHeader *FileHeader
+	var outputsCount uint64
+
+	headerConsumer := func(header *FileHeader) error {
+		if header.Version != SupportedFormatVersion {
+			return errors.Wrapf(ErrUnsupportedLSFileVersion, "local snapshot file version is %d but this HORNET version only supports %v", header.Version, SupportedFormatVersion)
+		}
+		lsHeader = header
+		log.Infof("solid entry points: %d, utxo txs: %d", header.SEPCount, header.UTXOCount)
+		return nil
+	}
+
+	// note that we only get the hash of the SEP message instead
+	// of also its associated oldest cone root index, since the index
+	// of the local snapshot milestone will be below max depth anyway.
+	// this information was included in pre Chrysalis Phase 2 local snapshots
+	// but has been deemed unnecessary for the reason mentioned above.
+	sepConsumer := func(sepMsgHashBytes [32]byte) error {
+		// TODO: consume SEP
+		return nil
+	}
+
+	utxoConsumer := func(outputs *TransactionOutputs) error {
+		outputsCount += uint64(len(outputs.UnspentOutputs))
+		// TODO: consume UTXOs
+		return nil
+	}
+
+	if err := StreamLocalSnapshotDataFrom(lsFile, headerConsumer, sepConsumer, utxoConsumer); err != nil {
+		return fmt.Errorf("unable to import local snapshot file: %w", err)
+	}
+
+	log.Infof("imported local snapshot file: %d SEPs, %d txs, %d outputs", lsHeader.SEPCount, lsHeader.UTXOCount, outputsCount)
 
 	cooPublicKey, err := utils.ParseEd25519PublicKeyFromString(config.NodeConfig.GetString(config.CfgCoordinatorPublicKey))
 	if err != nil {
 		return err
 	}
 
-	tangle.SetSnapshotMilestone(cooPublicKey, hornet.NullMessageID, milestone.Index(1), milestone.Index(1), milestone.Index(1), time.Now())
-	tangle.SetSolidMilestoneIndex(milestone.Index(1), false)
+	lsMilestoneIndex := milestone.Index(lsHeader.MilestoneIndex)
+	tangle.SetSnapshotMilestone(cooPublicKey, lsHeader.MilestoneHash[:], lsMilestoneIndex, lsMilestoneIndex, lsMilestoneIndex, time.Now())
+	tangle.SetSolidMilestoneIndex(lsMilestoneIndex, false)
 
 	return nil
-	/*
-		file, err := os.OpenFile(filePath, os.O_RDONLY, 0666)
-		if err != nil {
-			return err
-		}
-		defer file.Close()
-
-		// check file version
-		var fileVersion byte
-		if err := binary.Read(file, binary.LittleEndian, &fileVersion); err != nil {
-			return err
-		}
-
-		var supported bool
-		for _, v := range SupportedLocalSnapshotFileVersions {
-			if v == fileVersion {
-				supported = true
-				break
-			}
-		}
-		if !supported {
-			return errors.Wrapf(ErrUnsupportedLSFileVersion, "local snapshot file version is %d but this HORNET version only supports %v", fileVersion, SupportedLocalSnapshotFileVersions)
-		}
-
-		milestoneMessageID := make(hornet.Hash, 32)
-		if _, err := file.Read(milestoneMessageID); err != nil {
-			return err
-		}
-
-		tangle.WriteLockSolidEntryPoints()
-		tangle.ResetSolidEntryPoints()
-
-		var msIndex int32
-		var msTimestamp int64
-		var solidEntryPointsCount, seenMilestonesCount, ledgerEntriesCount int32
-
-		if err := binary.Read(file, binary.LittleEndian, &msIndex); err != nil {
-			return err
-		}
-
-		if err := binary.Read(file, binary.LittleEndian, &msTimestamp); err != nil {
-			return err
-		}
-
-		if err := binary.Read(file, binary.LittleEndian, &solidEntryPointsCount); err != nil {
-			return err
-		}
-
-		if err := binary.Read(file, binary.LittleEndian, &seenMilestonesCount); err != nil {
-			return err
-		}
-
-		if err := binary.Read(file, binary.LittleEndian, &ledgerEntriesCount); err != nil {
-			return err
-		}
-
-		cooPublicKey, err := utils.ParseEd25519PublicKeyFromString(config.NodeConfig.GetString(config.CfgCoordinatorPublicKey))
-		if err != nil {
-			return err
-		}
-
-		tangle.SetSnapshotMilestone(cooPublicKey, milestoneMessageID, milestone.Index(msIndex), milestone.Index(msIndex), milestone.Index(msIndex), time.Unix(msTimestamp, 0))
-		tangle.SolidEntryPointsAdd(milestoneMessageID, milestone.Index(msIndex))
-
-		log.Info("importing solid entry points")
-
-		for i := 0; i < int(solidEntryPointsCount); i++ {
-			if daemon.IsStopped() {
-				return ErrSnapshotImportWasAborted
-			}
-
-			var val int32
-			messageIDBuf := make(hornet.Hash, 32)
-
-			if err := binary.Read(file, binary.LittleEndian, messageIDBuf); err != nil {
-				return errors.Wrapf(ErrSnapshotImportFailed, "solidEntryPoints: %v", err)
-			}
-
-			if err := binary.Read(file, binary.LittleEndian, &val); err != nil {
-				return errors.Wrapf(ErrSnapshotImportFailed, "solidEntryPoints: %v", err)
-			}
-
-			tangle.SolidEntryPointsAdd(messageIDBuf, milestone.Index(val))
-		}
-
-		tangle.StoreSolidEntryPoints()
-		tangle.WriteUnlockSolidEntryPoints()
-
-		log.Info("importing seen milestones")
-
-		for i := 0; i < int(seenMilestonesCount); i++ {
-			if daemon.IsStopped() {
-				return ErrSnapshotImportWasAborted
-			}
-
-			var val int32
-			messageIDBuf := make(hornet.Hash, 32)
-
-			if err := binary.Read(file, binary.LittleEndian, messageIDBuf); err != nil {
-				return errors.Wrapf(ErrSnapshotImportFailed, "seenMilestones: %v", err)
-			}
-
-			if err := binary.Read(file, binary.LittleEndian, &val); err != nil {
-				return errors.Wrapf(ErrSnapshotImportFailed, "seenMilestones: %v", err)
-			}
-
-			// request the milestone and prevent the request from being discarded from the request queue
-			gossip.Request(messageIDBuf, milestone.Index(val), true)
-		}
-
-		log.Info("importing ledger state")
-
-		ledgerState := make(map[string]uint64)
-		for i := 0; i < int(ledgerEntriesCount); i++ {
-			if daemon.IsStopped() {
-				return ErrSnapshotImportWasAborted
-			}
-
-			var val uint64
-			addrBuf := make(hornet.Hash, 32)
-
-			if err := binary.Read(file, binary.LittleEndian, addrBuf); err != nil {
-				return errors.Wrapf(ErrSnapshotImportFailed, "ledgerEntries: %v", err)
-			}
-
-			if err := binary.Read(file, binary.LittleEndian, &val); err != nil {
-				return errors.Wrapf(ErrSnapshotImportFailed, "ledgerEntries: %v", err)
-			}
-
-			ledgerState[string(addrBuf)] = val
-		}
-
-		var total uint64
-		for _, value := range ledgerState {
-			total += value
-		}
-
-		if total != iotago.TokenSupply {
-			return errors.Wrapf(ErrInvalidBalance, "%d != %d", total, iotago.TokenSupply)
-		}
-
-		err = tangle.StoreSnapshotBalancesInDatabase(ledgerState, milestone.Index(msIndex))
-		if err != nil {
-			return errors.Wrapf(ErrSnapshotImportFailed, "snapshot ledgerEntries: %s", err)
-		}
-
-		err = tangle.StoreLedgerBalancesInDatabase(ledgerState, milestone.Index(msIndex))
-		if err != nil {
-			return errors.Wrapf(ErrSnapshotImportFailed, "ledgerEntries: %v", err)
-		}
-
-		// set the solid milestone index based on the snapshot milestone
-		tangle.SetSolidMilestoneIndex(milestone.Index(msIndex), false)
-
-		log.Info("finished loading snapshot")
-
-		tanglePlugin.Events.SnapshotMilestoneIndexChanged.Trigger(milestone.Index(msIndex))
-
-		return nil
-	*/
-
 }

--- a/plugins/snapshot/local_snapshot.go
+++ b/plugins/snapshot/local_snapshot.go
@@ -259,7 +259,7 @@ func createFullLocalSnapshotWithoutLocking(targetIndex milestone.Index, filePath
 		return fmt.Errorf("unable to create tmp local snapshot file: %w", err)
 	}
 
-	if err := StreamFullLocalSnapshotDataTo(lsFile, uint64(ts.Unix()), header,
+	if err := StreamLocalSnapshotDataTo(lsFile, uint64(ts.Unix()), header,
 		func() *[32]byte {
 			// TODO: generate SEPs
 			return nil
@@ -346,7 +346,7 @@ func LoadFullSnapshotFromFile(filePath string) error {
 			return errors.Wrapf(ErrUnsupportedLSFileVersion, "local snapshot file version is %d but this HORNET version only supports %v", header.Version, SupportedFormatVersion)
 		}
 		lsHeader = header
-		log.Infof("solid entry points: %d, outputs: %d, ms diffs: %d", header.SEPCount, header.UTXOCount, header.MilestoneDiffCount)
+		log.Infof("solid entry points: %d, outputs: %d, ms diffs: %d", header.SEPCount, header.OutputCount, header.MilestoneDiffCount)
 		return nil
 	}
 
@@ -370,7 +370,7 @@ func LoadFullSnapshotFromFile(filePath string) error {
 		return nil
 	}
 
-	if err := StreamFullLocalSnapshotDataFrom(lsFile, headerConsumer, sepConsumer, outputConsumer, msDiffConsumer); err != nil {
+	if err := StreamLocalSnapshotDataFrom(lsFile, headerConsumer, sepConsumer, outputConsumer, msDiffConsumer); err != nil {
 		return fmt.Errorf("unable to import local snapshot file: %w", err)
 	}
 

--- a/plugins/snapshot/local_snapshot_file.go
+++ b/plugins/snapshot/local_snapshot_file.go
@@ -1,0 +1,293 @@
+package snapshot
+
+import (
+	"bytes"
+	"encoding/binary"
+	"io"
+
+	"github.com/luca-moser/iota"
+)
+
+const (
+	// The supported local snapshot file version.
+	SupportedFormatVersion byte = 1
+	// The length of a solid entry point hash.
+	SolidEntryPointHashLength = iota.MessageHashLength
+)
+
+// TransactionOutputs are the unspent outputs under the same transaction hash within a local snapshot.
+type TransactionOutputs struct {
+	// The hash of the transaction.
+	TransactionHash [iota.TransactionIDLength]byte `json:"transaction_hash"`
+	// The unspent outputs belonging to this transaction.
+	UnspentOutputs []*UnspentOutput `json:"unspent_outputs"`
+}
+
+func (s *TransactionOutputs) MarshalBinary() ([]byte, error) {
+	var b bytes.Buffer
+	if _, err := b.Write(s.TransactionHash[:]); err != nil {
+		return nil, err
+	}
+
+	// write count of outputs
+	if err := binary.Write(&b, binary.LittleEndian, uint16(len(s.UnspentOutputs))); err != nil {
+		return nil, err
+	}
+
+	for _, out := range s.UnspentOutputs {
+		outData, err := out.MarshalBinary()
+		if err != nil {
+			return nil, err
+		}
+
+		if _, err := b.Write(outData); err != nil {
+			return nil, err
+		}
+	}
+
+	return b.Bytes(), nil
+}
+
+// UnspentOutput defines an unspent output within a local snapshot.
+type UnspentOutput struct {
+	// The index of the output.
+	Index uint16 `json:"index"`
+	// The underlying address to which this output deposits to.
+	Address iota.Serializable `json:"address"`
+	// The value of the deposit.
+	Value uint64 `json:"value"`
+}
+
+func (s *UnspentOutput) MarshalBinary() ([]byte, error) {
+	var b bytes.Buffer
+	if err := binary.Write(&b, binary.LittleEndian, s.Index); err != nil {
+		return nil, err
+	}
+	addrData, err := s.Address.Serialize(iota.DeSeriModePerformValidation)
+	if err != nil {
+		return nil, err
+	}
+	if _, err := b.Write(addrData); err != nil {
+		return nil, err
+	}
+	if err := binary.Write(&b, binary.LittleEndian, s.Value); err != nil {
+		return nil, err
+	}
+	return b.Bytes(), nil
+}
+
+// SEPIteratorFunc yields a solid entry point to be written to a local snapshot or nil if no more is available.
+type SEPIteratorFunc func() *[SolidEntryPointHashLength]byte
+
+// SEPConsumerFunc consumes the given solid entry point.
+// A returned error signals to cancel further reading.
+type SEPConsumerFunc func([SolidEntryPointHashLength]byte) error
+
+// HeaderConsumerFunc consumes the local snapshot file header.
+// A returned error signals to cancel further reading.
+type HeaderConsumerFunc func(*FileHeader) error
+
+// UTXOIteratorFunc yields a transaction and its outputs to be written to a local snapshot or nil if no more is available.
+type UTXOIteratorFunc func() *TransactionOutputs
+
+// UTXOConsumerFunc consumes the given transaction and its outputs.
+// A returned error signals to cancel further reading.
+type UTXOConsumerFunc func(*TransactionOutputs) error
+
+// FileHeader is the file header of a local snapshot file.
+type FileHeader struct {
+	// Version denotes the version of this local snapshot.
+	Version byte
+	// The milestone index for which this local snapshot was taken.
+	MilestoneIndex uint64
+	// The hash of the milestone corresponding to the given milestone index.
+	MilestoneHash [iota.MilestoneHashLength]byte
+	// The time at which the local snapshot was taken.
+	Timestamp uint64
+	// The count of solid entry points.
+	// This field is only available/used while reading a local snapshot.
+	SEPCount uint64
+	// The count of UTXOs.
+	// This field is only available/used while reading a local snapshot.
+	UTXOCount uint64
+}
+
+// StreamLocalSnapshotDataTo streams local snapshot data into the given io.WriteSeeker.
+func StreamLocalSnapshotDataTo(writeSeeker io.WriteSeeker, header *FileHeader,
+	sepIter SEPIteratorFunc, utxoIter UTXOIteratorFunc) error {
+
+	// version, seps count, utxo count
+	// timestamp, milestone index, milestone hash, seps, utxos
+	var sepsCount, utxoCount uint64
+
+	if _, err := writeSeeker.Write([]byte{header.Version}); err != nil {
+		return err
+	}
+
+	if err := binary.Write(writeSeeker, binary.LittleEndian, header.Timestamp); err != nil {
+		return err
+	}
+
+	if err := binary.Write(writeSeeker, binary.LittleEndian, header.MilestoneIndex); err != nil {
+		return err
+	}
+
+	if _, err := writeSeeker.Write(header.MilestoneHash[:]); err != nil {
+		return err
+	}
+
+	// write count and hash place holders
+	if _, err := writeSeeker.Write(make([]byte, iota.UInt64ByteSize*2)); err != nil {
+		return err
+	}
+
+	for sep := sepIter(); sep != nil; sep = sepIter() {
+		_, err := writeSeeker.Write(sep[:])
+		if err != nil {
+			return err
+		}
+		sepsCount++
+	}
+
+	for utxo := utxoIter(); utxo != nil; utxo = utxoIter() {
+		utxoData, err := utxo.MarshalBinary()
+		if err != nil {
+			return err
+		}
+		if _, err := writeSeeker.Write(utxoData); err != nil {
+			return err
+		}
+		utxoCount++
+	}
+
+	// seek back to counts version+timestamp+msindex+mshash and write element counts
+	if _, err := writeSeeker.Seek(iota.OneByte+iota.UInt64ByteSize+iota.UInt64ByteSize+iota.MilestoneHashLength, io.SeekStart); err != nil {
+		return err
+	}
+
+	if err := binary.Write(writeSeeker, binary.LittleEndian, sepsCount); err != nil {
+		return err
+	}
+
+	if err := binary.Write(writeSeeker, binary.LittleEndian, utxoCount); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// StreamLocalSnapshotDataFrom consumes local snapshot data from the given reader.
+func StreamLocalSnapshotDataFrom(reader io.Reader, headerConsumer HeaderConsumerFunc,
+	sepConsumer SEPConsumerFunc, utxoConsumer UTXOConsumerFunc) error {
+	header := &FileHeader{}
+
+	if err := binary.Read(reader, binary.LittleEndian, &header.Version); err != nil {
+		return err
+	}
+
+	if err := binary.Read(reader, binary.LittleEndian, &header.Timestamp); err != nil {
+		return err
+	}
+
+	if err := binary.Read(reader, binary.LittleEndian, &header.MilestoneIndex); err != nil {
+		return err
+	}
+
+	if _, err := io.ReadFull(reader, header.MilestoneHash[:]); err != nil {
+		return err
+	}
+
+	var sepsCount uint64
+	if err := binary.Read(reader, binary.LittleEndian, &sepsCount); err != nil {
+		return err
+	}
+
+	var utxoCount uint64
+	if err := binary.Read(reader, binary.LittleEndian, &utxoCount); err != nil {
+		return err
+	}
+
+	header.SEPCount = sepsCount
+	header.UTXOCount = utxoCount
+	if err := headerConsumer(header); err != nil {
+		return err
+	}
+
+	for i := uint64(0); i < sepsCount; i++ {
+		var sep [SolidEntryPointHashLength]byte
+		if _, err := io.ReadFull(reader, sep[:]); err != nil {
+			return err
+		}
+
+		// sep gets copied
+		if err := sepConsumer(sep); err != nil {
+			return err
+		}
+	}
+
+	for i := uint64(0); i < utxoCount; i++ {
+		utxo := &TransactionOutputs{}
+
+		// read tx hash
+		if _, err := io.ReadFull(reader, utxo.TransactionHash[:]); err != nil {
+			return err
+		}
+
+		var outputsCount uint16
+		if err := binary.Read(reader, binary.LittleEndian, &outputsCount); err != nil {
+			return err
+		}
+
+		for j := uint16(0); j < outputsCount; j++ {
+			output := &UnspentOutput{}
+
+			if err := binary.Read(reader, binary.LittleEndian, &output.Index); err != nil {
+				return err
+			}
+
+			// look ahead address type
+			var addrTypeBuf [iota.SmallTypeDenotationByteSize]byte
+			if _, err := io.ReadFull(reader, addrTypeBuf[:]); err != nil {
+				return err
+			}
+
+			addrType := addrTypeBuf[0]
+			addr, err := iota.AddressSelector(uint32(addrType))
+			if err != nil {
+				return err
+			}
+
+			var addrDataWithoutType []byte
+			switch addr.(type) {
+			case *iota.WOTSAddress:
+				addrDataWithoutType = make([]byte, iota.WOTSAddressBytesLength)
+			case *iota.Ed25519Address:
+				addrDataWithoutType = make([]byte, iota.Ed25519AddressBytesLength)
+			default:
+				panic("unknown address type")
+			}
+
+			// read the rest of the address
+			if _, err := io.ReadFull(reader, addrDataWithoutType); err != nil {
+				return err
+			}
+
+			if _, err := addr.Deserialize(append(addrTypeBuf[:], addrDataWithoutType...), iota.DeSeriModePerformValidation); err != nil {
+				return err
+			}
+			output.Address = addr
+
+			if err := binary.Read(reader, binary.LittleEndian, &output.Value); err != nil {
+				return err
+			}
+
+			utxo.UnspentOutputs = append(utxo.UnspentOutputs, output)
+		}
+
+		if err := utxoConsumer(utxo); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/plugins/snapshot/local_snapshot_file.go
+++ b/plugins/snapshot/local_snapshot_file.go
@@ -76,9 +76,12 @@ func (s *Output) MarshalBinary() ([]byte, error) {
 
 // MilestoneDiff represents the outputs which were created and consumed for the given milestone.
 type MilestoneDiff struct {
-	MilestoneIndex uint64    `json:"milestone_index"`
-	Created        []*Output `json:"created"`
-	Consumed       []*Output `json:"consumed"`
+	// The index of the milestone for which the diff applies.
+	MilestoneIndex uint64 `json:"milestone_index"`
+	// The created outputs with this milestone.
+	Created []*Output `json:"created"`
+	// The consumed outputs with this milestone.
+	Consumed []*Output `json:"consumed"`
 }
 
 func (md *MilestoneDiff) MarshalBinary() ([]byte, error) {
@@ -332,7 +335,7 @@ func StreamLocalSnapshotDataFrom(reader io.Reader, headerConsumer HeaderConsumer
 			return fmt.Errorf("unable to read LS SEP at pos %d: %w", i, err)
 		}
 		if err := sepConsumer(sep); err != nil {
-			return err
+			return fmt.Errorf("SEP consumer error at pos %d: %w", i, err)
 		}
 	}
 
@@ -344,7 +347,7 @@ func StreamLocalSnapshotDataFrom(reader io.Reader, headerConsumer HeaderConsumer
 			}
 
 			if err := outputConsumer(output); err != nil {
-				return err
+				return fmt.Errorf("output consumer error at pos %d: %w", i, err)
 			}
 		}
 	}
@@ -355,7 +358,7 @@ func StreamLocalSnapshotDataFrom(reader io.Reader, headerConsumer HeaderConsumer
 			return fmt.Errorf("at pos %d: %w", i, err)
 		}
 		if err := msDiffConsumer(msDiff); err != nil {
-			return err
+			return fmt.Errorf("ms-diff consumer error at pos %d: %w", i, err)
 		}
 	}
 

--- a/plugins/snapshot/local_snapshot_file.go
+++ b/plugins/snapshot/local_snapshot_file.go
@@ -3,76 +3,115 @@ package snapshot
 import (
 	"bytes"
 	"encoding/binary"
+	"errors"
+	"fmt"
 	"io"
 
-	"github.com/iotaledger/iota.go"
+	iotago "github.com/iotaledger/iota.go"
 )
 
 const (
 	// The supported local snapshot file version.
 	SupportedFormatVersion byte = 1
 	// The length of a solid entry point hash.
-	SolidEntryPointHashLength = iota.MessageHashLength
+	SolidEntryPointHashLength = iotago.MessageHashLength
+
+	// The offset of counters within a local snapshot file:
+	// version+type+timestamp+sep-ms-index+sep-ms-hash+ledger-ms-index+ledger-ms-hash
+	countersOffset = iotago.OneByte + iotago.OneByte + iotago.UInt64ByteSize +
+		iotago.UInt64ByteSize + iotago.MilestonePayloadHashLength +
+		iotago.UInt64ByteSize + iotago.MilestonePayloadHashLength
 )
 
-// TransactionOutputs are the unspent outputs under the same transaction hash within a local snapshot.
-type TransactionOutputs struct {
-	// The hash of the transaction.
-	TransactionHash [iota.TransactionIDLength]byte `json:"transaction_hash"`
-	// The unspent outputs belonging to this transaction.
-	UnspentOutputs []*UnspentOutput `json:"unspent_outputs"`
-}
+var (
+	// Returned when a wrong snapshot type is being read.
+	ErrWrongSnapshotType = errors.New("wrong snapshot type")
+)
 
-func (s *TransactionOutputs) MarshalBinary() ([]byte, error) {
-	var b bytes.Buffer
-	if _, err := b.Write(s.TransactionHash[:]); err != nil {
-		return nil, err
-	}
+// Type defines the type of the local snapshot.
+type Type byte
 
-	// write count of outputs
-	if err := binary.Write(&b, binary.LittleEndian, uint16(len(s.UnspentOutputs))); err != nil {
-		return nil, err
-	}
+const (
+	// Full is a local snapshot which contains the full ledger entry for a given milestone
+	// plus the milestone diffs which subtracted to the ledger milestone reduce to the snapshot milestone ledger.
+	Full Type = iota
+	// Delta is a local snapshot which contains solely diffs of milestones newer than a certain ledger milestone.
+	Delta
+)
 
-	for _, out := range s.UnspentOutputs {
-		outData, err := out.MarshalBinary()
-		if err != nil {
-			return nil, err
-		}
-
-		if _, err := b.Write(outData); err != nil {
-			return nil, err
-		}
-	}
-
-	return b.Bytes(), nil
-}
-
-// UnspentOutput defines an unspent output within a local snapshot.
-type UnspentOutput struct {
+// Output defines an output within a local snapshot.
+type Output struct {
+	TransactionHash [iotago.TransactionIDLength]byte `json:"transaction_hash"`
 	// The index of the output.
 	Index uint16 `json:"index"`
 	// The underlying address to which this output deposits to.
-	Address iota.Serializable `json:"address"`
+	Address iotago.Serializable `json:"address"`
 	// The value of the deposit.
 	Value uint64 `json:"value"`
 }
 
-func (s *UnspentOutput) MarshalBinary() ([]byte, error) {
+func (s *Output) MarshalBinary() ([]byte, error) {
 	var b bytes.Buffer
-	if err := binary.Write(&b, binary.LittleEndian, s.Index); err != nil {
-		return nil, err
+	if _, err := b.Write(s.TransactionHash[:]); err != nil {
+		return nil, fmt.Errorf("unable to write transaction hash for ls-output: %w", err)
 	}
-	addrData, err := s.Address.Serialize(iota.DeSeriModePerformValidation)
+	if err := binary.Write(&b, binary.LittleEndian, s.Index); err != nil {
+		return nil, fmt.Errorf("unable to write index for ls-output: %w", err)
+	}
+	addrData, err := s.Address.Serialize(iotago.DeSeriModePerformValidation)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("unable to serialize address for ls-output: %w", err)
 	}
 	if _, err := b.Write(addrData); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("unable to write address for ls-output: %w", err)
 	}
 	if err := binary.Write(&b, binary.LittleEndian, s.Value); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("unable to write value for ls-output: %w", err)
 	}
+	return b.Bytes(), nil
+}
+
+// MilestoneDiff represents the outputs which were created and consumed for the given milestone.
+type MilestoneDiff struct {
+	MilestoneIndex uint64    `json:"milestone_index"`
+	Created        []*Output `json:"created"`
+	Consumed       []*Output `json:"consumed"`
+}
+
+func (md *MilestoneDiff) MarshalBinary() ([]byte, error) {
+	var b bytes.Buffer
+	if err := binary.Write(&b, binary.LittleEndian, md.MilestoneIndex); err != nil {
+		return nil, fmt.Errorf("unable to write milestone index for ls-milestone-diff %d: %w", md.MilestoneIndex, err)
+	}
+
+	if err := binary.Write(&b, binary.LittleEndian, uint64(len(md.Created))); err != nil {
+		return nil, fmt.Errorf("unable to write created outputs array length for ls-milestone-diff %d: %w", md.MilestoneIndex, err)
+	}
+
+	for x, output := range md.Created {
+		outputBytes, err := output.MarshalBinary()
+		if err != nil {
+			return nil, fmt.Errorf("unable to serialize output %d for ls-milestone-diff %d: %w", x, md.MilestoneIndex, err)
+		}
+		if _, err := b.Write(outputBytes); err != nil {
+			return nil, fmt.Errorf("unable to write output %d for ls-milestone-diff %d: %w", x, md.MilestoneIndex, err)
+		}
+	}
+
+	if err := binary.Write(&b, binary.LittleEndian, uint64(len(md.Consumed))); err != nil {
+		return nil, fmt.Errorf("unable to write consumed outputs array length for ls-milestone-diff %d: %w", md.MilestoneIndex, err)
+	}
+
+	for x, output := range md.Consumed {
+		outputBytes, err := output.MarshalBinary()
+		if err != nil {
+			return nil, fmt.Errorf("unable to serialize output %d for ls-milestone-diff %d: %w", x, md.MilestoneIndex, err)
+		}
+		if _, err := b.Write(outputBytes); err != nil {
+			return nil, fmt.Errorf("unable to write output %d for ls-milestone-diff %d: %w", x, md.MilestoneIndex, err)
+		}
+	}
+
 	return b.Bytes(), nil
 }
 
@@ -85,209 +124,306 @@ type SEPConsumerFunc func([SolidEntryPointHashLength]byte) error
 
 // HeaderConsumerFunc consumes the local snapshot file header.
 // A returned error signals to cancel further reading.
-type HeaderConsumerFunc func(*FileHeader) error
+type HeaderConsumerFunc func(*ReadFileHeader) error
 
-// UTXOIteratorFunc yields a transaction and its outputs to be written to a local snapshot or nil if no more is available.
-type UTXOIteratorFunc func() *TransactionOutputs
+// OutputIteratorFunc yields an output to be written to a local snapshot or nil if no more is available.
+type OutputIteratorFunc func() *Output
 
-// UTXOConsumerFunc consumes the given transaction and its outputs.
+// OutputConsumerFunc consumes the given output.
 // A returned error signals to cancel further reading.
-type UTXOConsumerFunc func(*TransactionOutputs) error
+type OutputConsumerFunc func(output *Output) error
+
+// MilestoneDiffIteratorFunc yields a milestone diff to be written to a local snapshot or nil if no more is available.
+type MilestoneDiffIteratorFunc func() *MilestoneDiff
+
+// MilestoneDiffConsumerFunc consumes the given MilestoneDiff.
+// A returned error signals to cancel further reading.
+type MilestoneDiffConsumerFunc func(milestoneDiff *MilestoneDiff) error
 
 // FileHeader is the file header of a local snapshot file.
 type FileHeader struct {
 	// Version denotes the version of this local snapshot.
 	Version byte
-	// The milestone index for which this local snapshot was taken.
-	MilestoneIndex uint64
-	// The hash of the milestone corresponding to the given milestone index.
-	MilestoneHash [iota.MilestonePayloadHashLength]byte
+	// Type denotes the type of this local snapshot.
+	Type Type
+	// The milestone index of the SEPs for which this local snapshot was taken.
+	SEPMilestoneIndex uint64
+	// The hash of the milestone of the SEPs.
+	SEPMilestoneHash [iotago.MilestonePayloadHashLength]byte
+	// The milestone index of the ledger data within the local snapshot.
+	LedgerMilestoneIndex uint64
+	// The hash of the ledger milestone.
+	LedgerMilestoneHash [iotago.MilestonePayloadHashLength]byte
+}
+
+// ReadFileHeader is a FileHeader but with additional content read from the local snapshot.
+type ReadFileHeader struct {
+	FileHeader
 	// The time at which the local snapshot was taken.
 	Timestamp uint64
 	// The count of solid entry points.
-	// This field is only available/used while reading a local snapshot.
 	SEPCount uint64
 	// The count of UTXOs.
-	// This field is only available/used while reading a local snapshot.
 	UTXOCount uint64
+	// The count of milestone diffs.
+	MilestoneDiffCount uint64
 }
 
-// StreamLocalSnapshotDataTo streams local snapshot data into the given io.WriteSeeker.
-func StreamLocalSnapshotDataTo(writeSeeker io.WriteSeeker, header *FileHeader,
-	sepIter SEPIteratorFunc, utxoIter UTXOIteratorFunc) error {
+// StreamFullLocalSnapshotDataTo streams a full local snapshot data into the given io.WriteSeeker.
+func StreamFullLocalSnapshotDataTo(writeSeeker io.WriteSeeker, timestamp uint64, header *FileHeader,
+	sepIter SEPIteratorFunc, outputIter OutputIteratorFunc, msDiffIter MilestoneDiffIteratorFunc) error {
 
-	// version, seps count, utxo count
-	// timestamp, milestone index, milestone hash, seps, utxos
-	var sepsCount, utxoCount uint64
+	var sepsCount, utxoCount, msDiffCount uint64
 
-	if _, err := writeSeeker.Write([]byte{header.Version}); err != nil {
-		return err
+	// write LS file version and type
+	if _, err := writeSeeker.Write([]byte{header.Version, byte(Full)}); err != nil {
+		return fmt.Errorf("unable to write LS version and type: %w", err)
 	}
 
-	if err := binary.Write(writeSeeker, binary.LittleEndian, header.Timestamp); err != nil {
-		return err
+	if err := binary.Write(writeSeeker, binary.LittleEndian, timestamp); err != nil {
+		return fmt.Errorf("unable to write LS timestamp: %w", err)
 	}
 
-	if err := binary.Write(writeSeeker, binary.LittleEndian, header.MilestoneIndex); err != nil {
-		return err
+	if err := binary.Write(writeSeeker, binary.LittleEndian, header.SEPMilestoneIndex); err != nil {
+		return fmt.Errorf("unable to write LS SEPs milestone index: %w", err)
 	}
 
-	if _, err := writeSeeker.Write(header.MilestoneHash[:]); err != nil {
-		return err
+	if _, err := writeSeeker.Write(header.SEPMilestoneHash[:]); err != nil {
+		return fmt.Errorf("unable to write LS SEPs milestone hash: %w", err)
+	}
+
+	if err := binary.Write(writeSeeker, binary.LittleEndian, header.LedgerMilestoneIndex); err != nil {
+		return fmt.Errorf("unable to write LS ledger milestone index: %w", err)
+	}
+
+	if _, err := writeSeeker.Write(header.LedgerMilestoneHash[:]); err != nil {
+		return fmt.Errorf("unable to write LS ledger milestone hash: %w", err)
 	}
 
 	// write count and hash place holders
-	if _, err := writeSeeker.Write(make([]byte, iota.UInt64ByteSize*2)); err != nil {
-		return err
+	if _, err := writeSeeker.Write(make([]byte, iotago.UInt64ByteSize*3)); err != nil {
+		return fmt.Errorf("unable to write LS SEPs/Outputs/Diffs placeholders: %w", err)
 	}
 
 	for sep := sepIter(); sep != nil; sep = sepIter() {
-		_, err := writeSeeker.Write(sep[:])
-		if err != nil {
-			return err
-		}
 		sepsCount++
+		if _, err := writeSeeker.Write(sep[:]); err != nil {
+			return fmt.Errorf("unable to write LS SEP #%d: %w", sepsCount, err)
+		}
 	}
 
-	for utxo := utxoIter(); utxo != nil; utxo = utxoIter() {
-		utxoData, err := utxo.MarshalBinary()
-		if err != nil {
-			return err
-		}
-		if _, err := writeSeeker.Write(utxoData); err != nil {
-			return err
-		}
+	for output := outputIter(); output != nil; output = outputIter() {
 		utxoCount++
+		outputBytes, err := output.MarshalBinary()
+		if err != nil {
+			return fmt.Errorf("unable to serialize LS output #%d: %w", utxoCount, err)
+		}
+		if _, err := writeSeeker.Write(outputBytes); err != nil {
+			return fmt.Errorf("unable to write LS output #%d: %w", utxoCount, err)
+		}
 	}
 
-	// seek back to counts version+timestamp+msindex+mshash and write element counts
-	if _, err := writeSeeker.Seek(iota.OneByte+iota.UInt64ByteSize+iota.UInt64ByteSize+iota.MilestonePayloadHashLength, io.SeekStart); err != nil {
-		return err
+	for msDiff := msDiffIter(); msDiff != nil; msDiff = msDiffIter() {
+		msDiffCount++
+		msDiffBytes, err := msDiff.MarshalBinary()
+		if err != nil {
+			return fmt.Errorf("unable to serialize LS milestone diff #%d: %w", msDiffCount, err)
+		}
+		if _, err := writeSeeker.Write(msDiffBytes); err != nil {
+			return fmt.Errorf("unable to write LS milestone diff #%d: %w", msDiffCount, err)
+		}
+	}
+
+	if _, err := writeSeeker.Seek(countersOffset, io.SeekStart); err != nil {
+		return fmt.Errorf("unable to seek to LS counter placeholders: %w", err)
 	}
 
 	if err := binary.Write(writeSeeker, binary.LittleEndian, sepsCount); err != nil {
-		return err
+		return fmt.Errorf("unable to write to LS SEPs count: %w", err)
 	}
 
 	if err := binary.Write(writeSeeker, binary.LittleEndian, utxoCount); err != nil {
-		return err
+		return fmt.Errorf("unable to write to LS outputs count: %w", err)
+	}
+
+	if err := binary.Write(writeSeeker, binary.LittleEndian, msDiffCount); err != nil {
+		return fmt.Errorf("unable to write to LS ms-diffs count: %w", err)
 	}
 
 	return nil
 }
 
-// StreamLocalSnapshotDataFrom consumes local snapshot data from the given reader.
-func StreamLocalSnapshotDataFrom(reader io.Reader, headerConsumer HeaderConsumerFunc,
-	sepConsumer SEPConsumerFunc, utxoConsumer UTXOConsumerFunc) error {
-	header := &FileHeader{}
+// StreamFullLocalSnapshotDataFrom consumes a full local snapshot from the given reader.
+func StreamFullLocalSnapshotDataFrom(reader io.Reader, headerConsumer HeaderConsumerFunc,
+	sepConsumer SEPConsumerFunc, outputConsumer OutputConsumerFunc, msDiffConsumer MilestoneDiffConsumerFunc) error {
+	header := &ReadFileHeader{}
 
 	if err := binary.Read(reader, binary.LittleEndian, &header.Version); err != nil {
-		return err
+		return fmt.Errorf("unable to read LS version: %w", err)
+	}
+
+	if err := binary.Read(reader, binary.LittleEndian, &header.Type); err != nil {
+		return fmt.Errorf("unable to read LS type: %w", err)
+	}
+
+	if header.Type != Full {
+		return fmt.Errorf("%w: expected to read a full local snapshot but got: %d", ErrWrongSnapshotType, header.Type)
 	}
 
 	if err := binary.Read(reader, binary.LittleEndian, &header.Timestamp); err != nil {
-		return err
+		return fmt.Errorf("unable to read LS timestamp: %w", err)
 	}
 
-	if err := binary.Read(reader, binary.LittleEndian, &header.MilestoneIndex); err != nil {
-		return err
+	if err := binary.Read(reader, binary.LittleEndian, &header.SEPMilestoneIndex); err != nil {
+		return fmt.Errorf("unable to read LS SEPs milestone index: %w", err)
 	}
 
-	if _, err := io.ReadFull(reader, header.MilestoneHash[:]); err != nil {
-		return err
+	if _, err := io.ReadFull(reader, header.SEPMilestoneHash[:]); err != nil {
+		return fmt.Errorf("unable to read LS SEPs milestone hash: %w", err)
 	}
 
-	var sepsCount uint64
-	if err := binary.Read(reader, binary.LittleEndian, &sepsCount); err != nil {
-		return err
+	if err := binary.Read(reader, binary.LittleEndian, &header.LedgerMilestoneIndex); err != nil {
+		return fmt.Errorf("unable to read LS ledger milestone index: %w", err)
 	}
 
-	var utxoCount uint64
-	if err := binary.Read(reader, binary.LittleEndian, &utxoCount); err != nil {
-		return err
+	if _, err := io.ReadFull(reader, header.LedgerMilestoneHash[:]); err != nil {
+		return fmt.Errorf("unable to read LS ledger milestone hash: %w", err)
 	}
 
-	header.SEPCount = sepsCount
-	header.UTXOCount = utxoCount
+	if err := binary.Read(reader, binary.LittleEndian, &header.SEPCount); err != nil {
+		return fmt.Errorf("unable to read LS SEPs count: %w", err)
+	}
+
+	if err := binary.Read(reader, binary.LittleEndian, &header.UTXOCount); err != nil {
+		return fmt.Errorf("unable to read LS outputs count: %w", err)
+	}
+
+	if err := binary.Read(reader, binary.LittleEndian, &header.MilestoneDiffCount); err != nil {
+		return fmt.Errorf("unable to read LS ms-diff count: %w", err)
+	}
+
 	if err := headerConsumer(header); err != nil {
 		return err
 	}
 
-	for i := uint64(0); i < sepsCount; i++ {
+	for i := uint64(0); i < header.SEPCount; i++ {
 		var sep [SolidEntryPointHashLength]byte
 		if _, err := io.ReadFull(reader, sep[:]); err != nil {
-			return err
+			return fmt.Errorf("unable to read LS SEP at pos %d: %w", i, err)
 		}
-
-		// sep gets copied
 		if err := sepConsumer(sep); err != nil {
 			return err
 		}
 	}
 
-	for i := uint64(0); i < utxoCount; i++ {
-		utxo := &TransactionOutputs{}
+	for i := uint64(0); i < header.UTXOCount; i++ {
+		output, err := readOutput(reader)
+		if err != nil {
+			return fmt.Errorf("at pos %d: %w", i, err)
+		}
 
-		// read tx hash
-		if _, err := io.ReadFull(reader, utxo.TransactionHash[:]); err != nil {
+		if err := outputConsumer(output); err != nil {
 			return err
 		}
+	}
 
-		var outputsCount uint16
-		if err := binary.Read(reader, binary.LittleEndian, &outputsCount); err != nil {
-			return err
+	for i := uint64(0); i < header.MilestoneDiffCount; i++ {
+		msDiff, err := readMilestoneDiff(reader)
+		if err != nil {
+			return fmt.Errorf("at pos %d: %w", i, err)
 		}
-
-		for j := uint16(0); j < outputsCount; j++ {
-			output := &UnspentOutput{}
-
-			if err := binary.Read(reader, binary.LittleEndian, &output.Index); err != nil {
-				return err
-			}
-
-			// look ahead address type
-			var addrTypeBuf [iota.SmallTypeDenotationByteSize]byte
-			if _, err := io.ReadFull(reader, addrTypeBuf[:]); err != nil {
-				return err
-			}
-
-			addrType := addrTypeBuf[0]
-			addr, err := iota.AddressSelector(uint32(addrType))
-			if err != nil {
-				return err
-			}
-
-			var addrDataWithoutType []byte
-			switch addr.(type) {
-			case *iota.WOTSAddress:
-				addrDataWithoutType = make([]byte, iota.WOTSAddressBytesLength)
-			case *iota.Ed25519Address:
-				addrDataWithoutType = make([]byte, iota.Ed25519AddressBytesLength)
-			default:
-				panic("unknown address type")
-			}
-
-			// read the rest of the address
-			if _, err := io.ReadFull(reader, addrDataWithoutType); err != nil {
-				return err
-			}
-
-			if _, err := addr.Deserialize(append(addrTypeBuf[:], addrDataWithoutType...), iota.DeSeriModePerformValidation); err != nil {
-				return err
-			}
-			output.Address = addr
-
-			if err := binary.Read(reader, binary.LittleEndian, &output.Value); err != nil {
-				return err
-			}
-
-			utxo.UnspentOutputs = append(utxo.UnspentOutputs, output)
-		}
-
-		if err := utxoConsumer(utxo); err != nil {
+		if err := msDiffConsumer(msDiff); err != nil {
 			return err
 		}
 	}
 
 	return nil
+}
+
+// reads a MilestoneDiff from the given reader.
+func readMilestoneDiff(reader io.Reader) (*MilestoneDiff, error) {
+	msDiff := &MilestoneDiff{}
+
+	if err := binary.Read(reader, binary.LittleEndian, &msDiff.MilestoneIndex); err != nil {
+		return nil, fmt.Errorf("unable to read LS ms-diff ms-index: %w", err)
+	}
+
+	var createdCount, consumedCount uint64
+	if err := binary.Read(reader, binary.LittleEndian, &createdCount); err != nil {
+		return nil, fmt.Errorf("unable to read LS ms-diff created count: %w", err)
+	}
+
+	msDiff.Created = make([]*Output, createdCount)
+	for i := uint64(0); i < createdCount; i++ {
+		diffCreatedOutput, err := readOutput(reader)
+		if err != nil {
+			return nil, fmt.Errorf("(ms-diff created-output) at pos %d: %w", i, err)
+		}
+		msDiff.Created[i] = diffCreatedOutput
+	}
+
+	if err := binary.Read(reader, binary.LittleEndian, &consumedCount); err != nil {
+		return nil, fmt.Errorf("unable to read LS ms-diff consumed count: %w", err)
+	}
+
+	msDiff.Consumed = make([]*Output, consumedCount)
+	for i := uint64(0); i < consumedCount; i++ {
+		diffConsumedOutput, err := readOutput(reader)
+		if err != nil {
+			return nil, fmt.Errorf("(ms-diff consumed-output) at pos %d: %w", i, err)
+		}
+		msDiff.Consumed[i] = diffConsumedOutput
+	}
+
+	return msDiff, nil
+}
+
+// reads an Output from the given reader.
+func readOutput(reader io.Reader) (*Output, error) {
+	output := &Output{}
+	if _, err := io.ReadFull(reader, output.TransactionHash[:]); err != nil {
+		return nil, fmt.Errorf("unable to read LS output tx hash: %w", err)
+	}
+
+	if err := binary.Read(reader, binary.LittleEndian, &output.Index); err != nil {
+		return nil, fmt.Errorf("unable to read LS output index: %w", err)
+	}
+
+	// look ahead address type
+	var addrTypeBuf [iotago.SmallTypeDenotationByteSize]byte
+	if _, err := io.ReadFull(reader, addrTypeBuf[:]); err != nil {
+		return nil, fmt.Errorf("unable to read LS output address type byte: %w", err)
+	}
+
+	addrType := addrTypeBuf[0]
+	addr, err := iotago.AddressSelector(uint32(addrType))
+	if err != nil {
+		return nil, fmt.Errorf("unable to determine address type of LS output: %w", err)
+	}
+
+	var addrDataWithoutType []byte
+	switch addr.(type) {
+	case *iotago.WOTSAddress:
+		addrDataWithoutType = make([]byte, iotago.WOTSAddressBytesLength)
+	case *iotago.Ed25519Address:
+		addrDataWithoutType = make([]byte, iotago.Ed25519AddressBytesLength)
+	default:
+		panic("unknown address type")
+	}
+
+	// read the rest of the address
+	if _, err := io.ReadFull(reader, addrDataWithoutType); err != nil {
+		return nil, fmt.Errorf("unable to read LS output address: %w", err)
+	}
+
+	if _, err := addr.Deserialize(append(addrTypeBuf[:], addrDataWithoutType...), iotago.DeSeriModePerformValidation); err != nil {
+		return nil, fmt.Errorf("invalid LS output address: %w", err)
+	}
+	output.Address = addr
+
+	if err := binary.Read(reader, binary.LittleEndian, &output.Value); err != nil {
+		return nil, fmt.Errorf("unable to read LS output value: %w", err)
+	}
+
+	return output, nil
 }

--- a/plugins/snapshot/local_snapshot_file.go
+++ b/plugins/snapshot/local_snapshot_file.go
@@ -5,7 +5,7 @@ import (
 	"encoding/binary"
 	"io"
 
-	"github.com/luca-moser/iota"
+	"github.com/iotaledger/iota.go"
 )
 
 const (
@@ -101,7 +101,7 @@ type FileHeader struct {
 	// The milestone index for which this local snapshot was taken.
 	MilestoneIndex uint64
 	// The hash of the milestone corresponding to the given milestone index.
-	MilestoneHash [iota.MilestoneHashLength]byte
+	MilestoneHash [iota.MilestonePayloadHashLength]byte
 	// The time at which the local snapshot was taken.
 	Timestamp uint64
 	// The count of solid entry points.
@@ -161,7 +161,7 @@ func StreamLocalSnapshotDataTo(writeSeeker io.WriteSeeker, header *FileHeader,
 	}
 
 	// seek back to counts version+timestamp+msindex+mshash and write element counts
-	if _, err := writeSeeker.Seek(iota.OneByte+iota.UInt64ByteSize+iota.UInt64ByteSize+iota.MilestoneHashLength, io.SeekStart); err != nil {
+	if _, err := writeSeeker.Seek(iota.OneByte+iota.UInt64ByteSize+iota.UInt64ByteSize+iota.MilestonePayloadHashLength, io.SeekStart); err != nil {
 		return err
 	}
 

--- a/plugins/snapshot/local_snapshot_file_test.go
+++ b/plugins/snapshot/local_snapshot_file_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/blang/vfs/memfs"
 	"github.com/gohornet/hornet/plugins/snapshot"
-	"github.com/luca-moser/iota"
+	"github.com/iotaledger/iota.go"
 	"github.com/stretchr/testify/require"
 )
 
@@ -35,7 +35,7 @@ func TestStreamLocalSnapshotDataToAndFrom(t *testing.T) {
 	rand.Seed(346587549867)
 
 	originHeader := &snapshot.FileHeader{
-		Version: iota.LSFormatVersion, MilestoneIndex: uint64(rand.Intn(10000)),
+		Version: snapshot.SupportedFormatVersion, MilestoneIndex: uint64(rand.Intn(10000)),
 		MilestoneHash: rand32ByteHash(), Timestamp: uint64(time.Now().Unix()),
 	}
 

--- a/plugins/snapshot/local_snapshot_file_test.go
+++ b/plugins/snapshot/local_snapshot_file_test.go
@@ -1,0 +1,207 @@
+package snapshot_test
+
+import (
+	"fmt"
+	"math/rand"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/blang/vfs/memfs"
+	"github.com/gohornet/hornet/plugins/snapshot"
+	"github.com/luca-moser/iota"
+	"github.com/stretchr/testify/require"
+)
+
+type test struct {
+	name             string
+	snapshotFileName string
+	originHeader     *snapshot.FileHeader
+	sepGenerator     snapshot.SEPIteratorFunc
+	sepGenRetriever  sepRetrieverFunc
+	utxoGenerator    snapshot.UTXOIteratorFunc
+	utxoGenRetriever utxoRetrieverFunc
+	headerConsumer   snapshot.HeaderConsumerFunc
+	sepConsumer      snapshot.SEPConsumerFunc
+	sepConRetriever  sepRetrieverFunc
+	utxoConsumer     snapshot.UTXOConsumerFunc
+	utxoConRetriever utxoRetrieverFunc
+}
+
+func TestStreamLocalSnapshotDataToAndFrom(t *testing.T) {
+	if testing.Short() {
+		return
+	}
+	rand.Seed(346587549867)
+
+	originHeader := &snapshot.FileHeader{
+		Version: iota.LSFormatVersion, MilestoneIndex: uint64(rand.Intn(10000)),
+		MilestoneHash: rand32ByteHash(), Timestamp: uint64(time.Now().Unix()),
+	}
+
+	testCases := []test{
+		func() test {
+
+			// create generators and consumers
+			utxoIterFunc, utxosGenRetriever := newUTXOGenerator(1000000, 4)
+			sepIterFunc, sepGenRetriever := newSEPGenerator(150)
+			sepConsumerfunc, sepsCollRetriever := newSEPCollector()
+			utxoConsumerFunc, utxoCollRetriever := newUTXOCollector()
+
+			t := test{
+				name:             "150 seps, 1 mil txs, uncompressed",
+				snapshotFileName: "uncompressed_snapshot.bin",
+				originHeader:     originHeader,
+				sepGenerator:     sepIterFunc,
+				sepGenRetriever:  sepGenRetriever,
+				utxoGenerator:    utxoIterFunc,
+				utxoGenRetriever: utxosGenRetriever,
+				headerConsumer:   headerEqualFunc(t, originHeader),
+				sepConsumer:      sepConsumerfunc,
+				sepConRetriever:  sepsCollRetriever,
+				utxoConsumer:     utxoConsumerFunc,
+				utxoConRetriever: utxoCollRetriever,
+			}
+			return t
+		}(),
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			filePath := tt.snapshotFileName
+			fs := memfs.Create()
+			snapshotFileWrite, err := fs.OpenFile(filePath, os.O_CREATE|os.O_RDWR, 0666)
+			require.NoError(t, err)
+
+			require.NoError(t, snapshot.StreamLocalSnapshotDataTo(snapshotFileWrite, tt.originHeader, tt.sepGenerator, tt.utxoGenerator))
+			require.NoError(t, snapshotFileWrite.Close())
+
+			fileInfo, err := fs.Stat(filePath)
+			require.NoError(t, err)
+			fmt.Printf("%s: written local snapshot file size: %d MB\n", tt.name, fileInfo.Size()/1024/1024)
+
+			// read back written data and verify that it is equal
+			snapshotFileRead, err := fs.OpenFile(filePath, os.O_RDONLY, 0666)
+			require.NoError(t, err)
+
+			require.NoError(t, snapshot.StreamLocalSnapshotDataFrom(snapshotFileRead, tt.headerConsumer, tt.sepConsumer, tt.utxoConsumer))
+
+			utxoGenerated, _ := tt.utxoGenRetriever()
+			utxoConsumed, _ := tt.utxoConRetriever()
+			require.EqualValues(t, utxoGenerated, utxoConsumed)
+			require.EqualValues(t, tt.sepGenRetriever(), tt.sepConRetriever())
+		})
+	}
+
+}
+
+type sepRetrieverFunc func() [][snapshot.SolidEntryPointHashLength]byte
+
+func newSEPGenerator(count int) (snapshot.SEPIteratorFunc, sepRetrieverFunc) {
+	var generatedSEPs [][snapshot.SolidEntryPointHashLength]byte
+	return func() *[snapshot.SolidEntryPointHashLength]byte {
+			if count == 0 {
+				return nil
+			}
+			count--
+			x := rand32ByteHash()
+			generatedSEPs = append(generatedSEPs, x)
+			return &x
+		}, func() [][32]byte {
+			return generatedSEPs
+		}
+}
+
+func newSEPCollector() (snapshot.SEPConsumerFunc, sepRetrieverFunc) {
+	var generatedSEPs [][snapshot.SolidEntryPointHashLength]byte
+	return func(sep [snapshot.SolidEntryPointHashLength]byte) error {
+			generatedSEPs = append(generatedSEPs, sep)
+			return nil
+		}, func() [][32]byte {
+			return generatedSEPs
+		}
+}
+
+type utxoRetrieverFunc func() ([]snapshot.TransactionOutputs, uint64)
+
+func newUTXOGenerator(count int, maxRandOutputsPerTx int) (snapshot.UTXOIteratorFunc, utxoRetrieverFunc) {
+	var generatedUTXOs []snapshot.TransactionOutputs
+	var outputsTotal uint64
+	return func() *snapshot.TransactionOutputs {
+			if count == 0 {
+				return nil
+			}
+			count--
+			outputsCount := rand.Intn(maxRandOutputsPerTx) + 1
+			tx := randLSTransactionUnspentOutputs(outputsCount)
+			generatedUTXOs = append(generatedUTXOs, *tx)
+			outputsTotal += uint64(len(tx.UnspentOutputs))
+			return tx
+		}, func() ([]snapshot.TransactionOutputs, uint64) {
+			return generatedUTXOs, outputsTotal
+		}
+}
+
+func newUTXOCollector() (snapshot.UTXOConsumerFunc, utxoRetrieverFunc) {
+	var generatedUTXOs []snapshot.TransactionOutputs
+	return func(utxo *snapshot.TransactionOutputs) error {
+			generatedUTXOs = append(generatedUTXOs, *utxo)
+			return nil
+		}, func() ([]snapshot.TransactionOutputs, uint64) {
+			return generatedUTXOs, 0
+		}
+}
+
+func headerEqualFunc(t *testing.T, originHeader *snapshot.FileHeader) snapshot.HeaderConsumerFunc {
+	return func(readHeader *snapshot.FileHeader) error {
+		readHeader.UTXOCount = 0
+		readHeader.SEPCount = 0
+		require.Equal(t, originHeader, readHeader)
+		return nil
+	}
+}
+
+func randBytes(length int) []byte {
+	var b []byte
+	for i := 0; i < length; i++ {
+		b = append(b, byte(rand.Intn(256)))
+	}
+	return b
+}
+
+func rand32ByteHash() [iota.TransactionIDLength]byte {
+	var h [iota.TransactionIDLength]byte
+	b := randBytes(32)
+	copy(h[:], b)
+	return h
+}
+
+func randLSTransactionUnspentOutputs(outputsCount int) *snapshot.TransactionOutputs {
+	return &snapshot.TransactionOutputs{
+		TransactionHash: rand32ByteHash(),
+		UnspentOutputs: func() []*snapshot.UnspentOutput {
+			outputs := make([]*snapshot.UnspentOutput, outputsCount)
+			for i := 0; i < outputsCount; i++ {
+				addr, _ := randEd25519Addr()
+				outputs[i] = &snapshot.UnspentOutput{
+					Index:   uint16(i),
+					Address: addr,
+					Value:   uint64(rand.Intn(1000000) + 1),
+				}
+			}
+			return outputs
+		}(),
+	}
+}
+
+func randEd25519Addr() (*iota.Ed25519Address, []byte) {
+	// type
+	edAddr := &iota.Ed25519Address{}
+	addr := randBytes(iota.Ed25519AddressBytesLength)
+	copy(edAddr[:], addr)
+	// serialized
+	var b [iota.Ed25519AddressSerializedBytesSize]byte
+	b[0] = iota.AddressEd25519
+	copy(b[iota.SmallTypeDenotationByteSize:], addr)
+	return edAddr, b[:]
+}

--- a/plugins/snapshot/plugin.go
+++ b/plugins/snapshot/plugin.go
@@ -149,7 +149,7 @@ func configure(plugin *node.Plugin) {
 				}
 			}
 
-			err = LoadSnapshotFromFile(path)
+			err = LoadFullSnapshotFromFile(path)
 		}
 	default:
 		log.Fatalf("invalid snapshot type under config option '%s': %s", config.CfgSnapshotLoadType, config.NodeConfig.GetString(config.CfgSnapshotLoadType))
@@ -194,7 +194,7 @@ func run(_ *node.Plugin) {
 
 				if shouldTakeSnapshot(solidMilestoneIndex) {
 					localSnapshotPath := config.NodeConfig.GetString(config.CfgLocalSnapshotsPath)
-					if err := createLocalSnapshotWithoutLocking(solidMilestoneIndex-snapshotDepth, localSnapshotPath, true, shutdownSignal); err != nil {
+					if err := createFullLocalSnapshotWithoutLocking(solidMilestoneIndex-snapshotDepth, localSnapshotPath, true, shutdownSignal); err != nil {
 						if errors.Is(err, ErrCritical) {
 							log.Panic(errors.Wrap(ErrSnapshotCreationFailed, err.Error()))
 						}


### PR DESCRIPTION
This PR adds local snapshot file generation compatible with Chrysalis Phase 2. A node can either produce a "full" or "delta" local snapshot:
* `Full`: represents the full ledger state of outputs of the node's LSMI, SEPs of the snapshot milestone and the output diffs<sup>1</sup> per milestone within range of the LSMI to the snapshot milestone. A node bootstrapping from such file can reproduce the ledger state of the snapshot milestone by applying the output diffs within the file to the ledger state of the LSMI.
* `Delta`: does not contain the full ledger state but only SEPs of the snapshot milestone and output diffs of milestones from the the nodes origin ledger milestone index forward.

Rational for the split: Producing `Full` local snapshots can become heavy to the node since over time a large number of UTXOs will be created and streaming them to disk can be a long task. Node implementations may even block ledger operations during local snapshot creation, producing a long blocking time if a `Full` local snapshot gets generated with millions of UTXOs. To circumvent this, nodes can generate `Delta` local snapshots which are relatively cheap to produce. A node which bootstraps for the first time can use a `Full` and `Delta` local snapshots to produce a recent state of the ledger. Furthermore, given a `Full` and `Delta` snapshot, a new compacted `Full` local snapshot can be generated offline, lowering space requirements.

<sup>1</sup>An output diff contains the newly produced and consumed outputs per milestone.

<details>
  <summary>Full format</summary>
  
```
# New format / Large - type 0 / snapshot_155302.bin

version<byte>
type<byte> = 0
timestamp<uint64>
seps_milestone_index<uint64>
seps_milestone_hash<array[32]>
ledger_milestone_index<uint64>
ledger_milestone_hash<array[32]>
seps_count<uint64>
utxos_count<uint64>
diffs_count<uint64>
seps<array>:
	sep<array[32]>
outputs<array>:
	transaction_hash<array[32]>
	output_index<uint16>
	address:
		address_type<byte>
		wots_address<array[49]>
		||
		address_tybe<byte>
		ed25519_address<array[32]>
	value<uint64>
diffs<array>:
	diff_milestone_index<array[32]>
	created_outputs_count<uint64>
	created_outputs<array>:
		transaction_hash<array[32]>
		output_index<uint16>
		address:
			address_type<byte> = 0
			wots_address<array[49]>
			||
			address_tybe<byte> = 1
			ed25519_address<array[32]>
		value<uint64>
	consumed_outputs_count<uint64>
	consumed_outputs<array>:
		transaction_hash<array[32]>
		output_index<uint16>
		address:
			address_type<byte>
			wots_address<array[49]>
			||
			address_tybe<byte>
			ed25519_address<array[32]>
		value<uint64>		
```
</details>

<details>
  <summary>Delta format</summary>
  
```
# New format / Deltas - type 1 / snapshot_deltas_155302.bin

version<byte>
type<byte> = 1
timestamp<uint64>
seps_milestone_index<uint64>
seps_milestone_hash<array[32]>
ledger_milestone_index<uint64>
ledger_milestone_hash<array[32]>
seps_count<uint64>
diffs_count<uint64>
seps<array>:
	sep<array[32]>
diffs<array>:
	diff_milestone_index<array[32]>
	created_outputs_count<uint64>
	created_outputs<array>:
		transaction_hash<array[32]>
		output_index<uint16>
		address:
			address_type<byte> = 0
			wots_address<array[49]>
			||
			address_tybe<byte> = 1
			ed25519_address<array[32]>
		value<uint64>
	consumed_outputs_count<uint64>
	consumed_outputs<array>:
		transaction_hash<array[32]>
		output_index<uint16>
		address:
			address_type<byte> = 0
			wots_address<array[49]>
			||
			address_tybe<byte> = 1
			ed25519_address<array[32]>
		value<uint64>
```
</details>