### PR TITLE
Add API bech32 support

### DIFF
--- a/alphanet/config_alphanet.json
+++ b/alphanet/config_alphanet.json
@@ -20,6 +20,8 @@
       "/api/v1/outputs/:outputID",
       "/api/v1/addresses/:address",
       "/api/v1/addresses/:address/outputs",
+      "/api/v1/addresses/ed25519/:address",
+      "/api/v1/addresses/ed25519/:address/outputs",
       "/api/v1/peers/:peerID",
       "/api/v1/peers"
     ],

--- a/config.json
+++ b/config.json
@@ -19,7 +19,9 @@
       "/api/v1/milestones/:milestoneIndex",
       "/api/v1/outputs/:outputID",
       "/api/v1/addresses/:address",
-      "/api/v1/addresses/:address/outputs"
+      "/api/v1/addresses/:address/outputs",
+      "/api/v1/addresses/ed25519/:address",
+      "/api/v1/addresses/ed25519/:address/outputs"
     ],
     "whitelistedAddresses": [
       "127.0.0.1",

--- a/config_comnet.json
+++ b/config_comnet.json
@@ -19,7 +19,9 @@
       "/api/v1/milestones/:milestoneIndex",
       "/api/v1/outputs/:outputID",
       "/api/v1/addresses/:address",
-      "/api/v1/addresses/:address/outputs"
+      "/api/v1/addresses/:address/outputs",
+      "/api/v1/addresses/ed25519/:address",
+      "/api/v1/addresses/ed25519/:address/outputs"
     ],
     "whitelistedAddresses": [
       "127.0.0.1",

--- a/config_devnet.json
+++ b/config_devnet.json
@@ -19,7 +19,9 @@
       "/api/v1/milestones/:milestoneIndex",
       "/api/v1/outputs/:outputID",
       "/api/v1/addresses/:address",
-      "/api/v1/addresses/:address/outputs"
+      "/api/v1/addresses/:address/outputs",
+      "/api/v1/addresses/ed25519/:address",
+      "/api/v1/addresses/ed25519/:address/outputs"
     ],
     "whitelistedAddresses": [
       "127.0.0.1",

--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/gorilla/websocket v1.4.2
 	github.com/hashicorp/go-version v1.2.1 // indirect
 	github.com/iotaledger/hive.go v0.0.0-20201124222826-cfc75d969092
-	github.com/iotaledger/iota.go v1.0.0-beta.15.0.20201117144025-0657bc1c8025
+	github.com/iotaledger/iota.go v1.0.0-beta.15.0.20201202132833-d0121354a850
 	github.com/ipfs/go-ds-badger v0.2.6
 	github.com/koron/go-ssdp v0.0.2 // indirect
 	github.com/kr/pretty v0.2.1 // indirect
@@ -61,10 +61,10 @@ require (
 	go.uber.org/atomic v1.7.0
 	go.uber.org/dig v1.10.0
 	go.uber.org/multierr v1.6.0 // indirect
-	golang.org/x/crypto v0.0.0-20201117144127-c1f2f97bffc9
-	golang.org/x/net v0.0.0-20201110031124-69a78807bb2b // indirect
-	golang.org/x/sys v0.0.0-20201119102817-f84b799fce68 // indirect
+	golang.org/x/crypto v0.0.0-20201124201722-c8d3bf9c5392
+	golang.org/x/net v0.0.0-20201202161906-c7110b5ffcbb // indirect
+	golang.org/x/sys v0.0.0-20201201145000-ef89a241ccb3 // indirect
 	golang.org/x/tools v0.0.0-20201123232213-4aa1a224cdb5 // indirect
-	google.golang.org/genproto v0.0.0-20201119123407-9b1e624d6bc4 // indirect
+	google.golang.org/genproto v0.0.0-20201202151023-55d61f90c1ce // indirect
 	google.golang.org/grpc v1.33.2 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -354,8 +354,8 @@ github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod
 github.com/iotaledger/hive.go v0.0.0-20201124222826-cfc75d969092 h1:4aMchOmpu0e+JzoYP0Den3x1GepZzEv09fWfhMTlbhc=
 github.com/iotaledger/hive.go v0.0.0-20201124222826-cfc75d969092/go.mod h1:xqn2tIsuGgEU68fgTiR5SH6tD1hxRwznLfvgR0ZEPUs=
 github.com/iotaledger/iota.go v1.0.0-beta.15.0.20200924093814-add1daca64b6/go.mod h1:Rn6v5hLAn8YBaJlRu1ZQdPAgKlshJR1PTeLQaft2778=
-github.com/iotaledger/iota.go v1.0.0-beta.15.0.20201117144025-0657bc1c8025 h1:YvDZongm91GFLnLf54kMF12c+/0WrsDkJxaNTPx3Eec=
-github.com/iotaledger/iota.go v1.0.0-beta.15.0.20201117144025-0657bc1c8025/go.mod h1:70AnUp7PT4kXRUCA8Ptw4Ddh80RIx6SmOO2eon/TqTQ=
+github.com/iotaledger/iota.go v1.0.0-beta.15.0.20201202132833-d0121354a850 h1:kPxVBK+ptMKEoQrDZezLxCoyDuR122isZ3F7yyfr5xs=
+github.com/iotaledger/iota.go v1.0.0-beta.15.0.20201202132833-d0121354a850/go.mod h1:70AnUp7PT4kXRUCA8Ptw4Ddh80RIx6SmOO2eon/TqTQ=
 github.com/ipfs/go-cid v0.0.1/go.mod h1:GHWU/WuQdMPmIosc4Yn1bcCT7dSeX4lBafM7iqUPQvM=
 github.com/ipfs/go-cid v0.0.2/go.mod h1:GHWU/WuQdMPmIosc4Yn1bcCT7dSeX4lBafM7iqUPQvM=
 github.com/ipfs/go-cid v0.0.3/go.mod h1:GHWU/WuQdMPmIosc4Yn1bcCT7dSeX4lBafM7iqUPQvM=
@@ -1095,6 +1095,8 @@ golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20201016220609-9e8e0b390897/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20201117144127-c1f2f97bffc9 h1:phUcVbl53swtrUN8kQEXFhUxPlIlWyBfKmidCu7P95o=
 golang.org/x/crypto v0.0.0-20201117144127-c1f2f97bffc9/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
+golang.org/x/crypto v0.0.0-20201124201722-c8d3bf9c5392 h1:xYJJ3S178yv++9zXV/hnr29plCAGO9vAFG9dorqaFQc=
+golang.org/x/crypto v0.0.0-20201124201722-c8d3bf9c5392/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20200513190911-00229845015e h1:rMqLP+9XLy+LdbCXHjJHAmTfXCr93W7oruWA6Hq1Alc=
@@ -1146,8 +1148,8 @@ golang.org/x/net v0.0.0-20200625001655-4c5254603344/go.mod h1:/O7V0waA8r7cgGh81R
 golang.org/x/net v0.0.0-20200822124328-c89045814202/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20200904194848-62affa334b73/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
-golang.org/x/net v0.0.0-20201110031124-69a78807bb2b h1:uwuIcX0g4Yl1NC5XAz37xsr2lTtcqevgzYNVt49waME=
-golang.org/x/net v0.0.0-20201110031124-69a78807bb2b/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
+golang.org/x/net v0.0.0-20201202161906-c7110b5ffcbb h1:eBmm0M9fYhWpKZLjQUUKka/LtIxf46G4fxeEz5KJr9U=
+golang.org/x/net v0.0.0-20201202161906-c7110b5ffcbb/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -1207,8 +1209,8 @@ golang.org/x/sys v0.0.0-20200826173525-f9321e4c35a6/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200909081042-eff7692f9009/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201015000850-e3ed0017c211/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20201119102817-f84b799fce68 h1:nxC68pudNYkKU6jWhgrqdreuFiOQWj1Fs7T3VrH4Pjw=
-golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20201201145000-ef89a241ccb3 h1:kzM6+9dur93BcC2kVlYl34cHU+TYZLanmpSJHVMmL64=
+golang.org/x/sys v0.0.0-20201201145000-ef89a241ccb3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221 h1:/ZHdbVpdR/jk3g30/d4yUL0JU9kksj8+F/bnQUVLGDM=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -1262,8 +1264,8 @@ google.golang.org/genproto v0.0.0-20190425155659-357c62f0e4bb/go.mod h1:VzzqZJRn
 google.golang.org/genproto v0.0.0-20190530194941-fb225487d101/go.mod h1:z3L6/3dTEVtUr6QSP8miRzeRqwQOioJ9I66odjN4I7s=
 google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55/go.mod h1:DMBHOl98Agz4BDEuKkezgsaosCRResVns1a3J2ZsMNc=
 google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013/go.mod h1:NbSheEEYHJ7i3ixzK3sjbqSGDJWnxyFXZblF3eUsNvo=
-google.golang.org/genproto v0.0.0-20201119123407-9b1e624d6bc4 h1:Rt0FRalMgdSlXAVJvX4pr65KfqaxHXSLkSJRD9pw6g0=
-google.golang.org/genproto v0.0.0-20201119123407-9b1e624d6bc4/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
+google.golang.org/genproto v0.0.0-20201202151023-55d61f90c1ce h1:iS2R2xZpNiQFZrGqWisFYEYzOyKzvz07am2h/QXKqoY=
+google.golang.org/genproto v0.0.0-20201202151023-55d61f90c1ce/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/grpc v1.12.0/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=
 google.golang.org/grpc v1.17.0/go.mod h1:6QZJwpn2B+Zp71q/5VxRsJ6NXXVCE5NRUHRo+f3cWCs=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=

--- a/integration-tests/tester/framework/config.go
+++ b/integration-tests/tester/framework/config.go
@@ -225,6 +225,8 @@ func DefaultRestAPIConfig() RestAPIConfig {
 			"/api/v1/outputs/:outputID",
 			"/api/v1/addresses/:address",
 			"/api/v1/addresses/:address/outputs",
+			"/api/v1/addresses/ed25519/:address",
+			"/api/v1/addresses/ed25519/:address/outputs",
 			"/api/v1/peers/:peerID",
 			"/api/v1/peers",
 			"/api/v1/debug/outputs",

--- a/integration-tests/tester/tests/value/value_test.go
+++ b/integration-tests/tester/tests/value/value_test.go
@@ -80,15 +80,15 @@ func TestValue(t *testing.T) {
 	}, 30*time.Second, 100*time.Millisecond)
 
 	// check that indeed the balances are available
-	res, err := n.Coordinator().NodeAPI.BalanceByAddress(framework.GenesisAddress.String())
+	res, err := n.Coordinator().NodeAPI.BalanceByEd25519Address(framework.GenesisAddress.String())
 	require.NoError(t, err)
 	require.Zero(t, res.Balance)
 
-	res, err = n.Coordinator().NodeAPI.BalanceByAddress(target1Addr.String())
+	res, err = n.Coordinator().NodeAPI.BalanceByEd25519Address(target1Addr.String())
 	require.NoError(t, err)
 	require.EqualValues(t, target1Deposit, res.Balance)
 
-	res, err = n.Coordinator().NodeAPI.BalanceByAddress(target2Addr.String())
+	res, err = n.Coordinator().NodeAPI.BalanceByEd25519Address(target2Addr.String())
 	require.NoError(t, err)
 	require.EqualValues(t, target2Deposit, res.Balance)
 

--- a/pkg/toolset/toolset.go
+++ b/pkg/toolset/toolset.go
@@ -23,7 +23,7 @@ func HandleTools() {
 
 	toolFound := false
 	for i, arg := range args {
-		if strings.ToLower(arg) == "tool" {
+		if strings.ToLower(arg) == "tool" || strings.ToLower(arg) == "tools" {
 			args = args[i:]
 			toolFound = true
 			break

--- a/plugins/restapi/params.go
+++ b/plugins/restapi/params.go
@@ -47,6 +47,8 @@ var params = &node.PluginParams{
 					"/api/v1/outputs/:outputID",
 					"/api/v1/addresses/:address",
 					"/api/v1/addresses/:address/outputs",
+					"/api/v1/addresses/ed25519/:address",
+					"/api/v1/addresses/ed25519/:address/outputs",
 				}, "the allowed HTTP REST routes which can be called from non whitelisted addresses")
 			fs.StringSlice(CfgRestAPIWhitelistedAddresses, []string{"127.0.0.1", "::1"}, "the whitelist of addresses which are allowed to access the REST API")
 			fs.Bool(CfgRestAPIExcludeHealthCheckFromAuth, false, "whether to allow the health check route anyways")

--- a/plugins/restapi/v1/plugin.go
+++ b/plugins/restapi/v1/plugin.go
@@ -85,13 +85,25 @@ const (
 	// GET returns the output.
 	RouteOutput = "/outputs/:" + ParameterOutputID
 
-	// RouteAddressBalance is the route for getting the total balance of all unspent outputs of an address.
+	// RouteAddressBech32Balance is the route for getting the total balance of all unspent outputs of an address.
+	// The address must be encoded in bech32.
 	// GET returns the balance of all unspent outputs of this address.
-	RouteAddressBalance = "/addresses/:" + ParameterAddress
+	RouteAddressBech32Balance = "/addresses/:" + ParameterAddress
 
-	// RouteAddressOutputs is the route for getting all output IDs for an address.
+	// RouteAddressEd25519Balance is the route for getting the total balance of all unspent outputs of an ed25519 address.
+	// The ed25519 address must be encoded in hex.
+	// GET returns the balance of all unspent outputs of this address.
+	RouteAddressEd25519Balance = "/addresses/ed25519/:" + ParameterAddress
+
+	// RouteAddressBech32Outputs is the route for getting all output IDs for an address.
+	// The address must be encoded in bech32.
 	// GET returns the outputIDs for all outputs of this address (optional query parameters: "include-spent").
-	RouteAddressOutputs = "/addresses/:" + ParameterAddress + "/outputs"
+	RouteAddressBech32Outputs = "/addresses/:" + ParameterAddress + "/outputs"
+
+	// RouteAddressEd25519Outputs is the route for getting all output IDs for an ed25519 address.
+	// The ed25519 address must be encoded in hex.
+	// GET returns the outputIDs for all outputs of this address (optional query parameters: "include-spent").
+	RouteAddressEd25519Outputs = "/addresses/ed25519/:" + ParameterAddress + "/outputs"
 
 	// RoutePeer is the route for getting peers by their peerID.
 	// GET returns the peer
@@ -280,8 +292,8 @@ func configure() {
 		return restapi.JSONResponse(c, http.StatusOK, resp)
 	})
 
-	routeGroup.GET(RouteAddressBalance, func(c echo.Context) error {
-		resp, err := balanceByAddress(c)
+	routeGroup.GET(RouteAddressBech32Balance, func(c echo.Context) error {
+		resp, err := balanceByBech32Address(c)
 		if err != nil {
 			return err
 		}
@@ -289,8 +301,26 @@ func configure() {
 		return restapi.JSONResponse(c, http.StatusOK, resp)
 	})
 
-	routeGroup.GET(RouteAddressOutputs, func(c echo.Context) error {
-		resp, err := outputsIDsByAddress(c)
+	routeGroup.GET(RouteAddressEd25519Balance, func(c echo.Context) error {
+		resp, err := balanceByEd25519Address(c)
+		if err != nil {
+			return err
+		}
+
+		return restapi.JSONResponse(c, http.StatusOK, resp)
+	})
+
+	routeGroup.GET(RouteAddressBech32Outputs, func(c echo.Context) error {
+		resp, err := outputsIDsByBech32Address(c)
+		if err != nil {
+			return err
+		}
+
+		return restapi.JSONResponse(c, http.StatusOK, resp)
+	})
+
+	routeGroup.GET(RouteAddressEd25519Outputs, func(c echo.Context) error {
+		resp, err := outputsIDsByEd25519Address(c)
 		if err != nil {
 			return err
 		}

--- a/plugins/restapi/v1/plugin.go
+++ b/plugins/restapi/v1/plugin.go
@@ -139,6 +139,14 @@ const (
 	// GET returns the outputIDs for all spent outputs.
 	RouteDebugOutputsSpent = "/debug/outputs/spent"
 
+	// RouteDebugAddresses is the debug route for getting all known addresses.
+	// GET returns all known addresses encoded in hex.
+	RouteDebugAddresses = "/debug/addresses"
+
+	// RouteDebugAddressesEd25519 is the debug route for getting all known ed25519 addresses.
+	// GET returns all known ed25519 addresses encoded in hex.
+	RouteDebugAddressesEd25519 = "/debug/addresses/ed25519"
+
 	// RouteDebugMilestoneDiffs is the debug route for getting a milestone diff by it's milestoneIndex.
 	// GET returns the utxo diff (new outputs & spents) for the milestone index.
 	RouteDebugMilestoneDiffs = "/debug/ms-diff/:" + ParameterMilestoneIndex
@@ -407,6 +415,24 @@ func configure() {
 
 	routeGroup.GET(RouteDebugOutputsSpent, func(c echo.Context) error {
 		resp, err := debugSpentOutputsIDs(c)
+		if err != nil {
+			return err
+		}
+
+		return restapi.JSONResponse(c, http.StatusOK, resp)
+	})
+
+	routeGroup.GET(RouteDebugAddresses, func(c echo.Context) error {
+		resp, err := debugAddresses(c)
+		if err != nil {
+			return err
+		}
+
+		return restapi.JSONResponse(c, http.StatusOK, resp)
+	})
+
+	routeGroup.GET(RouteDebugAddressesEd25519, func(c echo.Context) error {
+		resp, err := debugAddressesEd25519(c)
 		if err != nil {
 			return err
 		}

--- a/plugins/restapi/v1/types.go
+++ b/plugins/restapi/v1/types.go
@@ -142,6 +142,22 @@ type outputIDsResponse struct {
 	OutputIDs []string `json:"outputIds"`
 }
 
+// address defines the response of a GET debug addresses REST API call.
+type address struct {
+	// The type of the address (0=WOTS, 1=Ed25519).
+	AddressType byte `json:"addressType"`
+	// The hex encoded address.
+	Address string `json:"address"`
+	// The balance of the address.
+	Balance uint64 `json:"balance"`
+}
+
+// addressesResponse defines the response of a GET debug addresses REST API call.
+type addressesResponse struct {
+	// The addresses (type + hex encoded address).
+	Addresses []*address `json:"addresses"`
+}
+
 // outputIDsResponse defines the response of a GET debug milestone diff REST API call.
 type milestoneDiffResponse struct {
 	// The index of the milestone.

--- a/plugins/restapi/v1/types.go
+++ b/plugins/restapi/v1/types.go
@@ -110,6 +110,8 @@ type outputResponse struct {
 
 // addressBalanceResponse defines the response of a GET addresses REST API call.
 type addressBalanceResponse struct {
+	// The type of the address (0=WOTS, 1=Ed25519).
+	AddressType byte `json:"addressType"`
 	// The hex encoded address.
 	Address string `json:"address"`
 	// The maximum count of results that are returned by the node.
@@ -122,6 +124,8 @@ type addressBalanceResponse struct {
 
 // addressOutputsResponse defines the response of a GET outputs by address REST API call.
 type addressOutputsResponse struct {
+	// The type of the address (0=WOTS, 1=Ed25519).
+	AddressType byte `json:"addressType"`
 	// The hex encoded address.
 	Address string `json:"address"`
 	// The maximum count of results that are returned by the node.

--- a/plugins/restapi/v1/utxo.go
+++ b/plugins/restapi/v1/utxo.go
@@ -73,44 +73,24 @@ func outputByID(c echo.Context) (*outputResponse, error) {
 	return newOutputResponse(output, !unspent)
 }
 
-func balanceByAddress(c echo.Context) (*addressBalanceResponse, error) {
-
-	if !deps.Storage.WaitForNodeSynced(waitForNodeSyncedTimeout) {
-		return nil, errors.WithMessage(restapi.ErrServiceUnavailable, "node is not synced")
-	}
-
-	addressParam := strings.ToLower(c.Param(ParameterAddress))
-
-	// ToDo: accept bech32 input
-
-	addressBytes, err := hex.DecodeString(addressParam)
-	if err != nil {
-		return nil, errors.WithMessagef(restapi.ErrInvalidParameter, "invalid address: %s, error: %s", addressParam, err)
-	}
-
-	if len(addressBytes) != (iotago.Ed25519AddressBytesLength) {
-		return nil, errors.WithMessagef(restapi.ErrInvalidParameter, "invalid address length: %s", addressParam)
-	}
-
-	var address iotago.Ed25519Address
-	copy(address[:], addressBytes)
-
+func ed25519Balance(address *iotago.Ed25519Address) (*addressBalanceResponse, error) {
 	maxResults := deps.NodeConfig.Int(restapiplugin.CfgRestAPILimitsMaxResults)
 
-	balance, count, err := deps.UTXO.AddressBalance(&address, maxResults)
+	balance, count, err := deps.UTXO.AddressBalance(address, maxResults)
 	if err != nil {
 		return nil, errors.WithMessagef(restapi.ErrInternalError, "reading address balance failed: %s, error: %s", address, err)
 	}
 
 	return &addressBalanceResponse{
-		Address:    addressParam,
-		MaxResults: uint32(maxResults),
-		Count:      uint32(count),
-		Balance:    balance,
+		AddressType: iotago.AddressEd25519,
+		Address:     address.String(),
+		MaxResults:  uint32(maxResults),
+		Count:       uint32(count),
+		Balance:     balance,
 	}, nil
 }
 
-func outputsIDsByAddress(c echo.Context) (*addressOutputsResponse, error) {
+func balanceByBech32Address(c echo.Context) (*addressBalanceResponse, error) {
 
 	if !deps.Storage.WaitForNodeSynced(waitForNodeSyncedTimeout) {
 		return nil, errors.WithMessage(restapi.ErrServiceUnavailable, "node is not synced")
@@ -118,7 +98,29 @@ func outputsIDsByAddress(c echo.Context) (*addressOutputsResponse, error) {
 
 	addressParam := strings.ToLower(c.Param(ParameterAddress))
 
-	// ToDo: accept bech32 input
+	_, bech32Address, err := iotago.ParseBech32(addressParam)
+	if err != nil {
+		return nil, errors.WithMessagef(restapi.ErrInvalidParameter, "invalid address: %s, error: %s", addressParam, err)
+	}
+
+	switch address := bech32Address.(type) {
+	case *iotago.WOTSAddress:
+		// TODO: implement
+		return nil, errors.WithMessagef(restapi.ErrInvalidParameter, "invalid address: %s, error: %s", addressParam, iotago.ErrWOTSNotImplemented)
+	case *iotago.Ed25519Address:
+		return ed25519Balance(address)
+	default:
+		return nil, errors.WithMessagef(restapi.ErrInvalidParameter, "invalid address: %s, error: unknown address type", addressParam)
+	}
+}
+
+func balanceByEd25519Address(c echo.Context) (*addressBalanceResponse, error) {
+
+	if !deps.Storage.WaitForNodeSynced(waitForNodeSyncedTimeout) {
+		return nil, errors.WithMessage(restapi.ErrServiceUnavailable, "node is not synced")
+	}
+
+	addressParam := strings.ToLower(c.Param(ParameterAddress))
 
 	addressBytes, err := hex.DecodeString(addressParam)
 	if err != nil {
@@ -132,9 +134,13 @@ func outputsIDsByAddress(c echo.Context) (*addressOutputsResponse, error) {
 	var address iotago.Ed25519Address
 	copy(address[:], addressBytes)
 
+	return ed25519Balance(&address)
+}
+
+func ed25519Outputs(address *iotago.Ed25519Address, includeSpent bool) (*addressOutputsResponse, error) {
 	maxResults := deps.NodeConfig.Int(restapiplugin.CfgRestAPILimitsMaxResults)
 
-	unspentOutputs, err := deps.UTXO.UnspentOutputsForAddress(&address, maxResults)
+	unspentOutputs, err := deps.UTXO.UnspentOutputsForAddress(address, maxResults)
 	if err != nil {
 		return nil, errors.WithMessagef(restapi.ErrInternalError, "reading unspent outputs failed: %s, error: %s", address, err)
 	}
@@ -144,11 +150,9 @@ func outputsIDsByAddress(c echo.Context) (*addressOutputsResponse, error) {
 		outputIDs = append(outputIDs, hex.EncodeToString(unspentOutput.OutputID()[:]))
 	}
 
-	includeSpent, _ := strconv.ParseBool(strings.ToLower(c.QueryParam("include-spent")))
-
 	if includeSpent && maxResults-len(outputIDs) > 0 {
 
-		spents, err := deps.UTXO.SpentOutputsForAddress(&address, maxResults-len(outputIDs))
+		spents, err := deps.UTXO.SpentOutputsForAddress(address, maxResults-len(outputIDs))
 		if err != nil {
 			return nil, errors.WithMessagef(restapi.ErrInternalError, "reading spent outputs failed: %s, error: %s", address, err)
 		}
@@ -159,9 +163,59 @@ func outputsIDsByAddress(c echo.Context) (*addressOutputsResponse, error) {
 	}
 
 	return &addressOutputsResponse{
-		Address:    addressParam,
-		MaxResults: uint32(maxResults),
-		Count:      uint32(len(outputIDs)),
-		OutputIDs:  outputIDs,
+		AddressType: iotago.AddressEd25519,
+		Address:     address.String(),
+		MaxResults:  uint32(maxResults),
+		Count:       uint32(len(outputIDs)),
+		OutputIDs:   outputIDs,
 	}, nil
+}
+
+func outputsIDsByBech32Address(c echo.Context) (*addressOutputsResponse, error) {
+
+	if !deps.Storage.WaitForNodeSynced(waitForNodeSyncedTimeout) {
+		return nil, errors.WithMessage(restapi.ErrServiceUnavailable, "node is not synced")
+	}
+
+	addressParam := strings.ToLower(c.Param(ParameterAddress))
+	includeSpent, _ := strconv.ParseBool(strings.ToLower(c.QueryParam("include-spent")))
+
+	_, bech32Address, err := iotago.ParseBech32(addressParam)
+	if err != nil {
+		return nil, errors.WithMessagef(restapi.ErrInvalidParameter, "invalid address: %s, error: %s", addressParam, err)
+	}
+
+	switch address := bech32Address.(type) {
+	case *iotago.WOTSAddress:
+		// TODO: implement
+		return nil, errors.WithMessagef(restapi.ErrInvalidParameter, "invalid address: %s, error: %s", addressParam, iotago.ErrWOTSNotImplemented)
+	case *iotago.Ed25519Address:
+		return ed25519Outputs(address, includeSpent)
+	default:
+		return nil, errors.WithMessagef(restapi.ErrInvalidParameter, "invalid address: %s, error: unknown address type", addressParam)
+	}
+}
+
+func outputsIDsByEd25519Address(c echo.Context) (*addressOutputsResponse, error) {
+
+	if !deps.Storage.WaitForNodeSynced(waitForNodeSyncedTimeout) {
+		return nil, errors.WithMessage(restapi.ErrServiceUnavailable, "node is not synced")
+	}
+
+	addressParam := strings.ToLower(c.Param(ParameterAddress))
+	includeSpent, _ := strconv.ParseBool(strings.ToLower(c.QueryParam("include-spent")))
+
+	addressBytes, err := hex.DecodeString(addressParam)
+	if err != nil {
+		return nil, errors.WithMessagef(restapi.ErrInvalidParameter, "invalid address: %s, error: %s", addressParam, err)
+	}
+
+	if len(addressBytes) != (iotago.Ed25519AddressBytesLength) {
+		return nil, errors.WithMessagef(restapi.ErrInvalidParameter, "invalid address length: %s", addressParam)
+	}
+
+	var address iotago.Ed25519Address
+	copy(address[:], addressBytes)
+
+	return ed25519Outputs(&address, includeSpent)
 }


### PR DESCRIPTION
# Description

This PR adds support for bech32 encoding in the REST API.
**This is a breaking change!**

For this purpose the endpoint `addresses/:address` was changed to accept bech32 inputs only.
The former route was moved to `/addresses/ed25519/:address` to specify a hex encoded ed25519 address.

## Type of change

- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Checked the results in the browser. Tests have to be adapted after the necessary change in iota.go.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
