### PR TITLE
Add r/w stream deadlines and fixes stream write goroutine not terminating

### DIFF
--- a/core/gossip/params.go
+++ b/core/gossip/params.go
@@ -8,6 +8,10 @@ import (
 const (
 	// Defines the maximum amount of unknown peers a gossip protocol connection is established to.
 	CfgP2PGossipUnknownPeersLimit = "p2p.gossipUnknownPeersLimit"
+	// Defines the read timeout for subsequent reads in seconds.
+	CfgGossipStreamReadTimeoutSec = "gossip.streamReadTimeoutSec"
+	// Defines the write timeout for writes to the stream in seconds.
+	CfgGossipStreamWriteTimeoutSec = "gossip.streamWriteTimeoutSec"
 )
 
 var params = &node.PluginParams{
@@ -15,6 +19,8 @@ var params = &node.PluginParams{
 		"nodeConfig": func() *flag.FlagSet {
 			fs := flag.NewFlagSet("", flag.ContinueOnError)
 			fs.Int(CfgP2PGossipUnknownPeersLimit, 4, "maximum amount of unknown peers a gossip protocol connection is established to")
+			fs.Int(CfgGossipStreamReadTimeoutSec, 60, "the read timeout for reads from the gossip stream in seconds")
+			fs.Int(CfgGossipStreamWriteTimeoutSec, 10, "the write timeout for writes to the gossip stream in seconds")
 			return fs
 		}(),
 	},

--- a/pkg/protocol/gossip/protocol.go
+++ b/pkg/protocol/gossip/protocol.go
@@ -36,7 +36,7 @@ type ProtocolEvents struct {
 }
 
 // NewProtocol creates a new gossip protocol instance associated to the given peer.
-func NewProtocol(peerID peer.ID, stream network.Stream, sendQueueSize int) *Protocol {
+func NewProtocol(peerID peer.ID, stream network.Stream, sendQueueSize int, readTimeout, writeTimeout time.Duration) *Protocol {
 	defs := gossipMessageRegistry.Definitions()
 	sentEvents := make([]*events.Event, len(defs))
 	for i, def := range defs {
@@ -57,8 +57,10 @@ func NewProtocol(peerID peer.ID, stream network.Stream, sendQueueSize int) *Prot
 			Closed: events.NewEvent(events.CallbackCaller),
 			Errors: events.NewEvent(events.ErrorCaller),
 		},
-		Stream:    stream,
-		SendQueue: make(chan []byte, sendQueueSize),
+		Stream:       stream,
+		SendQueue:    make(chan []byte, sendQueueSize),
+		readTimeout:  readTimeout,
+		writeTimeout: writeTimeout,
 	}
 }
 
@@ -81,8 +83,10 @@ type Protocol struct {
 	// The send queue into which to enqueue messages to send.
 	SendQueue chan []byte
 	// The metrics around this protocol instance.
-	Metrics Metrics
-	sendMu  sync.Mutex
+	Metrics      Metrics
+	sendMu       sync.Mutex
+	readTimeout  time.Duration
+	writeTimeout time.Duration
 }
 
 // Enqueue enqueues the given gossip protocol message to be sent to the peer.
@@ -96,12 +100,20 @@ func (p *Protocol) Enqueue(data []byte) {
 	}
 }
 
+// Read reads from the stream into the given buffer.
+func (p *Protocol) Read(buf []byte) (int, error) {
+	_ = p.Stream.SetReadDeadline(time.Now().Add(p.readTimeout))
+	r, err := p.Stream.Read(buf)
+	return r, err
+}
+
 // Send sends the given gossip message on the underlying Protocol.Stream.
 func (p *Protocol) Send(message []byte) error {
 	p.sendMu.Lock()
 	defer p.sendMu.Unlock()
 
 	// write message
+	_ = p.Stream.SetWriteDeadline(time.Now().Add(p.writeTimeout))
 	if _, err := p.Stream.Write(message); err != nil {
 		return fmt.Errorf("failed to send message: %w", err)
 	}


### PR DESCRIPTION
Adds sensible read/write deadlines for read/write calls from/to gossip streams, to ensure that eventually the corresponding goroutines are terminated. Also fixes an error occurring while writing to a stream not aborting the write goroutine.