### PR TITLE
Avoid SEGFAULTs by not trying linking statically

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -12,8 +12,6 @@ builds:
   # Linux AMD64
   - id: hornet-linux-amd64
     binary: hornet
-    env:
-      - CGO_ENABLED=1
     ldflags:
       - -s -w -X github.com/gohornet/hornet/core/cli.AppVersion={{.Version}}
     flags:

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -20,9 +20,9 @@ RUN go mod verify
 COPY . .
 
 # Build the binary
-RUN CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build \
-      -ldflags='-w -s -extldflags "-static"' -a \
-       -o /go/bin/hornet
+RUN GOOS=linux GOARCH=amd64 go build \
+      -ldflags='-w -s' -a \
+      -o /go/bin/hornet
 
 ############################
 # Image


### PR DESCRIPTION
# Description

Using CGO in combination with the `net` packages causes a dynamic link to glibc. Build options although instruct the linker to attempt a `-static` executable. This causes runtime issues leading into SIGSEGV.
In addition let's remove the explicit `CGO_ENABLED` flag; it is enabled by default and better let Go have the final say on what to do with that, it is probably more savvy then us when it comes to compile optimizations.
Only amd64 builds have been changed, as I don't have the time to test the arm builds. I think the `-static` flag should be removed from those builds too.

Fixes runtime SIGSEGV.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Ran new binary with old "weird" static binary side by side, one crashes consistently, the other does not.
