### PR TITLE
Fix run_2nd.bat - backslash to carrot

### DIFF
--- a/run_2nd.bat
+++ b/run_2nd.bat
@@ -1,5 +1,5 @@
 del /f /q /s alphanetdb2
-go run -tags "pow_avx" main.go -c config_alphanet.json \
+go run -tags "pow_avx" main.go -c config_alphanet.json ^
 --protocol.networkID="alphanet1" ^
 --restAPI.bindAddress="0.0.0.0:14266" ^
 --dashboard.bindAddress="localhost:8082" ^


### PR DESCRIPTION
Backslash needs to be a carrot

- [ X ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ X ] I have tested my code extensively
- [ ] I have selected the `develop` branch as the target branch
