### PR TITLE
Updates to the latest iota.go version

### DIFF
--- a/alphanet/config_alphanet.json
+++ b/alphanet/config_alphanet.json
@@ -64,7 +64,6 @@
   "protocol": {
     "networkID": "alphanet1",
     "minPoWScore": 100,
-    "milestoneMerkleTreeHashFunc": "BLAKE2b-512",
     "milestonePublicKeyCount": 2,
     "publicKeyRanges": [
       {

--- a/config_comnet.json
+++ b/config_comnet.json
@@ -63,7 +63,6 @@
   "protocol": {
     "networkID": "comnet1",
     "minPoWScore": 0,
-    "milestoneMerkleTreeHashFunc": "BLAKE2b-512",
     "milestonePublicKeyCount": 2,
     "publicKeyRanges": [
       {

--- a/config_devnet.json
+++ b/config_devnet.json
@@ -63,7 +63,6 @@
   "protocol": {
     "networkID": "devnet1",
     "minPoWScore": 0,
-    "milestoneMerkleTreeHashFunc": "BLAKE2b-512",
     "milestonePublicKeyCount": 2,
     "publicKeyRanges": [
       {

--- a/core/protocfg/core.go
+++ b/core/protocfg/core.go
@@ -22,8 +22,6 @@ const (
 	CfgProtocolNetworkIDName = "protocol.networkID"
 	// the amount of public keys in a milestone
 	CfgProtocolMilestonePublicKeyCount = "protocol.milestonePublicKeyCount"
-	// the hash function to use to calculate milestone merkle tree hash (see RFC-0012)
-	CfgProtocolMilestoneMerkleTreeHashFunc = "protocol.milestoneMerkleTreeHashFunc"
 )
 
 func init() {
@@ -39,7 +37,6 @@ func init() {
 						fs.Float64(CfgProtocolMinPoWScore, 4000, "the minimum PoW score required by the network.")
 						fs.Int(CfgProtocolMilestonePublicKeyCount, 2, "the amount of public keys in a milestone")
 						fs.String(CfgProtocolNetworkIDName, "mainnet1", "the network ID on which this node operates on.")
-						fs.String(CfgProtocolMilestoneMerkleTreeHashFunc, "BLAKE2b-512", "the hash function the coordinator will use to calculate milestone merkle tree hash (see RFC-0012)")
 						return fs
 					}(),
 				},

--- a/core/tangle/core.go
+++ b/core/tangle/core.go
@@ -120,7 +120,6 @@ func configure() {
 	deps.Storage.ConfigureMilestones(
 		keyManager,
 		deps.NodeConfig.Int(protocfg.CfgProtocolMilestonePublicKeyCount),
-		coordinator.MilestoneMerkleTreeHashFuncWithName(deps.NodeConfig.String(protocfg.CfgProtocolMilestoneMerkleTreeHashFunc)),
 	)
 
 	configureEvents()

--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/gorilla/websocket v1.4.2
 	github.com/hashicorp/go-version v1.2.1 // indirect
 	github.com/iotaledger/hive.go v0.0.0-20201124222826-cfc75d969092
-	github.com/iotaledger/iota.go v1.0.0-beta.15.0.20201202132833-d0121354a850
+	github.com/iotaledger/iota.go v1.0.0-beta.15.0.20201204112822-4366bca72dd8
 	github.com/ipfs/go-ds-badger v0.2.6
 	github.com/koron/go-ssdp v0.0.2 // indirect
 	github.com/kr/pretty v0.2.1 // indirect
@@ -61,10 +61,10 @@ require (
 	go.uber.org/atomic v1.7.0
 	go.uber.org/dig v1.10.0
 	go.uber.org/multierr v1.6.0 // indirect
-	golang.org/x/crypto v0.0.0-20201124201722-c8d3bf9c5392
+	golang.org/x/crypto v0.0.0-20201203163018-be400aefbc4c
 	golang.org/x/net v0.0.0-20201202161906-c7110b5ffcbb // indirect
-	golang.org/x/sys v0.0.0-20201201145000-ef89a241ccb3 // indirect
+	golang.org/x/sys v0.0.0-20201202213521-69691e467435 // indirect
 	golang.org/x/tools v0.0.0-20201123232213-4aa1a224cdb5 // indirect
-	google.golang.org/genproto v0.0.0-20201202151023-55d61f90c1ce // indirect
-	google.golang.org/grpc v1.33.2 // indirect
+	google.golang.org/genproto v0.0.0-20201203001206-6486ece9c497 // indirect
+	google.golang.org/grpc v1.34.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -91,6 +91,7 @@ github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XL
 github.com/clbanning/x2j v0.0.0-20191024224557-825249438eec/go.mod h1:jMjuTZXRI4dUb/I5gc9Hdhagfvm9+RyrPryS/auMzxE=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
+github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
 github.com/cockroachdb/datadriven v1.0.0/go.mod h1:5Ib8Meh+jk1RlHIXej6Pzevx/NLlNvQB9pmSBZErGA4=
 github.com/cockroachdb/errors v1.2.4/go.mod h1:rQD95gz6FARkaKkQXUksEje/d9a6wBJoCr5oaCLELYA=
@@ -177,6 +178,7 @@ github.com/envoyproxy/go-control-plane v0.6.9/go.mod h1:SBwIajubJHhxtWwsL9s8ss4s
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
+github.com/envoyproxy/go-control-plane v0.9.7/go.mod h1:cwu0lG7PUMfa9snN8LXBig5ynNVH9qI8YYLbd1fK2po=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/etcd-io/bbolt v1.3.3/go.mod h1:ZF2nL25h33cCyBtcyWeZ2/I3HQOfTP+0PIEvHjkjCrw=
 github.com/fasthttp-contrib/websocket v0.0.0-20160511215533-1f3b11f56072/go.mod h1:duJ4Jxv5lDcvg4QuQr0oowTf7dz4/CR8NtyCooz9HL8=
@@ -354,8 +356,8 @@ github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod
 github.com/iotaledger/hive.go v0.0.0-20201124222826-cfc75d969092 h1:4aMchOmpu0e+JzoYP0Den3x1GepZzEv09fWfhMTlbhc=
 github.com/iotaledger/hive.go v0.0.0-20201124222826-cfc75d969092/go.mod h1:xqn2tIsuGgEU68fgTiR5SH6tD1hxRwznLfvgR0ZEPUs=
 github.com/iotaledger/iota.go v1.0.0-beta.15.0.20200924093814-add1daca64b6/go.mod h1:Rn6v5hLAn8YBaJlRu1ZQdPAgKlshJR1PTeLQaft2778=
-github.com/iotaledger/iota.go v1.0.0-beta.15.0.20201202132833-d0121354a850 h1:kPxVBK+ptMKEoQrDZezLxCoyDuR122isZ3F7yyfr5xs=
-github.com/iotaledger/iota.go v1.0.0-beta.15.0.20201202132833-d0121354a850/go.mod h1:70AnUp7PT4kXRUCA8Ptw4Ddh80RIx6SmOO2eon/TqTQ=
+github.com/iotaledger/iota.go v1.0.0-beta.15.0.20201204112822-4366bca72dd8 h1:J1JtgTtTqmvqtwNbwDynsxvDWHxJJAVvHPaVi8rKUY0=
+github.com/iotaledger/iota.go v1.0.0-beta.15.0.20201204112822-4366bca72dd8/go.mod h1:70AnUp7PT4kXRUCA8Ptw4Ddh80RIx6SmOO2eon/TqTQ=
 github.com/ipfs/go-cid v0.0.1/go.mod h1:GHWU/WuQdMPmIosc4Yn1bcCT7dSeX4lBafM7iqUPQvM=
 github.com/ipfs/go-cid v0.0.2/go.mod h1:GHWU/WuQdMPmIosc4Yn1bcCT7dSeX4lBafM7iqUPQvM=
 github.com/ipfs/go-cid v0.0.3/go.mod h1:GHWU/WuQdMPmIosc4Yn1bcCT7dSeX4lBafM7iqUPQvM=
@@ -1095,8 +1097,8 @@ golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20201016220609-9e8e0b390897/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20201117144127-c1f2f97bffc9 h1:phUcVbl53swtrUN8kQEXFhUxPlIlWyBfKmidCu7P95o=
 golang.org/x/crypto v0.0.0-20201117144127-c1f2f97bffc9/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
-golang.org/x/crypto v0.0.0-20201124201722-c8d3bf9c5392 h1:xYJJ3S178yv++9zXV/hnr29plCAGO9vAFG9dorqaFQc=
-golang.org/x/crypto v0.0.0-20201124201722-c8d3bf9c5392/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
+golang.org/x/crypto v0.0.0-20201203163018-be400aefbc4c h1:9HhBz5L/UjnK9XLtiZhYAdue5BVKep3PMmS2LuPDt8k=
+golang.org/x/crypto v0.0.0-20201203163018-be400aefbc4c/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20200513190911-00229845015e h1:rMqLP+9XLy+LdbCXHjJHAmTfXCr93W7oruWA6Hq1Alc=
@@ -1209,8 +1211,8 @@ golang.org/x/sys v0.0.0-20200826173525-f9321e4c35a6/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200909081042-eff7692f9009/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201015000850-e3ed0017c211/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20201201145000-ef89a241ccb3 h1:kzM6+9dur93BcC2kVlYl34cHU+TYZLanmpSJHVMmL64=
-golang.org/x/sys v0.0.0-20201201145000-ef89a241ccb3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20201202213521-69691e467435 h1:25AvDqqB9PrNqj1FLf2/70I4W0L19qqoaFq3gjNwbKk=
+golang.org/x/sys v0.0.0-20201202213521-69691e467435/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221 h1:/ZHdbVpdR/jk3g30/d4yUL0JU9kksj8+F/bnQUVLGDM=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -1264,8 +1266,8 @@ google.golang.org/genproto v0.0.0-20190425155659-357c62f0e4bb/go.mod h1:VzzqZJRn
 google.golang.org/genproto v0.0.0-20190530194941-fb225487d101/go.mod h1:z3L6/3dTEVtUr6QSP8miRzeRqwQOioJ9I66odjN4I7s=
 google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55/go.mod h1:DMBHOl98Agz4BDEuKkezgsaosCRResVns1a3J2ZsMNc=
 google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013/go.mod h1:NbSheEEYHJ7i3ixzK3sjbqSGDJWnxyFXZblF3eUsNvo=
-google.golang.org/genproto v0.0.0-20201202151023-55d61f90c1ce h1:iS2R2xZpNiQFZrGqWisFYEYzOyKzvz07am2h/QXKqoY=
-google.golang.org/genproto v0.0.0-20201202151023-55d61f90c1ce/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
+google.golang.org/genproto v0.0.0-20201203001206-6486ece9c497 h1:jDYzwXmX9tLnuG4sL85HPmE1ruErXOopALp2i/0AHnI=
+google.golang.org/genproto v0.0.0-20201203001206-6486ece9c497/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/grpc v1.12.0/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=
 google.golang.org/grpc v1.17.0/go.mod h1:6QZJwpn2B+Zp71q/5VxRsJ6NXXVCE5NRUHRo+f3cWCs=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
@@ -1282,8 +1284,8 @@ google.golang.org/grpc v1.28.1/go.mod h1:rpkK4SK4GF4Ach/+MFLZUBavHOvF2JJB5uozKKa
 google.golang.org/grpc v1.29.1/go.mod h1:itym6AZVZYACWQqET3MqgPpjcuV5QH3BxFS3IjizoKk=
 google.golang.org/grpc v1.31.1/go.mod h1:N36X2cJ7JwdamYAgDz+s+rVMFjt3numwzf/HckM8pak=
 google.golang.org/grpc v1.33.1/go.mod h1:fr5YgcSWrqhRRxogOsw7RzIpsmvOZ6IcH4kBYTpR3n0=
-google.golang.org/grpc v1.33.2 h1:EQyQC3sa8M+p6Ulc8yy9SWSS2GVwyRc83gAbG8lrl4o=
-google.golang.org/grpc v1.33.2/go.mod h1:JMHMWHQWaTccqQQlmk3MJZS+GWXOdAesneDmEnv2fbc=
+google.golang.org/grpc v1.34.0 h1:raiipEjMOIC/TO2AvyTxP25XFdLxNIBwzDh3FM3XztI=
+google.golang.org/grpc v1.34.0/go.mod h1:WotjhfgOW/POjDeRt8vscBtXq+2VjORFy659qA51WJ8=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
 google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQJ+fmap5saPgwCLgHXTUD7jkjRqWcaiX5VyM=

--- a/pkg/model/coordinator/coordinator.go
+++ b/pkg/model/coordinator/coordinator.go
@@ -5,8 +5,6 @@ import (
 	"os"
 	"time"
 
-	_ "golang.org/x/crypto/blake2b" // import implementation
-
 	"github.com/pkg/errors"
 
 	"github.com/iotaledger/hive.go/events"

--- a/pkg/model/coordinator/coordinator.go
+++ b/pkg/model/coordinator/coordinator.go
@@ -1,10 +1,8 @@
 package coordinator
 
 import (
-	"crypto"
 	"fmt"
 	"os"
-	"strings"
 	"time"
 
 	_ "golang.org/x/crypto/blake2b" // import implementation
@@ -64,7 +62,6 @@ type Coordinator struct {
 	networkID                uint64
 	powHandler               *pow.Handler
 	sendMesssageFunc         SendMessageFunc
-	milestoneMerkleHashFunc  crypto.Hash
 
 	// internal state
 	state        *State
@@ -74,41 +71,17 @@ type Coordinator struct {
 	Events *Events
 }
 
-// MilestoneMerkleTreeHashFuncWithName maps the passed name to one of the supported crypto.Hash hashing functions.
-// Also verifies that the available function is available or else panics.
-func MilestoneMerkleTreeHashFuncWithName(name string) crypto.Hash {
-	var hashFunc crypto.Hash
-	switch strings.ToLower(name) {
-	case strings.ToLower(crypto.BLAKE2b_512.String()):
-		hashFunc = crypto.BLAKE2b_512
-	case strings.ToLower(crypto.BLAKE2b_384.String()):
-		hashFunc = crypto.BLAKE2b_384
-	case strings.ToLower(crypto.BLAKE2b_256.String()):
-		hashFunc = crypto.BLAKE2b_256
-	case strings.ToLower(crypto.BLAKE2s_256.String()):
-		hashFunc = crypto.BLAKE2s_256
-	default:
-		panic(fmt.Sprintf("Unsupported merkle tree hash func '%s'", name))
-	}
-
-	if !hashFunc.Available() {
-		panic(fmt.Sprintf("Merkle tree hash func '%s' not available. Please check the package imports", name))
-	}
-	return hashFunc
-}
-
 // New creates a new coordinator instance.
-func New(storage *storage.Storage, networkID uint64, signerProvider MilestoneSignerProvider, stateFilePath string, milestoneIntervalSec int, powHandler *pow.Handler, sendMessageFunc SendMessageFunc, milestoneMerkleHashFunc crypto.Hash) (*Coordinator, error) {
+func New(storage *storage.Storage, networkID uint64, signerProvider MilestoneSignerProvider, stateFilePath string, milestoneIntervalSec int, powHandler *pow.Handler, sendMessageFunc SendMessageFunc) (*Coordinator, error) {
 
 	result := &Coordinator{
-		storage:                 storage,
-		networkID:               networkID,
-		signerProvider:          signerProvider,
-		stateFilePath:           stateFilePath,
-		milestoneIntervalSec:    milestoneIntervalSec,
-		powHandler:              powHandler,
-		sendMesssageFunc:        sendMessageFunc,
-		milestoneMerkleHashFunc: milestoneMerkleHashFunc,
+		storage:              storage,
+		networkID:            networkID,
+		signerProvider:       signerProvider,
+		stateFilePath:        stateFilePath,
+		milestoneIntervalSec: milestoneIntervalSec,
+		powHandler:           powHandler,
+		sendMesssageFunc:     sendMessageFunc,
 		Events: &Events{
 			IssuedCheckpointMessage: events.NewEvent(CheckpointCaller),
 			IssuedMilestone:         events.NewEvent(MilestoneCaller),
@@ -211,7 +184,7 @@ func (coo *Coordinator) createAndSendMilestone(parent1MessageID *hornet.MessageI
 	}()
 
 	// compute merkle tree root
-	mutations, err := whiteflag.ComputeWhiteFlagMutations(coo.storage, newMilestoneIndex, cachedMsgMetas, cachedMessages, coo.milestoneMerkleHashFunc, parent1MessageID, parent2MessageID)
+	mutations, err := whiteflag.ComputeWhiteFlagMutations(coo.storage, newMilestoneIndex, cachedMsgMetas, cachedMessages, parent1MessageID, parent2MessageID)
 	if err != nil {
 		return err
 	}

--- a/pkg/model/coordinator/milestones.go
+++ b/pkg/model/coordinator/milestones.go
@@ -28,7 +28,7 @@ func createCheckpoint(networkID uint64, parent1MessageID *hornet.MessageID, pare
 }
 
 // createMilestone creates a signed milestone message.
-func createMilestone(index milestone.Index, networkID uint64, parent1MessageID *hornet.MessageID, parent2MessageID *hornet.MessageID, signerProvider MilestoneSignerProvider, whiteFlagMerkleRootTreeHash [64]byte, powHandler *pow.Handler) (*storage.Message, error) {
+func createMilestone(index milestone.Index, networkID uint64, parent1MessageID *hornet.MessageID, parent2MessageID *hornet.MessageID, signerProvider MilestoneSignerProvider, whiteFlagMerkleRootTreeHash [iotago.MilestoneInclusionMerkleProofLength]byte, powHandler *pow.Handler) (*storage.Message, error) {
 
 	milestoneIndexSigner := signerProvider.MilestoneIndexSigner(index)
 	pubKeys := milestoneIndexSigner.PublicKeys()

--- a/pkg/model/storage/milestones.go
+++ b/pkg/model/storage/milestones.go
@@ -2,7 +2,6 @@ package storage
 
 import (
 	"context"
-	"crypto"
 	"crypto/ed25519"
 	"fmt"
 	"time"
@@ -31,18 +30,13 @@ func MilestoneCaller(handler interface{}, params ...interface{}) {
 	handler.(func(cachedMs *CachedMilestone))(params[0].(*CachedMilestone).Retain())
 }
 
-func (s *Storage) ConfigureMilestones(cooKeyManager *keymanager.KeyManager, cooMilestonePublicKeyCount int, cooMilestoneMerkleHashFunc crypto.Hash) {
+func (s *Storage) ConfigureMilestones(cooKeyManager *keymanager.KeyManager, cooMilestonePublicKeyCount int) {
 	s.keyManager = cooKeyManager
 	s.milestonePublicKeyCount = cooMilestonePublicKeyCount
-	s.coordinatorMilestoneMerkleHashFunc = cooMilestoneMerkleHashFunc
 }
 
 func (s *Storage) KeyManager() *keymanager.KeyManager {
 	return s.keyManager
-}
-
-func (s *Storage) GetMilestoneMerkleHashFunc() crypto.Hash {
-	return s.coordinatorMilestoneMerkleHashFunc
 }
 
 func (s *Storage) ResetMilestoneIndexes() {

--- a/pkg/model/storage/storage.go
+++ b/pkg/model/storage/storage.go
@@ -1,7 +1,6 @@
 package storage
 
 import (
-	"crypto"
 	"os"
 	"path/filepath"
 	"sync"
@@ -69,7 +68,6 @@ type Storage struct {
 	// milestones
 	keyManager                         *keymanager.KeyManager
 	milestonePublicKeyCount            int
-	coordinatorMilestoneMerkleHashFunc crypto.Hash
 
 	// utxo
 	utxoManager *utxo.Manager

--- a/pkg/testsuite/coordinator.go
+++ b/pkg/testsuite/coordinator.go
@@ -21,7 +21,6 @@ const (
 	cooPublicKey  = "ed3c3f1a319ff4e909cf2771d79fece0ac9bd9fd2ee49ea6c0885c9cb3b1248c"
 
 	mwm            = 1
-	merkleHashFunc = crypto.BLAKE2b_512
 )
 
 // configureCoordinator configures a new coordinator with clean state for the tests.
@@ -51,7 +50,7 @@ func (te *TestEnvironment) configureCoordinator() {
 
 	}
 
-	te.coo, err = coordinator.New(cooPrivKey, fmt.Sprintf("%s/coordinator.state", te.tempDir), 10, te.powHandler, storeMessageFunc, merkleHashFunc)
+	te.coo, err = coordinator.New(cooPrivKey, fmt.Sprintf("%s/coordinator.state", te.tempDir), 10, te.powHandler, storeMessageFunc)
 	require.NoError(te.testState, err)
 	require.NotNil(te.testState, te.coo)
 

--- a/pkg/whiteflag/confirmation.go
+++ b/pkg/whiteflag/confirmation.go
@@ -66,7 +66,7 @@ func ConfirmMilestone(s *storage.Storage, serverMetrics *metrics.ServerMetrics, 
 
 	ts := time.Now()
 
-	mutations, err := ComputeWhiteFlagMutations(s, milestoneIndex, cachedMessageMetas, cachedMessages, s.GetMilestoneMerkleHashFunc(), message.GetParent1MessageID(), message.GetParent2MessageID())
+	mutations, err := ComputeWhiteFlagMutations(s, milestoneIndex, cachedMessageMetas, cachedMessages, message.GetParent1MessageID(), message.GetParent2MessageID())
 	if err != nil {
 		// According to the RFC we should panic if we encounter any invalid messages during confirmation
 		return nil, fmt.Errorf("confirmMilestone: whiteflag.ComputeConfirmation failed with Error: %v", err)

--- a/pkg/whiteflag/white_flag.go
+++ b/pkg/whiteflag/white_flag.go
@@ -8,6 +8,8 @@ import (
 	iotago "github.com/iotaledger/iota.go"
 	"github.com/pkg/errors"
 
+	_ "golang.org/x/crypto/blake2b" // import implementation
+
 	"github.com/gohornet/hornet/pkg/common"
 	"github.com/gohornet/hornet/pkg/dag"
 	"github.com/gohornet/hornet/pkg/model/hornet"

--- a/plugins/coordinator/plugin.go
+++ b/plugins/coordinator/plugin.go
@@ -159,7 +159,6 @@ func initCoordinator(bootstrap bool, startIndex uint32, powHandler *powpackage.H
 		deps.NodeConfig.Int(CfgCoordinatorIntervalSeconds),
 		powHandler,
 		sendMessage,
-		coordinator.MilestoneMerkleTreeHashFuncWithName(deps.NodeConfig.String(protocfg.CfgProtocolMilestoneMerkleTreeHashFunc)),
 	)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
* The new iota.go version has:
  * an optimized Curl (done by @Wollac @c-mnd)
  * adjusted milestone inclusion merkle root of 32 bytes
  * fixed JSON representation of the milestone payload
* Defines the milestone inclusion merkle root hash function to be Blake2b-256 and is no longer configurable.

Obviously this PR is breaking.