### PR TITLE
Chrysalis Pt2 MQTT Events - Volume 2

### DIFF
--- a/pkg/mqtt/broker.go
+++ b/pkg/mqtt/broker.go
@@ -47,6 +47,10 @@ func (b *Broker) GetConfig() *broker.Config {
 	return b.config
 }
 
+func (b *Broker) HasSubscribers(topic string) bool {
+	return b.topicManager.hasSubscribers(topic)
+}
+
 // Send publishes a message.
 func (b *Broker) Send(topic string, payload []byte) {
 

--- a/pkg/mqtt/topic_manager.go
+++ b/pkg/mqtt/topic_manager.go
@@ -28,15 +28,17 @@ func (t topicManager) Subscribe(topic []byte, qos byte, subscriber interface{}) 
 
 	b, err := t.mem.Subscribe(topic, qos, subscriber)
 
-	topicName := string(topic)
-	count, has := t.subscribedTopics[topicName]
-	if has {
-		t.subscribedTopics[topicName] = count + 1
-	} else {
-		t.subscribedTopics[topicName] = 1
-	}
+	if err == nil {
+		topicName := string(topic)
+		count, has := t.subscribedTopics[topicName]
+		if has {
+			t.subscribedTopics[topicName] = count + 1
+		} else {
+			t.subscribedTopics[topicName] = 1
+		}
 
-	t.onSubscribe(topic)
+		t.onSubscribe(topic)
+	}
 
 	return b, err
 }
@@ -46,6 +48,8 @@ func (t topicManager) Unsubscribe(topic []byte, subscriber interface{}) error {
 	defer t.subscribedTopicsLock.Unlock()
 
 	err := t.mem.Unsubscribe(topic, subscriber)
+
+	//Ignore error here, always unsubscribe to be safe
 
 	topicName := string(topic)
 	count, has := t.subscribedTopics[topicName]

--- a/pkg/mqtt/topic_manager.go
+++ b/pkg/mqtt/topic_manager.go
@@ -1,6 +1,8 @@
 package mqtt
 
 import (
+	"sync"
+
 	"github.com/eclipse/paho.mqtt.golang/packets"
 	"github.com/fhmq/hmq/broker/lib/topics"
 )
@@ -11,24 +13,52 @@ type OnUnsubscribeHandler func(topic []byte)
 // topicManager registers itself instead of the normal memtopic and implements the TopicsProvider interface.
 // This allows to get notified when a topic is subscribed or unsubscribed
 type topicManager struct {
-	mem           topics.TopicsProvider
+	mem topics.TopicsProvider
+
+	subscribedTopics     map[string]int
+	subscribedTopicsLock sync.RWMutex
+
 	onSubscribe   OnSubscribeHandler
 	onUnsubscribe OnUnsubscribeHandler
 }
 
 func (t topicManager) Subscribe(topic []byte, qos byte, subscriber interface{}) (byte, error) {
+	t.subscribedTopicsLock.Lock()
+	defer t.subscribedTopicsLock.Unlock()
+
 	b, err := t.mem.Subscribe(topic, qos, subscriber)
-	if err == nil {
-		t.onSubscribe(topic)
+
+	topicName := string(topic)
+	count, has := t.subscribedTopics[topicName]
+	if has {
+		t.subscribedTopics[topicName] = count + 1
+	} else {
+		t.subscribedTopics[topicName] = 1
 	}
+
+	t.onSubscribe(topic)
+
 	return b, err
 }
 
 func (t topicManager) Unsubscribe(topic []byte, subscriber interface{}) error {
+	t.subscribedTopicsLock.Lock()
+	defer t.subscribedTopicsLock.Unlock()
+
 	err := t.mem.Unsubscribe(topic, subscriber)
-	if err == nil {
-		t.onUnsubscribe(topic)
+
+	topicName := string(topic)
+	count, has := t.subscribedTopics[topicName]
+	if has {
+		if count <= 0 {
+			delete(t.subscribedTopics, topicName)
+		} else {
+			t.subscribedTopics[topicName] = count - 1
+		}
 	}
+
+	t.onUnsubscribe(topic)
+
 	return err
 }
 
@@ -48,12 +78,21 @@ func (t topicManager) Close() error {
 	return t.mem.Close()
 }
 
+func (t topicManager) hasSubscribers(topicName string) bool {
+	t.subscribedTopicsLock.RLock()
+	defer t.subscribedTopicsLock.RUnlock()
+
+	count, has := t.subscribedTopics[topicName]
+	return has && count > 0
+}
+
 func newTopicManager(onSubscribe OnSubscribeHandler, onUnsubscribe OnUnsubscribeHandler) *topicManager {
 
 	mgr := &topicManager{
-		mem:           topics.NewMemProvider(),
-		onSubscribe:   onSubscribe,
-		onUnsubscribe: onUnsubscribe,
+		mem:              topics.NewMemProvider(),
+		subscribedTopics: make(map[string]int),
+		onSubscribe:      onSubscribe,
+		onUnsubscribe:    onUnsubscribe,
 	}
 
 	// The normal MQTT broker uses the `mem` topic manager internally, so first unregister the default one.

--- a/plugins/mqtt/topics.go
+++ b/plugins/mqtt/topics.go
@@ -5,7 +5,10 @@ const (
 	topicMilestonesLatest = "milestones/latest"
 	topicMilestonesSolid  = "milestones/solid"
 
-	topicMessagesMetadata = "messages/{messageId}/metadata"
+	topicMessages           = "messages"
+	topicMessagesReferenced = "messages/referenced"
+	topicMessagesIndexation = "messages/indexation/{index}"
+	topicMessagesMetadata   = "messages/{messageId}/metadata"
 
 	topicOutputs = "outputs/{outputId}"
 


### PR DESCRIPTION
This introduces the following MQTT topics:

## Messages

- `messages`
Payload includes the raw bytes of the messages
- `messages/indexation/{index}`
Payload includes the raw bytes of the messages

- `messages/referenced `
Payload corresponds to the `GetMessageMetadataByIdResponse` REST api (without the `data` envelope).

**Only new values will be delivered directly after subscription**

Additionally this PR now optimizes the MQTT packets generated by only serializing JSON and binary payloads if there is an active subscriber for the given topic.