### PR TITLE
docker: use distroless image with glibc as we compile with CGO

### DIFF
--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -29,7 +29,7 @@ RUN CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build \
 ############################
 # using static nonroot image
 # user:group is nonroot:nonroot, uid:gid = 65532:65532
-FROM gcr.io/distroless/static@sha256:23aa732bba4c8618c0d97c26a72a32997363d591807b0d4c31b0bbc8a774bddf
+FROM gcr.io/distroless/base@sha256:5e0cc69445ed1d8a17198250a7249d56dd4b6966bb6b2118e60ae9194c310647
 
 EXPOSE 8081/tcp
 EXPOSE 14265/tcp

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -27,8 +27,8 @@ RUN CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build \
 ############################
 # Image
 ############################
-# using static nonroot image
-# user:group is nonroot:nonroot, uid:gid = 65532:65532
+# https://github.com/GoogleContainerTools/distroless/blob/master/base/README.md
+# using distroless base image, contains: glibc, libssl and openssl
 FROM gcr.io/distroless/base@sha256:5e0cc69445ed1d8a17198250a7249d56dd4b6966bb6b2118e60ae9194c310647
 
 EXPOSE 8081/tcp


### PR DESCRIPTION
# Description

Docker.dev compiles a dinamically-linked go binary using CGO, to fully support `net` functions a glibc needs to be present on the runtime system.

Fixes hostname resolution problems (glibc dependant) with custom docker networks.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Ran in latest Docker Engine (v20)

