### PR TITLE
Fix snapshot glue code and add more test cases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ dist/
 alphanetdb*/
 comnetdb*/
 devnetdb*/
+testnetdb*/
 mainnetdb*/
 p2pstore*/
 

--- a/pkg/model/utxo/output.go
+++ b/pkg/model/utxo/output.go
@@ -150,13 +150,7 @@ func NewOutput(messageID hornet.MessageID, transaction *iotago.Transaction, inde
 		return nil, err
 	}
 
-	return &Output{
-		outputID:   &outputID,
-		messageID:  messageID,
-		outputType: output.Type(),
-		address:    address,
-		amount:     amount,
-	}, nil
+	return CreateOutput(&outputID, messageID, output.Type(), address, amount), nil
 }
 
 //- kvStorable

--- a/pkg/snapshot/snapshot.go
+++ b/pkg/snapshot/snapshot.go
@@ -531,14 +531,20 @@ func newMsDiffsProducer(utxoManager *utxo.Manager, direction MsDiffDirection, le
 
 			for _, output := range diff.Outputs {
 				createdOutputs = append(createdOutputs, &Output{
-					MessageID: output.MessageID().ToArray(), OutputID: *output.OutputID(),
-					Address: output.Address(), Amount: output.Amount()})
+					MessageID:  output.MessageID().ToArray(),
+					OutputID:   *output.OutputID(),
+					OutputType: output.OutputType(),
+					Address:    output.Address(),
+					Amount:     output.Amount()})
 			}
 
 			for _, spent := range diff.Spents {
 				consumedOutputs = append(consumedOutputs, &Spent{Output: Output{
-					MessageID: spent.MessageID().ToArray(), OutputID: *spent.OutputID(),
-					Address: spent.Address(), Amount: spent.Amount()},
+					MessageID:  spent.MessageID().ToArray(),
+					OutputID:   *spent.OutputID(),
+					OutputType: spent.OutputType(),
+					Address:    spent.Address(),
+					Amount:     spent.Amount()},
 					TargetTransactionID: *spent.TargetTransactionID()},
 				)
 			}

