### PR TITLE
Add Bech32 support to MQTT

### DIFF
--- a/plugins/mqtt/topics.go
+++ b/plugins/mqtt/topics.go
@@ -12,5 +12,6 @@ const (
 
 	topicOutputs = "outputs/{outputId}"
 
-	topicAddressesOutput = "addresses/{address}/outputs"
+	topicAddressesOutput        = "addresses/{address}/outputs"
+	topicAddressesEd25519Output = "addresses/ed25519/{address}/outputs"
 )


### PR DESCRIPTION
Changed MQTT `addresses/{address}/outputs` topic to use bech32 format and added separate `addresses/ed25519/{address}/outputs` topic

Since we don't know which bech32-prefix is in use, we check if there are subscribers on both mainnet and testnet prefixes.