### PR TITLE
Fixes SEPs creation and probably other unknown bugs

### DIFF
--- a/core/gossip/core.go
+++ b/core/gossip/core.go
@@ -246,7 +246,7 @@ func run() {
 	}, shutdown.PriorityMessageProcessor)
 
 	_ = CorePlugin.Daemon().BackgroundWorker("HeartbeatBroadcaster", func(shutdownSignal <-chan struct{}) {
-		timeutil.Ticker(checkHeartbeats, checkHeartbeatsInterval, shutdownSignal)
+		timeutil.NewTicker(checkHeartbeats, checkHeartbeatsInterval, shutdownSignal)
 	}, shutdown.PriorityHeartbeats)
 }
 

--- a/core/tangle/core.go
+++ b/core/tangle/core.go
@@ -167,7 +167,7 @@ func run() {
 
 	// create a background worker that prints a status message every second
 	CorePlugin.Daemon().BackgroundWorker("Tangle status reporter", func(shutdownSignal <-chan struct{}) {
-		timeutil.Ticker(deps.Tangle.PrintStatus, 1*time.Second, shutdownSignal)
+		timeutil.NewTicker(deps.Tangle.PrintStatus, 1*time.Second, shutdownSignal)
 	}, shutdown.PriorityStatusReport)
 
 }

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d // indirect
 	github.com/blang/vfs v1.0.0
 	github.com/btcsuite/btcd v0.21.0-beta // indirect
-	github.com/cockroachdb/pebble v0.0.0-20201123184641-2da62788eede
+	github.com/cockroachdb/pebble v0.0.0-20201130172119-f19faf8529d6
 	github.com/davidlazar/go-crypto v0.0.0-20200604182044-b73af7476f6c // indirect
 	github.com/dchest/blake2b v1.0.0
 	github.com/docker/distribution v2.7.1+incompatible // indirect