--- a/pkg/snapshot/snapshot_file_test.go
+++ b/pkg/snapshot/snapshot_file_test.go
@@ -286,6 +286,7 @@ func randLSTransactionUnspentOutputs() *snapshot.Output {
 	binary.LittleEndian.PutUint16(outputID[iotago.TransactionIDLength:], uint16(rand.Intn(100)))
 
 	return &snapshot.Output{
+		MessageID:  randMessageID().ToArray(),
 		OutputID:   outputID,
 		OutputType: byte(rand.Intn(256)),
 		Address:    addr,
@@ -302,6 +303,7 @@ func randLSTransactionSpents() *snapshot.Spent {
 	binary.LittleEndian.PutUint16(outputID[iotago.TransactionIDLength:], uint16(rand.Intn(100)))
 
 	output := &snapshot.Output{
+		MessageID:  randMessageID().ToArray(),
 		OutputID:   outputID,
 		OutputType: byte(rand.Intn(256)),
 		Address:    addr,

--- a/pkg/snapshot/snapshot_test.go
+++ b/pkg/snapshot/snapshot_test.go
@@ -3,6 +3,7 @@ package snapshot
 import (
 	"bytes"
 	"math/rand"
+	"sort"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -12,6 +13,8 @@ import (
 
 	iotago "github.com/iotaledger/iota.go/v2"
 
+	"github.com/gohornet/hornet/pkg/model/hornet"
+	"github.com/gohornet/hornet/pkg/model/milestone"
 	"github.com/gohornet/hornet/pkg/model/utxo"
 )
 
@@ -22,6 +25,10 @@ func randBytes(length int) []byte {
 		b = append(b, byte(rand.Intn(256)))
 	}
 	return b
+}
+
+func randMessageID() hornet.MessageID {
+	return hornet.MessageID(randBytes(iotago.MessageIDLength))
 }
 
 func randomAddress() *iotago.Ed25519Address {
@@ -35,7 +42,7 @@ func randomOutput(outputType iotago.OutputType, address ...iotago.Address) *utxo
 	outputID := &iotago.UTXOInputID{}
 	copy(outputID[:], randBytes(34))
 
-	messageID := randBytes(32)
+	messageID := randMessageID()
 
 	var addr iotago.Address
 	if len(address) > 0 {
@@ -47,6 +54,65 @@ func randomOutput(outputType iotago.OutputType, address ...iotago.Address) *utxo
 	amount := uint64(rand.Intn(2156465))
 
 	return utxo.CreateOutput(outputID, messageID, outputType, addr, amount)
+}
+
+func randomSpent(output *utxo.Output, msIndex ...milestone.Index) *utxo.Spent {
+	transactionID := &iotago.TransactionID{}
+	copy(transactionID[:], randBytes(iotago.TransactionIDLength))
+
+	confirmationIndex := milestone.Index(rand.Intn(216589))
+	if len(msIndex) > 0 {
+		confirmationIndex = msIndex[0]
+	}
+
+	return utxo.NewSpent(output, transactionID, confirmationIndex)
+}
+
+func EqualOutput(t *testing.T, expected *utxo.Output, actual *utxo.Output) {
+	require.Equal(t, expected.OutputID()[:], actual.OutputID()[:])
+	require.Equal(t, expected.MessageID()[:], actual.MessageID()[:])
+	require.Equal(t, expected.OutputType(), actual.OutputType())
+	require.Equal(t, expected.Address().String(), actual.Address().String())
+	require.Equal(t, expected.Amount(), actual.Amount())
+}
+
+func EqualOutputs(t *testing.T, expected utxo.Outputs, actual utxo.Outputs) {
+	require.Equal(t, len(expected), len(actual))
+
+	// Sort Outputs by output ID.
+	sort.Slice(expected, func(i, j int) bool {
+		return bytes.Compare(expected[i].OutputID()[:], expected[j].OutputID()[:]) == -1
+	})
+	sort.Slice(actual, func(i, j int) bool {
+		return bytes.Compare(actual[i].OutputID()[:], actual[j].OutputID()[:]) == -1
+	})
+
+	for i := 0; i < len(expected); i++ {
+		EqualOutput(t, expected[i], actual[i])
+	}
+}
+
+func EqualSpent(t *testing.T, expected *utxo.Spent, actual *utxo.Spent) {
+	require.Equal(t, expected.OutputID()[:], actual.OutputID()[:])
+	require.Equal(t, expected.TargetTransactionID()[:], actual.TargetTransactionID()[:])
+	require.Equal(t, expected.ConfirmationIndex(), actual.ConfirmationIndex())
+	EqualOutput(t, expected.Output(), actual.Output())
+}
+
+func EqualSpents(t *testing.T, expected utxo.Spents, actual utxo.Spents) {
+	require.Equal(t, len(expected), len(actual))
+
+	// Sort Spents by output ID.
+	sort.Slice(expected, func(i, j int) bool {
+		return bytes.Compare(expected[i].OutputID()[:], expected[j].OutputID()[:]) == -1
+	})
+	sort.Slice(actual, func(i, j int) bool {
+		return bytes.Compare(actual[i].OutputID()[:], actual[j].OutputID()[:]) == -1
+	})
+
+	for i := 0; i < len(expected); i++ {
+		EqualSpent(t, expected[i], actual[i])
+	}
 }
 
 func TestSnapshotOutputProducerAndConsumer(t *testing.T) {
@@ -132,4 +198,121 @@ func TestSnapshotOutputProducerAndConsumer(t *testing.T) {
 	})
 	require.Equal(t, count, singleCount)
 	require.Equal(t, count, allowanceCount)
+}
+
+func TestMsIndexIteratorOnwards(t *testing.T) {
+
+	var startIndex milestone.Index = 1000
+	var targetIndex milestone.Index = 1050
+	msIterator := newMsIndexIterator(MsDiffDirectionOnwards, startIndex, targetIndex)
+
+	var done bool
+	var msIndex milestone.Index
+
+	currentIndex := startIndex + 1
+	for msIndex, done = msIterator(); !done; msIndex, done = msIterator() {
+		require.GreaterOrEqual(t, msIndex, startIndex+1)
+		require.LessOrEqual(t, msIndex, targetIndex)
+		require.Equal(t, currentIndex, msIndex)
+		currentIndex++
+	}
+}
+
+func TestMsIndexIteratorBackwards(t *testing.T) {
+
+	var startIndex milestone.Index = 1050
+	var targetIndex milestone.Index = 1000
+	msIterator := newMsIndexIterator(MsDiffDirectionBackwards, startIndex, targetIndex)
+
+	var done bool
+	var msIndex milestone.Index
+
+	currentIndex := startIndex
+	for msIndex, done = msIterator(); !done; msIndex, done = msIterator() {
+		require.GreaterOrEqual(t, msIndex, targetIndex+1)
+		require.LessOrEqual(t, msIndex, startIndex)
+		require.Equal(t, currentIndex, msIndex)
+		currentIndex--
+	}
+}
+
+func TestSnapshotMsDiffProducerAndConsumer(t *testing.T) {
+
+	map1 := mapdb.NewMapDB()
+	u1 := utxo.New(map1)
+	map2 := mapdb.NewMapDB()
+	u2 := utxo.New(map2)
+
+	// Fill the first UTXO manager with some data
+	var startIndex milestone.Index = 1000
+	var targetIndex milestone.Index = 1050
+	msIterator := newMsIndexIterator(MsDiffDirectionOnwards, startIndex, targetIndex)
+
+	var done bool
+	var msIndex milestone.Index
+
+	for msIndex, done = msIterator(); !done; msIndex, done = msIterator() {
+
+		outputs := utxo.Outputs{
+			randomOutput(iotago.OutputSigLockedSingleOutput),
+			randomOutput(iotago.OutputSigLockedSingleOutput),
+			randomOutput(iotago.OutputSigLockedDustAllowanceOutput),
+			randomOutput(iotago.OutputSigLockedSingleOutput),
+			randomOutput(iotago.OutputSigLockedSingleOutput),
+		}
+
+		spents := utxo.Spents{
+			randomSpent(outputs[3], msIndex),
+			randomSpent(outputs[2], msIndex),
+		}
+
+		require.NoError(t, u1.ApplyConfirmationWithoutLocking(msIndex, outputs, spents))
+	}
+
+	producerU1 := newMsDiffsProducer(u1, MsDiffDirectionOnwards, startIndex, targetIndex)
+	consumerU2 := newMsDiffConsumer(u2)
+
+	err := u2.StoreLedgerIndex(startIndex)
+	require.NoError(t, err)
+
+	// Produce milestone diffs from UTXO manager 1 and apply them to UTXO manager 2 by consuming
+	for {
+		msDiff, err := producerU1()
+		require.NoError(t, err)
+
+		if msDiff == nil {
+			break
+		}
+
+		err = consumerU2(msDiff)
+		require.NoError(t, err)
+	}
+
+	//
+	loadedSpentsU1, err := u1.SpentOutputs()
+	require.NoError(t, err)
+
+	loadedUnspentU1, err := u1.UnspentOutputs()
+	require.NoError(t, err)
+
+	loadedSpentsU2, err := u2.SpentOutputs()
+	require.NoError(t, err)
+
+	loadedUnspentU2, err := u2.UnspentOutputs()
+	require.NoError(t, err)
+
+	// Compare all Outputs and Spents
+	EqualOutputs(t, loadedUnspentU1, loadedUnspentU2)
+	EqualSpents(t, loadedSpentsU1, loadedSpentsU2)
+
+	// Compare the raw keys values in the backing store
+	err = map1.Iterate(kvstore.EmptyPrefix, func(key kvstore.Key, value kvstore.Value) bool {
+
+		value2, err := map2.Get(key)
+		require.NoError(t, err)
+		require.Equal(t, value, value2)
+
+		return true
+	})
+	require.NoError(t, err)
 }

--- a/pkg/toolset/snapshot.go
+++ b/pkg/toolset/snapshot.go
@@ -101,7 +101,13 @@ func snapshotGen(args []string) error {
 		var nullMessageID [iotago.MessageIDLength]byte
 		var nullOutputID [utxo.OutputIDLength]byte
 
-		return &snapshot.Output{MessageID: nullMessageID, OutputID: nullOutputID, Address: &address, Amount: iotago.TokenSupply}, nil
+		return &snapshot.Output{
+			MessageID:  nullMessageID,
+			OutputID:   nullOutputID,
+			OutputType: iotago.OutputSigLockedSingleOutput,
+			Address:    &address,
+			Amount:     iotago.TokenSupply,
+		}, nil
 	}
 
 	// milestone diffs


### PR DESCRIPTION
# Description

This PR adds some test cases and fixes a bug in the snapshot milestone diff glue code, 
which caused `DustAllowanceOutputs` to be stored as `SigLockedSingleOutput` in the snapshots.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Added more test cases.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have tested my code extensively
- [X] I have selected the `develop` branch as the target branch
