### PR TITLE
Adds heartbeat to gossip information

### DIFF
--- a/pkg/protocol/gossip/protocol.go
+++ b/pkg/protocol/gossip/protocol.go
@@ -199,6 +199,14 @@ func (p *Protocol) IsSynced(lsi milestone.Index) bool {
 	return true
 }
 
+// Info returns
+func (p *Protocol) Info() *Info {
+	return &Info{
+		Heartbeat: p.LatestHeartbeat,
+		Metrics:   p.Metrics.Snapshot(),
+	}
+}
+
 // Metrics defines a set of metrics regarding a gossip protocol instance.
 type Metrics struct {
 	// The number of received messages which are new.
@@ -257,4 +265,10 @@ type MetricsSnapshot struct {
 	SentMilestoneReq     uint32 `json:"sentMilestoneRequests"`
 	SentHeartbeats       uint32 `json:"sentHeartbeats"`
 	DroppedPackets       uint32 `json:"droppedPackets"`
+}
+
+// Info represents information about an ongoing gossip protocol.
+type Info struct {
+	Heartbeat *Heartbeat      `json:"heartbeat"`
+	Metrics   MetricsSnapshot `json:"metrics"`
 }

--- a/pkg/protocol/gossip/sting.go
+++ b/pkg/protocol/gossip/sting.go
@@ -164,11 +164,11 @@ func ExtractRequestedMilestoneIndex(source []byte) (milestone.Index, error) {
 // Heartbeat contains information about a nodes current solid and pruned milestone index
 // and its connected and synced neighbors count.
 type Heartbeat struct {
-	SolidMilestoneIndex  milestone.Index `json:"solid_milestone_index"`
-	PrunedMilestoneIndex milestone.Index `json:"pruned_milestone_index"`
-	LatestMilestoneIndex milestone.Index `json:"latest_milestone_index"`
-	ConnectedNeighbors   int             `json:"connected_neighbors"`
-	SyncedNeighbors      int             `json:"synced_neighbors"`
+	SolidMilestoneIndex  milestone.Index `json:"solidMilestoneIndex"`
+	PrunedMilestoneIndex milestone.Index `json:"prunedMilestoneIndex"`
+	LatestMilestoneIndex milestone.Index `json:"latestMilestoneIndex"`
+	ConnectedNeighbors   int             `json:"connectedNeighbors"`
+	SyncedNeighbors      int             `json:"syncedNeighbors"`
 }
 
 /// ParseHeartbeat parses the given message into a heartbeat.

--- a/plugins/restapi/v1/peers.go
+++ b/plugins/restapi/v1/peers.go
@@ -27,9 +27,9 @@ func WrapInfoSnapshot(info *p2ppkg.PeerInfoSnapshot) *PeerResponse {
 	}
 
 	gossipProto := deps.Service.Protocol(info.Peer.ID)
-	var gossipMetrics gossip.MetricsSnapshot
+	var gossipInfo *gossip.Info
 	if gossipProto != nil {
-		gossipMetrics = gossipProto.Metrics.Snapshot()
+		gossipInfo = gossipProto.Info()
 	}
 
 	return &PeerResponse{
@@ -38,7 +38,7 @@ func WrapInfoSnapshot(info *p2ppkg.PeerInfoSnapshot) *PeerResponse {
 		Alias:          alias,
 		Relation:       info.Relation,
 		Connected:      info.Connected,
-		GossipMetrics:  gossipMetrics,
+		Gossip:         gossipInfo,
 	}
 }
 

--- a/plugins/restapi/v1/types.go
+++ b/plugins/restapi/v1/types.go
@@ -253,8 +253,8 @@ type PeerResponse struct {
 	Relation string `json:"relation"`
 	// Whether the peer is connected.
 	Connected bool `json:"connected"`
-	// The gossip metrics of the peer.
-	GossipMetrics gossip.MetricsSnapshot `json:"gossipMetrics,omitempty"`
+	// The gossip protocol information of the peer.
+	Gossip *gossip.Info `json:"gossip,omitempty"`
 }
 
 // pruneDatabaseResponse defines the response of a prune database REST API call.


### PR DESCRIPTION
Lets the gossip information reside within `gossip.heartbeat` and `gossip.metrics`.