@@ -26,7 +26,7 @@ require (
 	github.com/google/gopacket v1.1.19 // indirect
 	github.com/gorilla/websocket v1.4.2
 	github.com/hashicorp/go-version v1.2.1 // indirect
-	github.com/iotaledger/hive.go v0.0.0-20201124222826-cfc75d969092
+	github.com/iotaledger/hive.go v0.0.0-20210105145855-ce2c8231a283
 	github.com/iotaledger/iota.go v1.0.0-beta.15.0.20201222215724-43ffdd479925
 	github.com/ipfs/go-ds-badger v0.2.6
 	github.com/koron/go-ssdp v0.0.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -83,7 +83,6 @@ github.com/btcsuite/winsvc v1.0.0/go.mod h1:jsenWakMcC0zFBFurPLEAyrnc/teJEM1O46f
 github.com/casbin/casbin/v2 v2.1.2/go.mod h1:YcPU1XXisHhLzuxH9coDNf2FbKpjGlbCg3n9yuLkIJQ=
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/certifi/gocertifi v0.0.0-20200211180108-c7c1fbc02894/go.mod h1:sGbDF6GwGcLpkNXPUTkMRoywsNa/ol15pxFe6ERfguA=
 github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.1.1 h1:6MnRN8NT7+YBpUIWxHtefFZOKTAPgGjpQSxqLNn0+qY=
@@ -94,16 +93,13 @@ github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGX
 github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
 github.com/cockroachdb/datadriven v1.0.0/go.mod h1:5Ib8Meh+jk1RlHIXej6Pzevx/NLlNvQB9pmSBZErGA4=
-github.com/cockroachdb/errors v1.2.4/go.mod h1:rQD95gz6FARkaKkQXUksEje/d9a6wBJoCr5oaCLELYA=
 github.com/cockroachdb/errors v1.6.1/go.mod h1:tm6FTP5G81vwJ5lC0SizQo374JNCOPrHyXGitRJoDqM=
 github.com/cockroachdb/errors v1.8.1 h1:A5+txlVZfOqFBDa4mGz2bUWSp0aHElvHX2bKkdbQu+Y=
 github.com/cockroachdb/errors v1.8.1/go.mod h1:qGwQn6JmZ+oMjuLwjWzUNqblqk0xl4CVV3SQbGwK7Ac=
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f h1:o/kfcElHqOiXqcou5a3rIlMc7oJbMQkeLk0VQJ7zgqY=
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f/go.mod h1:i/u985jwjWRlyHXQbwatDASoW0RMlZ/3i9yJHE2xLkI=
-github.com/cockroachdb/pebble v0.0.0-20201023120638-f1224da22976/go.mod h1:BbtTitvfmE0eZNcncJgJw5BlQhskTzgZgoISnY+8s6k=
-github.com/cockroachdb/pebble v0.0.0-20201123184641-2da62788eede h1:bl7U+s/hdOLI3w3/igBLTYmCe/KZ2+CJPmrImiIdELU=
-github.com/cockroachdb/pebble v0.0.0-20201123184641-2da62788eede/go.mod h1:c3G8ud5zF3+nYHCWmVmtsA8eEtjrDSa6qeLtcRZyevE=
-github.com/cockroachdb/redact v0.0.0-20200622112456-cd282804bbd3/go.mod h1:BVNblN9mBWFyMyqK1k3AAiSxhvhfK2oOZZ2lK+dpvRg=
+github.com/cockroachdb/pebble v0.0.0-20201130172119-f19faf8529d6 h1:nDRfCYBBgSZ59ap7N5jxn0tqJZ1q4Q8Bs13a2ky1q3Y=
+github.com/cockroachdb/pebble v0.0.0-20201130172119-f19faf8529d6/go.mod h1:c3G8ud5zF3+nYHCWmVmtsA8eEtjrDSa6qeLtcRZyevE=
 github.com/cockroachdb/redact v1.0.8 h1:8QG/764wK+vmEYoOlfobpe12EQcS81ukx/a4hdVMxNw=
 github.com/cockroachdb/redact v1.0.8/go.mod h1:BVNblN9mBWFyMyqK1k3AAiSxhvhfK2oOZZ2lK+dpvRg=
 github.com/cockroachdb/sentry-go v0.6.1-cockroachdb.2 h1:IKgmqgMQlVJIZj19CdocBeSfSaiCbEBZGKODaixqtHM=
@@ -196,7 +192,6 @@ github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMo
 github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/gavv/httpexpect v2.0.0+incompatible/go.mod h1:x+9tiU1YnrOvnB725RkpoLv1M62hOWzwo5OXotisrKc=
-github.com/getsentry/raven-go v0.2.0/go.mod h1:KungGk8q33+aIAZUIVWZDr2OfAEBsO49PX4NzFV5kcQ=
 github.com/ghemawat/stream v0.0.0-20171120220530-696b145b53b9/go.mod h1:106OIgooyS7OzLDOpUGgm9fA3bQENb/cFSyyBmMoJDs=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gin-contrib/sse v0.0.0-20190301062529-5545eab6dad3/go.mod h1:VJ0WA2NBN22VlZ2dKZQPAPnyWw5XTlK1KymzLKsr59s=
@@ -353,8 +348,9 @@ github.com/hydrogen18/memlistener v0.0.0-20141126152155-54553eb933fb/go.mod h1:q
 github.com/imkira/go-interpol v1.1.0/go.mod h1:z0h2/2T3XF8kyEPpRgJ3kmNv+C43p+I/CoI+jC3w2iA=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
-github.com/iotaledger/hive.go v0.0.0-20201124222826-cfc75d969092 h1:4aMchOmpu0e+JzoYP0Den3x1GepZzEv09fWfhMTlbhc=
-github.com/iotaledger/hive.go v0.0.0-20201124222826-cfc75d969092/go.mod h1:xqn2tIsuGgEU68fgTiR5SH6tD1hxRwznLfvgR0ZEPUs=
+github.com/iotaledger/hive.go v0.0.0-20210105145855-ce2c8231a283 h1:p+pORoK/Btoohoevz6Kl1xdV7iqTEridJ6hQsuGr2eo=
+github.com/iotaledger/hive.go v0.0.0-20210105145855-ce2c8231a283/go.mod h1:dFt9vuTF3FdDPx7ve+uSDiNrX2PW2eV8sq7N06jeaFw=
+github.com/iotaledger/iota.go v1.0.0-beta.15.0.20200924093814-add1daca64b6/go.mod h1:Rn6v5hLAn8YBaJlRu1ZQdPAgKlshJR1PTeLQaft2778=
 github.com/iotaledger/iota.go v1.0.0-beta.15.0.20201222215724-43ffdd479925 h1:4kwpHfSIa3eGvE85WJ/eyz8ZcJEsZkyTYORU2m76zTk=
 github.com/iotaledger/iota.go v1.0.0-beta.15.0.20201222215724-43ffdd479925/go.mod h1:70AnUp7PT4kXRUCA8Ptw4Ddh80RIx6SmOO2eon/TqTQ=
 github.com/ipfs/go-cid v0.0.1/go.mod h1:GHWU/WuQdMPmIosc4Yn1bcCT7dSeX4lBafM7iqUPQvM=
@@ -1094,7 +1090,6 @@ golang.org/x/crypto v0.0.0-20200602180216-279210d13fed/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20201016220609-9e8e0b390897/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
-golang.org/x/crypto v0.0.0-20201117144127-c1f2f97bffc9 h1:phUcVbl53swtrUN8kQEXFhUxPlIlWyBfKmidCu7P95o=
 golang.org/x/crypto v0.0.0-20201117144127-c1f2f97bffc9/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
 golang.org/x/crypto v0.0.0-20201203163018-be400aefbc4c h1:9HhBz5L/UjnK9XLtiZhYAdue5BVKep3PMmS2LuPDt8k=
 golang.org/x/crypto v0.0.0-20201203163018-be400aefbc4c/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=

--- a/pkg/database/pebble.go
+++ b/pkg/database/pebble.go
@@ -24,7 +24,6 @@ func NewPebbleDB(directory string, verbose bool) *pebbleDB.DB {
 		MemTableSize:                64 << 20,
 		MemTableStopWritesThreshold: 4,
 	}
-	opts.Experimental.L0SublevelCompactions = true
 
 	for i := 0; i < len(opts.Levels); i++ {
 		l := &opts.Levels[i]
@@ -38,7 +37,6 @@ func NewPebbleDB(directory string, verbose bool) *pebbleDB.DB {
 		l.EnsureDefaults()
 	}
 	opts.Levels[6].FilterPolicy = nil
-	opts.Experimental.FlushSplitBytes = opts.Levels[0].TargetFileSize
 
 	opts.EnsureDefaults()
 

--- a/pkg/p2p/discovery.go
+++ b/pkg/p2p/discovery.go
@@ -168,7 +168,7 @@ func (ds *DiscoveryService) Start(shutdownSignal <-chan struct{}) {
 	if err := ds.dht.Bootstrap(context.Background()); err != nil {
 		panic(err)
 	}
-	timeutil.Ticker(ds.discover, ds.opts.AdvertiseInterval, shutdownSignal)
+	timeutil.NewTicker(ds.discover, ds.opts.AdvertiseInterval, shutdownSignal)
 	ds.dhtCtxCancel()
 	ds.host.Network().StopNotify((*dsNotifiee)(ds))
 }

--- a/pkg/tangle/tangle_processor.go
+++ b/pkg/tangle/tangle_processor.go
@@ -66,7 +66,7 @@ func (t *Tangle) RunTangleProcessor() {
 
 	// create a background worker that "measures" the MPS value every second
 	t.daemon.BackgroundWorker("Metrics MPS Updater", func(shutdownSignal <-chan struct{}) {
-		timeutil.Ticker(t.measureMPS, 1*time.Second, shutdownSignal)
+		timeutil.NewTicker(t.measureMPS, 1*time.Second, shutdownSignal)
 	}, shutdown.PriorityMetricsUpdater)
 
 	t.daemon.BackgroundWorker("TangleProcessor[UpdateMetrics]", func(shutdownSignal <-chan struct{}) {

--- a/plugins/coordinator/plugin.go
+++ b/plugins/coordinator/plugin.go
@@ -185,7 +185,7 @@ func run() {
 	// create a background worker that signals to issue new milestones
 	Plugin.Daemon().BackgroundWorker("Coordinator[MilestoneTicker]", func(shutdownSignal <-chan struct{}) {
 
-		timeutil.Ticker(func() {
+		timeutil.NewTicker(func() {
 			// issue next milestone
 			select {
 			case nextMilestoneSignal <- struct{}{}:

--- a/plugins/dashboard/dbsize.go
+++ b/plugins/dashboard/dbsize.go
@@ -67,7 +67,7 @@ func runDatabaseSizeCollector() {
 		database.Events.DatabaseCleanup.Attach(onDatabaseCleanup)
 		defer database.Events.DatabaseCleanup.Detach(onDatabaseCleanup)
 
-		timeutil.Ticker(func() {
+		timeutil.NewTicker(func() {
 			dbSizeMetric := currentDatabaseSize()
 			hub.BroadcastMsg(&Msg{Type: MsgTypeDatabaseSizeMetric, Data: []*DBSizeMetric{dbSizeMetric}})
 		}, 1*time.Minute, shutdownSignal)

--- a/plugins/spammer/plugin.go
+++ b/plugins/spammer/plugin.go
@@ -154,7 +154,7 @@ func run() {
 
 	// create a background worker that "measures" the spammer averages values every second
 	Plugin.Daemon().BackgroundWorker("Spammer Metrics Updater", func(shutdownSignal <-chan struct{}) {
-		timeutil.Ticker(measureSpammerMetrics, 1*time.Second, shutdownSignal)
+		timeutil.NewTicker(measureSpammerMetrics, 1*time.Second, shutdownSignal)
 	}, shutdown.PrioritySpammer)
 
 	// automatically start the spammer on node startup if the flag is set
@@ -236,7 +236,7 @@ func startSpammerWorkers(mpsRateLimit float64, cpuMaxUsage float64, spammerWorke
 			done := make(chan struct{})
 			currentProcessID := processID.Load()
 
-			timeutil.Ticker(func() {
+			timeutil.NewTicker(func() {
 
 				if currentProcessID != processID.Load() {
 					close(rateLimitAbortSignal)

--- a/plugins/versioncheck/plugin.go
+++ b/plugins/versioncheck/plugin.go
@@ -56,7 +56,7 @@ func configure() {
 func run() {
 	// create a background worker that checks for latest version every hour
 	_ = Plugin.Node.Daemon().BackgroundWorker("Version update checker", func(shutdownSignal <-chan struct{}) {
-		timeutil.Ticker(checkLatestVersion, 1*time.Hour, shutdownSignal)
+		timeutil.NewTicker(checkLatestVersion, 1*time.Hour, shutdownSignal)
 	}, shutdown.PriorityUpdateCheck)
 }
 


### PR DESCRIPTION
A bug in the upper bound prefix creation for the PebbleDB KVStore caused prefix iterations to not happen if a prefix key ended in byte value 255, therefore for certain messages, their children messages couldn't be traversed and hence not be identified as SEPs causing snapshots to get created with not all needed SEPs.

fixes #800 