### PR TITLE
Fix/deadlock p2p manager+service

### DIFF
--- a/pkg/p2p/manager.go
+++ b/pkg/p2p/manager.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/iotaledger/hive.go/events"
 	"github.com/iotaledger/hive.go/logger"
+	"github.com/iotaledger/hive.go/typeutils"
 )
 
 const (
@@ -32,6 +33,8 @@ var (
 	ErrCantConnectToItself = errors.New("the host can't connect to itself")
 	// Returned if a peer is tried to be added to the manager which is already added.
 	ErrPeerInManagerAlready = errors.New("peer is already in manager")
+	// Returned if the manager is shutting down.
+	ErrManagerShutdown = errors.New("manager is shutting down")
 )
 
 // PeerRelation defines the type of relation to a remote peer.
@@ -193,6 +196,7 @@ func NewManager(host host.Host, opts ...ManagerOption) *Manager {
 		host:               host,
 		peers:              map[peer.ID]*Peer{},
 		opts:               mngOpts,
+		stopped:            typeutils.NewAtomicBool(),
 		connectPeerChan:    make(chan *connectpeermsg, 10),
 		disconnectPeerChan: make(chan *disconnectpeermsg, 10),
 		isConnectedReqChan: make(chan *isconnectedrequestmsg, 10),
@@ -217,7 +221,10 @@ type Manager struct {
 	host host.Host
 	// holds the set of peers.
 	peers map[peer.ID]*Peer
-	opts  *ManagerOptions
+	// holds the manager options.
+	opts *ManagerOptions
+	// tells whether the manager was shut down.
+	stopped *typeutils.AtomicBool
 	// event loop channels
 	connectPeerChan    chan *connectpeermsg
 	disconnectPeerChan chan *disconnectpeermsg
@@ -250,10 +257,51 @@ func (m *Manager) Start(shutdownSignal <-chan struct{}) {
 	m.Events.StateChange.Trigger(ManagerStateStopped)
 }
 
+// shutdown sets the stopped flag and drains all outstanding requests of the event loop.
+func (m *Manager) shutdown() {
+	m.stopped.Set()
+
+	// drain all outstanding requests of the event loop.
+	// we do not care about correct handling of the channels, because we are shutting down anyway.
+drainLoop:
+	for {
+		select {
+		case connectPeerMsg := <-m.connectPeerChan:
+			// do not connect to the peer
+			connectPeerMsg.back <- ErrManagerShutdown
+
+		case disconnectPeerMsg := <-m.disconnectPeerChan:
+			disconnectPeerMsg.back <- ErrManagerShutdown
+
+		case <-m.reconnectChan:
+
+		case isConnectedReqMsg := <-m.isConnectedReqChan:
+			isConnectedReqMsg.back <- false
+
+		case <-m.connectedChan:
+
+		case <-m.disconnectedChan:
+
+		case forEachMsg := <-m.forEachChan:
+			forEachMsg.back <- struct{}{}
+
+		case callMsg := <-m.callChan:
+			callMsg.back <- struct{}{}
+
+		default:
+			break drainLoop
+		}
+	}
+}
+
 // ConnectPeer connects to the given peer.
 // If the peer is considered "known", then its connection is protected from trimming.
 // Optionally an alias for the peer can be defined to better identify it afterwards.
 func (m *Manager) ConnectPeer(addrInfo *peer.AddrInfo, peerRelation PeerRelation, alias ...string) error {
+	if m.stopped.IsSet() {
+		return ErrManagerShutdown
+	}
+
 	var al string
 	if len(alias) > 0 {
 		al = alias[0]
@@ -266,6 +314,10 @@ func (m *Manager) ConnectPeer(addrInfo *peer.AddrInfo, peerRelation PeerRelation
 // DisconnectPeer disconnects the given peer.
 // If the peer is considered "known", then its connection is unprotected from future trimming.
 func (m *Manager) DisconnectPeer(peerID peer.ID, disconnectReason ...error) error {
+	if m.stopped.IsSet() {
+		return ErrManagerShutdown
+	}
+
 	back := make(chan error)
 	var reason error
 	if len(disconnectReason) > 0 {
@@ -277,6 +329,10 @@ func (m *Manager) DisconnectPeer(peerID peer.ID, disconnectReason ...error) erro
 
 // IsConnected tells whether there is a connection to the given peer.
 func (m *Manager) IsConnected(peerID peer.ID) bool {
+	if m.stopped.IsSet() {
+		return false
+	}
+
 	back := make(chan bool)
 	m.isConnectedReqChan <- &isconnectedrequestmsg{peerID: peerID, back: back}
 	return <-back
@@ -290,6 +346,10 @@ type PeerForEachFunc func(p *Peer) bool
 // ForEach calls the given PeerForEachFunc on each Peer.
 // Optionally only loops over the peers with the given filter relation.
 func (m *Manager) ForEach(f PeerForEachFunc, filter ...PeerRelation) {
+	if m.stopped.IsSet() {
+		return
+	}
+
 	back := make(chan struct{})
 	m.forEachChan <- &foreachmsg{f: f, back: back, filter: filter}
 	<-back
@@ -337,6 +397,10 @@ type PeerFunc func(p *Peer)
 // Call calls the given PeerFunc synchronized within the Manager's event loop, if the peer exists.
 // PeerFunc must not call any function on Manager.
 func (m *Manager) Call(peerID peer.ID, f PeerFunc) {
+	if m.stopped.IsSet() {
+		return
+	}
+
 	back := make(chan struct{})
 	m.callChan <- &callmsg{peerID: peerID, f: f, back: back}
 	<-back
@@ -395,6 +459,7 @@ func (m *Manager) eventLoop(shutdownSignal <-chan struct{}) {
 	for {
 		select {
 		case <-shutdownSignal:
+			m.shutdown()
 			return
 
 		case connectPeerMsg := <-m.connectPeerChan:
@@ -556,6 +621,10 @@ func (m *Manager) scheduleReconnectIfKnown(peerID peer.ID) {
 
 	delay := m.opts.reconnectDelay()
 	p.reconnectTimer = time.AfterFunc(delay, func() {
+		if m.stopped.IsSet() {
+			return
+		}
+
 		m.reconnectChan <- &reconnectmsg{peerID: peerID}
 	})
 	m.Events.ScheduledReconnect.Trigger(p, delay)
@@ -644,7 +713,7 @@ func (m *Manager) forEach(f PeerForEachFunc, filter ...PeerRelation) {
 		if len(filter) > 0 && p.Relation != filter[0] {
 			continue
 		}
-		if !f(p) {
+		if m.stopped.IsSet() || !f(p) {
 			break
 		}
 	}
@@ -702,9 +771,15 @@ type netNotifiee Manager
 func (m *netNotifiee) Listen(net network.Network, multiaddr multiaddr.Multiaddr)      {}
 func (m *netNotifiee) ListenClose(net network.Network, multiaddr multiaddr.Multiaddr) {}
 func (m *netNotifiee) Connected(net network.Network, conn network.Conn) {
+	if m.stopped.IsSet() {
+		return
+	}
 	m.connectedChan <- &connectionmsg{net: net, conn: conn}
 }
 func (m *netNotifiee) Disconnected(net network.Network, conn network.Conn) {
+	if m.stopped.IsSet() {
+		return
+	}
 	m.disconnectedChan <- &disconnectmsg{net: net, conn: conn, reason: errors.New("connection closed by libp2p network event")}
 }
 func (m *netNotifiee) OpenedStream(net network.Network, stream network.Stream) {}

--- a/pkg/protocol/gossip/service.go
+++ b/pkg/protocol/gossip/service.go
@@ -5,16 +5,19 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/gohornet/hornet/pkg/metrics"
-	"github.com/gohornet/hornet/pkg/model/milestone"
-	"github.com/gohornet/hornet/pkg/p2p"
-	"github.com/iotaledger/hive.go/events"
-	"github.com/iotaledger/hive.go/logger"
 	"github.com/libp2p/go-libp2p-core/host"
 	"github.com/libp2p/go-libp2p-core/network"
 	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/libp2p/go-libp2p-core/protocol"
 	"github.com/multiformats/go-multiaddr"
+
+	"github.com/iotaledger/hive.go/events"
+	"github.com/iotaledger/hive.go/logger"
+	"github.com/iotaledger/hive.go/typeutils"
+
+	"github.com/gohornet/hornet/pkg/metrics"
+	"github.com/gohornet/hornet/pkg/model/milestone"
+	"github.com/gohornet/hornet/pkg/p2p"
 )
 
 // ServiceEvents are events happening around a Service.
@@ -51,12 +54,15 @@ const (
 	// StreamCancelReasonDuplicated defines a stream cancellation because
 	// it would lead to a duplicated ongoing stream.
 	StreamCancelReasonDuplicated StreamCancelReason = "duplicated stream"
-	// StreamCancelReasonUnknownPeer defines a stream cancellation because
+	// StreamCancelReasonInsufficientPeerRelation defines a stream cancellation because
 	// the relation to the other peer is insufficient.
 	StreamCancelReasonInsufficientPeerRelation StreamCancelReason = "insufficient peer relation"
-	// StreamCancelNoUnknownPeerSlotAvailable defines a stream cancellation
+	// StreamCancelReasonNoUnknownPeerSlotAvailable defines a stream cancellation
 	// because no more unknown peers slot were available.
-	StreamCancelNoUnknownPeerSlotAvailable StreamCancelReason = "no unknown peer slot available"
+	StreamCancelReasonNoUnknownPeerSlotAvailable StreamCancelReason = "no unknown peer slot available"
+	// StreamCancelReasonHostShutdown defines a stream cancellation
+	// because the host is shutting down.
+	StreamCancelReasonHostShutdown StreamCancelReason = "host shutdown"
 )
 
 const (
@@ -163,6 +169,7 @@ func NewService(
 		manager:             manager,
 		serverMetrics:       serverMetrics,
 		opts:                srvOpts,
+		stopped:             typeutils.NewAtomicBool(),
 		unknownPeers:        map[peer.ID]struct{}{},
 		inboundStreamChan:   make(chan network.Stream, 10),
 		connectedChan:       make(chan *connectionmsg, 10),
@@ -181,13 +188,20 @@ func NewService(
 // Service handles ongoing gossip streams.
 type Service struct {
 	// Events happening around a Service.
-	Events        ServiceEvents
-	host          host.Host
-	protocol      protocol.ID
-	streams       map[peer.ID]*Protocol
-	manager       *p2p.Manager
+	Events ServiceEvents
+	// the libp2p host instance from which to work with.
+	host     host.Host
+	protocol protocol.ID
+	// holds the set of protocols.
+	streams map[peer.ID]*Protocol
+	// the instance of the manager to work with.
+	manager *p2p.Manager
+	// the instance of the server metrics.
 	serverMetrics *metrics.ServerMetrics
-	opts          *ServiceOptions
+	// holds the service options.
+	opts *ServiceOptions
+	// tells whether the service was shut down.
+	stopped *typeutils.AtomicBool
 	// the amount of unknown peers with which a gossip stream is ongoing.
 	unknownPeers map[peer.ID]struct{}
 	// event loop channels
@@ -202,6 +216,10 @@ type Service struct {
 
 // Protocol returns the gossip.Protocol instance for the given peer or nil.
 func (s *Service) Protocol(peerID peer.ID) *Protocol {
+	if s.stopped.IsSet() {
+		return nil
+	}
+
 	back := make(chan *Protocol)
 	s.streamReqChan <- &streamreqmsg{peerID: peerID, back: back}
 	return <-back
@@ -214,6 +232,10 @@ type ProtocolForEachFunc func(proto *Protocol) bool
 
 // ForEach calls the given ProtocolForEachFunc on each Protocol.
 func (s *Service) ForEach(f ProtocolForEachFunc) {
+	if s.stopped.IsSet() {
+		return
+	}
+
 	back := make(chan struct{})
 	s.forEachChan <- &foreachmsg{f: f, back: back}
 	<-back
@@ -235,15 +257,27 @@ func (s *Service) SynchronizedCount(latestMilestoneIndex milestone.Index) int {
 // Start starts the Service's event loop.
 func (s *Service) Start(shutdownSignal <-chan struct{}) {
 	s.host.SetStreamHandler(s.protocol, func(stream network.Stream) {
+		if s.stopped.IsSet() {
+			return
+		}
 		s.inboundStreamChan <- stream
 	})
 	s.manager.Events.Connected.Attach(events.NewClosure(func(peer *p2p.Peer, conn network.Conn) {
+		if s.stopped.IsSet() {
+			return
+		}
 		s.connectedChan <- &connectionmsg{peer: peer, conn: conn}
 	}))
 	s.manager.Events.Disconnected.Attach(events.NewClosure(func(peerOptErr *p2p.PeerOptError) {
+		if s.stopped.IsSet() {
+			return
+		}
 		s.disconnectedChan <- &connectionmsg{peer: peerOptErr.Peer, conn: nil}
 	}))
 	s.manager.Events.RelationUpdated.Attach(events.NewClosure(func(peer *p2p.Peer, oldRel p2p.PeerRelation) {
+		if s.stopped.IsSet() {
+			return
+		}
 		s.relationUpdatedChan <- &relationupdatedmsg{peer: peer, oldRelation: oldRel}
 	}))
 	// manage libp2p network events
@@ -251,6 +285,38 @@ func (s *Service) Start(shutdownSignal <-chan struct{}) {
 	s.eventLoop(shutdownSignal)
 	// de-register libp2p network events
 	s.host.Network().StopNotify((*netNotifiee)(s))
+}
+
+// shutdown sets the stopped flag and drains all outstanding requests of the event loop.
+func (s *Service) shutdown() {
+	s.stopped.Set()
+
+	// drain all outstanding requests of the event loop.
+	// we do not care about correct handling of the channels, because we are shutting down anyway.
+drainLoop:
+	for {
+		select {
+
+		case <-s.inboundStreamChan:
+
+		case <-s.connectedChan:
+
+		case <-s.disconnectedChan:
+
+		case <-s.streamClosedChan:
+
+		case <-s.relationUpdatedChan:
+
+		case streamReqMsg := <-s.streamReqChan:
+			streamReqMsg.back <- nil
+
+		case forEachMsg := <-s.forEachChan:
+			forEachMsg.back <- struct{}{}
+
+		default:
+			break drainLoop
+		}
+	}
 }
 
 type connectionmsg struct {
@@ -283,6 +349,7 @@ func (s *Service) eventLoop(shutdownSignal <-chan struct{}) {
 	for {
 		select {
 		case <-shutdownSignal:
+			s.shutdown()
 			return
 
 		case inboundStream := <-s.inboundStreamChan:
@@ -352,7 +419,7 @@ func (s *Service) handleInboundStream(stream network.Stream) *Protocol {
 	case !hasKnownRelation && s.opts.UnknownPeersLimit == 0:
 		cancelReason = StreamCancelReasonInsufficientPeerRelation
 	case !hasKnownRelation && len(s.unknownPeers) == s.opts.UnknownPeersLimit:
-		cancelReason = StreamCancelNoUnknownPeerSlotAvailable
+		cancelReason = StreamCancelReasonNoUnknownPeerSlotAvailable
 	}
 
 	if len(cancelReason) > 0 {
@@ -491,7 +558,7 @@ func (s *Service) handleRelationUpdated(peer *p2p.Peer, oldRel p2p.PeerRelation)
 // calls the given ProtocolForEachFunc on each protocol.
 func (s *Service) forEach(f ProtocolForEachFunc) {
 	for _, p := range s.streams {
-		if !f(p) {
+		if s.stopped.IsSet() || !f(p) {
 			break
 		}
 	}
@@ -530,6 +597,9 @@ func (m *netNotifiee) Disconnected(net network.Network, conn network.Conn)      
 func (m *netNotifiee) OpenedStream(net network.Network, stream network.Stream)        {}
 func (m *netNotifiee) ClosedStream(net network.Network, stream network.Stream) {
 	if stream.Protocol() != m.protocol {
+		return
+	}
+	if m.stopped.IsSet() {
 		return
 	}
 	m.streamClosedChan <- &streamclosedmsg{peerID: stream.Conn().RemotePeer(), stream: stream}

--- a/pkg/shutdown/shutdown.go
+++ b/pkg/shutdown/shutdown.go
@@ -1,33 +1,36 @@
 package shutdown
 
+// Please add the dependencies if you add your own priority here.
+// Otherwise investigating deadlocks at shutdown is much more complicated.
+
 const (
-	PriorityCloseDatabase = iota
-	PriorityFlushToDatabase
-	PriorityRequestsProcessor
-	PriorityTipselection
-	PriorityMilestoneSolidifier
-	PriorityMilestoneProcessor
-	PrioritySolidifierGossip
-	PriorityReceiveTxWorker
+	PriorityCloseDatabase       = iota // no dependencies
+	PriorityFlushToDatabase            // depends on PriorityCloseDatabase
+	PriorityTipselection               // depends on PriorityFlushToDatabase, triggered by PriorityReceiveTxWorker, PriorityMilestoneSolidifier
+	PriorityMilestoneSolidifier        // depends on PriorityFlushToDatabase, triggered by PriorityReceiveTxWorker, PriorityMilestoneProcessor, PriorityMilestoneSolidifier, PriorityCoordinator, PriorityRestAPI, PriorityWarpSync
+	PriorityMilestoneProcessor         // depends on PriorityFlushToDatabase, PriorityMilestoneSolidifier, triggered by PriorityReceiveTxWorker, PriorityMilestoneSolidifier (searchMissingMilestone)
+	PrioritySolidifierGossip           // depends on PriorityFlushToDatabase, triggered by PriorityReceiveTxWorker
+	PriorityReceiveTxWorker            // triggered by PriorityMessageProcessor
 	PriorityMessageProcessor
 	PriorityPeerGossipProtocolWrite
 	PriorityPeerGossipProtocolRead
 	PriorityGossipService
-	PriorityBroadcastQueue
+	PriorityRequestsProcessor // depends on PriorityGossipService
+	PriorityBroadcastQueue    // depends on PriorityGossipService
 	PriorityKademliaDHT
 	PriorityPeerDiscovery
 	PriorityP2PManager
-	PriorityHeartbeats
+	PriorityHeartbeats // depends on PriorityGossipService
 	PriorityWarpSync
 	PrioritySnapshots
 	PriorityMetricsUpdater
 	PriorityDashboard
 	PriorityPoWHandler
-	PriorityRestAPI
+	PriorityRestAPI // depends on PriorityPoWHandler
 	PriorityMetricsPublishers
-	PrioritySpammer
+	PrioritySpammer // depends on PriorityPoWHandler
 	PriorityStatusReport
-	PriorityCoordinator
+	PriorityCoordinator // depends on PriorityPoWHandler
 	PriorityUpdateCheck
 	PriorityPrometheus
 )


### PR DESCRIPTION
This PR fixes deadlocks caused by a wrong shutdown priority and the fact that the p2p Service and Manager do not flush their channels on shutdown, and do not block new requests after shutdown.

Detailed description of the problem:
If the node was shutting down, the p2p Service and Manager were shut down first.
Afterwards the Request Queue was shut down. If the Request Queue was not empty at the time of the shutdown, the Draining of the Request Queue caused a deadlock because the EventLoop of the p2p Service was not processed anymore, which caused `service.ForEach` call in `RunRequestQueueDrainer` to deadlock.