### PR TITLE
Fixed output type in snapshot files

### DIFF
--- a/pkg/model/utxo/spent.go
+++ b/pkg/model/utxo/spent.go
@@ -1,6 +1,8 @@
 package utxo
 
 import (
+	"fmt"
+
 	"github.com/iotaledger/hive.go/byteutils"
 	"github.com/iotaledger/hive.go/kvstore"
 	"github.com/iotaledger/hive.go/marshalutil"
@@ -174,6 +176,8 @@ func (u *Manager) ForEachSpentOutput(consumer SpentConsumer, options ...UTXOIter
 		if opt.filterOutputType != nil {
 			key = byteutils.ConcatBytes(key, []byte{*opt.filterOutputType})
 		}
+	} else if opt.filterOutputType != nil {
+		return fmt.Errorf("output type filtering is only valid when also filtering for an address")
 	}
 
 	var i int

--- a/pkg/model/utxo/unspent.go
+++ b/pkg/model/utxo/unspent.go
@@ -1,6 +1,8 @@
 package utxo
 
 import (
+	"fmt"
+
 	"github.com/iotaledger/hive.go/byteutils"
 	"github.com/iotaledger/hive.go/kvstore"
 	"github.com/iotaledger/hive.go/marshalutil"
@@ -88,6 +90,8 @@ func (u *Manager) ForEachUnspentOutput(consumer OutputConsumer, options ...UTXOI
 		if opt.filterOutputType != nil {
 			key = byteutils.ConcatBytes(key, []byte{*opt.filterOutputType})
 		}
+	} else if opt.filterOutputType != nil {
+		return fmt.Errorf("output type filtering is only valid when also filtering for an address")
 	}
 
 	var i int

--- a/pkg/snapshot/snapshot.go
+++ b/pkg/snapshot/snapshot.go
@@ -355,7 +355,7 @@ func newLSMIUTXOProducer(utxoManager *utxo.Manager) OutputProducerFunc {
 
 	go func() {
 		if err := utxoManager.ForEachUnspentOutput(func(output *utxo.Output) bool {
-			prodChan <- &Output{MessageID: *output.MessageID(), OutputID: *output.OutputID(), Address: output.Address(), Amount: output.Amount()}
+			prodChan <- &Output{MessageID: *output.MessageID(), OutputID: *output.OutputID(), OutputType: output.OutputType(), Address: output.Address(), Amount: output.Amount()}
 			return true
 		}, utxo.ReadLockLedger(false)); err != nil {
 			errChan <- err

--- a/pkg/snapshot/snapshot_file_test.go
+++ b/pkg/snapshot/snapshot_file_test.go
@@ -283,9 +283,10 @@ func randLSTransactionUnspentOutputs() *snapshot.Output {
 	binary.LittleEndian.PutUint16(outputID[iotago.TransactionIDLength:], uint16(rand.Intn(100)))
 
 	return &snapshot.Output{
-		OutputID: outputID,
-		Address:  addr,
-		Amount:   uint64(rand.Intn(1000000) + 1),
+		OutputID:   outputID,
+		OutputType: byte(rand.Intn(1)),
+		Address:    addr,
+		Amount:     uint64(rand.Intn(1000000) + 1),
 	}
 }
 
@@ -298,9 +299,10 @@ func randLSTransactionSpents() *snapshot.Spent {
 	binary.LittleEndian.PutUint16(outputID[iotago.TransactionIDLength:], uint16(rand.Intn(100)))
 
 	output := &snapshot.Output{
-		OutputID: outputID,
-		Address:  addr,
-		Amount:   uint64(rand.Intn(1000000) + 1),
+		OutputID:   outputID,
+		OutputType: byte(rand.Intn(1)),
+		Address:    addr,
+		Amount:     uint64(rand.Intn(1000000) + 1),
 	}
 
 	return &snapshot.Spent{Output: *output, TargetTransactionID: rand32ByteHash()}

--- a/pkg/snapshot/snapshot_file_test.go
+++ b/pkg/snapshot/snapshot_file_test.go
@@ -284,7 +284,7 @@ func randLSTransactionUnspentOutputs() *snapshot.Output {
 
 	return &snapshot.Output{
 		OutputID:   outputID,
-		OutputType: byte(rand.Intn(1)),
+		OutputType: byte(rand.Intn(256)),
 		Address:    addr,
 		Amount:     uint64(rand.Intn(1000000) + 1),
 	}
@@ -300,7 +300,7 @@ func randLSTransactionSpents() *snapshot.Spent {
 
 	output := &snapshot.Output{
 		OutputID:   outputID,
-		OutputType: byte(rand.Intn(1)),
+		OutputType: byte(rand.Intn(256)),
 		Address:    addr,
 		Amount:     uint64(rand.Intn(1000000) + 1),
 	}

--- a/pkg/snapshot/snapshot_test.go
+++ b/pkg/snapshot/snapshot_test.go
@@ -1,0 +1,137 @@
+package snapshot
+
+import (
+	"bytes"
+	"math/rand"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/iotaledger/hive.go/kvstore"
+	"github.com/iotaledger/hive.go/kvstore/mapdb"
+
+	iotago "github.com/iotaledger/iota.go"
+
+	"github.com/gohornet/hornet/pkg/model/hornet"
+	"github.com/gohornet/hornet/pkg/model/utxo"
+)
+
+// returns length amount random bytes
+func randBytes(length int) []byte {
+	var b []byte
+	for i := 0; i < length; i++ {
+		b = append(b, byte(rand.Intn(256)))
+	}
+	return b
+}
+
+func randomAddress() *iotago.Ed25519Address {
+	address := &iotago.Ed25519Address{}
+	addressBytes := randBytes(32)
+	copy(address[:], addressBytes)
+	return address
+}
+
+func randomOutput(outputType iotago.OutputType, address ...iotago.Address) *utxo.Output {
+	outputID := &iotago.UTXOInputID{}
+	copy(outputID[:], randBytes(34))
+
+	messageID := &hornet.MessageID{}
+	copy(messageID[:], randBytes(32))
+
+	var addr iotago.Address
+	if len(address) > 0 {
+		addr = address[0]
+	} else {
+		addr = randomAddress()
+	}
+
+	amount := uint64(rand.Intn(2156465))
+
+	return utxo.CreateOutput(outputID, messageID, outputType, addr, amount)
+}
+
+func TestSnapshotOutputProducerAndConsumer(t *testing.T) {
+
+	map1 := mapdb.NewMapDB()
+	u1 := utxo.New(map1)
+	map2 := mapdb.NewMapDB()
+	u2 := utxo.New(map2)
+
+	count := 5000
+
+	// Fill up the UTXO
+	for i := 0; i < count; i++ {
+		u1.AddUnspentOutput(randomOutput(iotago.OutputSigLockedSingleOutput))
+		u1.AddUnspentOutput(randomOutput(iotago.OutputSigLockedDustAllowanceOutput))
+	}
+
+	// Count the outputs in the ledger
+	var singleCount int
+	var allowanceCount int
+	u1.ForEachOutput(func(output *utxo.Output) bool {
+		switch output.OutputType() {
+		case iotago.OutputSigLockedSingleOutput:
+			singleCount++
+		case iotago.OutputSigLockedDustAllowanceOutput:
+			allowanceCount++
+		default:
+			require.Fail(t, "invalid output type")
+		}
+		return true
+	})
+	require.Equal(t, count, singleCount)
+	require.Equal(t, count, allowanceCount)
+
+	// Pass all outputs from u1 to u2 over the snapshot serialization functions
+	producer := newLSMIUTXOProducer(u1)
+	consumer := newOutputConsumer(u2)
+
+	for {
+		output, err := producer()
+		require.NoError(t, err)
+
+		if output == nil {
+			break
+		}
+
+		// Marshal the output
+		outputBytes, err := output.MarshalBinary()
+		require.NoError(t, err)
+
+		// Unmarshal the output again
+		newOutput, err := readOutput(bytes.NewBuffer(outputBytes))
+		require.NoError(t, err)
+
+		err = consumer(newOutput)
+		require.NoError(t, err)
+	}
+
+	// Compare the raw keys values in the backing store
+	err := map1.Iterate(kvstore.EmptyPrefix, func(key kvstore.Key, value kvstore.Value) bool {
+
+		value2, err := map2.Get(key)
+		require.NoError(t, err)
+		require.Equal(t, value, value2)
+
+		return true
+	})
+	require.NoError(t, err)
+
+	// Count the outputs in the new ledger
+	singleCount = 0
+	allowanceCount = 0
+	u2.ForEachOutput(func(output *utxo.Output) bool {
+		switch output.OutputType() {
+		case iotago.OutputSigLockedSingleOutput:
+			singleCount++
+		case iotago.OutputSigLockedDustAllowanceOutput:
+			allowanceCount++
+		default:
+			require.Fail(t, "invalid output type")
+		}
+		return true
+	})
+	require.Equal(t, count, singleCount)
+	require.Equal(t, count, allowanceCount)
+}


### PR DESCRIPTION
There was a bug in the glue code between the UTXO and the Snapshot generation where we did not pass the correct output type to the Snapshot. All dust allowances were converted into normal outputs in the snapshot.