### PR TITLE
Track conflict reason in metadata

### DIFF
--- a/pkg/whiteflag/confirmation.go
+++ b/pkg/whiteflag/confirmation.go
@@ -169,9 +169,9 @@ func ConfirmMilestone(s *storage.Storage, serverMetrics *metrics.ServerMetrics, 
 	}
 
 	// confirm all conflicting messages
-	for _, messageID := range mutations.MessagesExcludedWithConflictingTransactions {
-		if err := forMessageMetadataWithMessageID(messageID, func(meta *storage.CachedMetadata) {
-			meta.GetMetadata().SetConflictingTx(true)
+	for _, conflictedMessage := range mutations.MessagesExcludedWithConflictingTransactions {
+		if err := forMessageMetadataWithMessageID(conflictedMessage.MessageID, func(meta *storage.CachedMetadata) {
+			meta.GetMetadata().SetConflictingTx(conflictedMessage.Conflict)
 			if !meta.GetMetadata().IsReferenced() {
 				meta.GetMetadata().SetReferenced(true, milestoneIndex)
 				meta.GetMetadata().SetConeRootIndexes(milestoneIndex, milestoneIndex, milestoneIndex)

--- a/plugins/dashboard/visualizer.go
+++ b/plugins/dashboard/visualizer.go
@@ -128,7 +128,7 @@ func runVisualizer() {
 
 		var excludedIDs []string
 		for _, messageID := range confirmation.Mutations.MessagesExcludedWithConflictingTransactions {
-			excludedIDs = append(excludedIDs, messageID.Hex()[:VisualizerIdLength])
+			excludedIDs = append(excludedIDs, messageID.MessageID.Hex()[:VisualizerIdLength])
 		}
 
 		hub.BroadcastMsg(

--- a/plugins/mqtt/types.go
+++ b/plugins/mqtt/types.go
@@ -3,6 +3,7 @@ package mqtt
 import (
 	"encoding/json"
 
+	"github.com/gohornet/hornet/pkg/model/storage"
 	"github.com/gohornet/hornet/pkg/model/milestone"
 )
 
@@ -28,6 +29,8 @@ type messageMetadataPayload struct {
 	ReferencedByMilestoneIndex *milestone.Index `json:"referencedByMilestoneIndex,omitempty"`
 	// The ledger inclusion state of the transaction payload.
 	LedgerInclusionState *string `json:"ledgerInclusionState,omitempty"`
+	// The reason why this message is marked as conflicting.
+	ConflictReason *storage.Conflict `json:"conflictReason,omitempty"`
 	// Whether the message should be promoted.
 	ShouldPromote *bool `json:"shouldPromote,omitempty"`
 	// Whether the message should be reattached.

--- a/plugins/mqtt/util.go
+++ b/plugins/mqtt/util.go
@@ -98,8 +98,11 @@ func publishMessageMetadata(cachedMetadata *storage.CachedMetadata) {
 		if referenced {
 			inclusionState := "noTransaction"
 
-			if metadata.IsConflictingTx() {
+			conflict := metadata.GetConflict()
+
+			if conflict != storage.ConflictNone {
 				inclusionState = "conflicting"
+				messageMetadataResponse.ConflictReason = &conflict
 			} else if metadata.IsIncludedTxInLedger() {
 				inclusionState = "included"
 			}

--- a/plugins/restapi/v1/messages.go
+++ b/plugins/restapi/v1/messages.go
@@ -65,8 +65,11 @@ func messageMetadataByID(c echo.Context) (*messageMetadataResponse, error) {
 	if referenced {
 		inclusionState := "noTransaction"
 
-		if metadata.IsConflictingTx() {
+		conflict := metadata.GetConflict()
+
+		if conflict != storage.ConflictNone {
 			inclusionState = "conflicting"
+			messageMetadataResponse.ConflictReason = &conflict
 		} else if metadata.IsIncludedTxInLedger() {
 			inclusionState = "included"
 		}

--- a/plugins/restapi/v1/types.go
+++ b/plugins/restapi/v1/types.go
@@ -3,6 +3,7 @@ package v1
 import (
 	"encoding/json"
 
+	"github.com/gohornet/hornet/pkg/model/storage"
 	"github.com/gohornet/hornet/pkg/model/milestone"
 )
 
@@ -50,6 +51,8 @@ type messageMetadataResponse struct {
 	ReferencedByMilestoneIndex *milestone.Index `json:"referencedByMilestoneIndex,omitempty"`
 	// The ledger inclusion state of the transaction payload.
 	LedgerInclusionState *string `json:"ledgerInclusionState,omitempty"`
+	// The reason why this message is marked as conflicting.
+	ConflictReason *storage.Conflict `json:"conflictReason,omitempty"`
 	// Whether the message should be promoted.
 	ShouldPromote *bool `json:"shouldPromote,omitempty"`
 	// Whether the message should be reattached.


### PR DESCRIPTION
- Added a byte to the message metadata tracking which conflict happened during white-flag validation. The JSON representation is an int.
