### PR TITLE
Add new debug plugin for debug API routes

### DIFF
--- a/integration-tests/tester/framework/config.go
+++ b/integration-tests/tester/framework/config.go
@@ -229,12 +229,7 @@ func DefaultRestAPIConfig() RestAPIConfig {
 			"/api/v1/addresses/ed25519/:address/outputs",
 			"/api/v1/peers/:peerID",
 			"/api/v1/peers",
-			"/api/v1/debug/outputs",
-			"/api/v1/debug/outputs/unspent",
-			"/api/v1/debug/outputs/spent",
-			"/api/v1/debug/ms-diff/:milestoneIndex",
-			"/api/v1/debug/requests",
-			"/api/v1/debug/message-cones/:messageID",
+			"/api/plugins/*",
 		},
 		EnableProofOfWork: true,
 	}

--- a/main.go
+++ b/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/gohornet/hornet/pkg/node"
 	"github.com/gohornet/hornet/plugins/coordinator"
 	"github.com/gohornet/hornet/plugins/dashboard"
+	"github.com/gohornet/hornet/plugins/debug"
 	"github.com/gohornet/hornet/plugins/mqtt"
 	"github.com/gohornet/hornet/plugins/p2pdisc"
 	"github.com/gohornet/hornet/plugins/profiling"
@@ -53,6 +54,7 @@ func main() {
 			mqtt.Plugin,
 			coordinator.Plugin,
 			prometheus.Plugin,
+			debug.Plugin,
 		}...),
 	)
 }

--- a/pkg/tipselect/urts.go
+++ b/pkg/tipselect/urts.go
@@ -25,7 +25,7 @@ import (
 // Score defines the score of a tip.
 type Score int
 
-// TipSelectionFunc is a function which performs a tipselection and returns two tips.
+// TipSelectionFunc is a function which performs a tipselection and returns tips.
 type TipSelectionFunc = func() (hornet.MessageIDs, error)
 
 // TipSelStats holds the stats for a tipselection run.

--- a/plugins/dashboard/routes.go
+++ b/plugins/dashboard/routes.go
@@ -101,7 +101,7 @@ func passThroughAPIRoute(e echo.Context) error {
 func passThroughSpammerRoute(e echo.Context) error {
 	apiBindAddr := deps.NodeConfig.String(restapi.CfgRestAPIBindAddress)
 
-	data, err := readDataFromURL("http://" + apiBindAddr + "/spammer?" + e.Request().URL.RawQuery)
+	data, err := readDataFromURL("http://" + apiBindAddr + "/api/plugins/spammer?" + e.Request().URL.RawQuery)
 	if err != nil {
 		return err
 	}
@@ -155,7 +155,7 @@ func setupRoutes(e *echo.Echo) {
 
 	// Pass all the explorer request through to the local rest API
 	e.GET("/api/*", passThroughAPIRoute)
-	e.GET("/plugins/spammer*", passThroughSpammerRoute)
+	e.GET("/api/plugins/spammer*", passThroughSpammerRoute)
 
 	// Everything else fallback to index for routing.
 	e.GET("*", indexRoute)

--- a/plugins/debug/plugin.go
+++ b/plugins/debug/plugin.go
@@ -1,0 +1,174 @@
+package debug
+
+import (
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+	"github.com/pkg/errors"
+	"go.uber.org/dig"
+
+	"github.com/gohornet/hornet/pkg/model/storage"
+	"github.com/gohornet/hornet/pkg/model/utxo"
+	"github.com/gohornet/hornet/pkg/node"
+	"github.com/gohornet/hornet/pkg/protocol/gossip"
+	"github.com/gohornet/hornet/pkg/restapi"
+	"github.com/gohornet/hornet/pkg/tangle"
+)
+
+const (
+	// ParameterMessageID is used to identify a message by it's ID.
+	ParameterMessageID = "messageID"
+
+	// ParameterMilestoneIndex is used to identify a milestone.
+	ParameterMilestoneIndex = "milestoneIndex"
+)
+
+const (
+	// RouteDebugSolidifier is the debug route to manually trigger the solidifier.
+	// GET triggers the solidifier.
+	RouteDebugSolidifier = "/solidifier"
+
+	// RouteDebugOutputs is the debug route for getting all output IDs.
+	// GET returns the outputIDs for all outputs.
+	RouteDebugOutputs = "/outputs"
+
+	// RouteDebugOutputsUnspent is the debug route for getting all unspent output IDs.
+	// GET returns the outputIDs for all unspent outputs.
+	RouteDebugOutputsUnspent = "/outputs/unspent"
+
+	// RouteDebugOutputsSpent is the debug route for getting all spent output IDs.
+	// GET returns the outputIDs for all spent outputs.
+	RouteDebugOutputsSpent = "/outputs/spent"
+
+	// RouteDebugAddresses is the debug route for getting all known addresses.
+	// GET returns all known addresses encoded in hex.
+	RouteDebugAddresses = "/addresses"
+
+	// RouteDebugAddressesEd25519 is the debug route for getting all known ed25519 addresses.
+	// GET returns all known ed25519 addresses encoded in hex.
+	RouteDebugAddressesEd25519 = "/addresses/ed25519"
+
+	// RouteDebugMilestoneDiffs is the debug route for getting a milestone diff by it's milestoneIndex.
+	// GET returns the utxo diff (new outputs & spents) for the milestone index.
+	RouteDebugMilestoneDiffs = "/ms-diff/:" + ParameterMilestoneIndex
+
+	// RouteDebugRequests is the debug route for getting all pending requests.
+	// GET returns a list of all pending requests.
+	RouteDebugRequests = "/requests"
+
+	// RouteDebugMessageCone is the debug route for traversing a cone of a message.
+	// it traverses the parents of a message until they reference an older milestone than the start message.
+	// GET returns the path of this traversal and the "entry points".
+	RouteDebugMessageCone = "/message-cones/:" + ParameterMessageID
+)
+
+func init() {
+	Plugin = &node.Plugin{
+		Status: node.Disabled,
+		Pluggable: node.Pluggable{
+			Name:      "Debug",
+			DepsFunc:  func(cDeps dependencies) { deps = cDeps },
+			Configure: configure,
+		},
+	}
+}
+
+var (
+	Plugin *node.Plugin
+
+	// ErrNodeNotSync is returned when the node was not synced.
+	ErrNodeNotSync = errors.New("node not synced")
+
+	deps dependencies
+)
+
+type dependencies struct {
+	dig.In
+	Storage      *storage.Storage
+	Tangle       *tangle.Tangle
+	RequestQueue gossip.RequestQueue
+	UTXO         *utxo.Manager
+	Echo         *echo.Echo
+}
+
+func configure() {
+	routeGroup := deps.Echo.Group("/api/plugins/debug")
+
+	routeGroup.GET(RouteDebugSolidifier, func(c echo.Context) error {
+		deps.Tangle.TriggerSolidifier()
+
+		return restapi.JSONResponse(c, http.StatusOK, "solidifier triggered")
+	})
+
+	routeGroup.GET(RouteDebugOutputs, func(c echo.Context) error {
+		resp, err := debugOutputsIDs(c)
+		if err != nil {
+			return err
+		}
+
+		return restapi.JSONResponse(c, http.StatusOK, resp)
+	})
+
+	routeGroup.GET(RouteDebugOutputsUnspent, func(c echo.Context) error {
+		resp, err := debugUnspentOutputsIDs(c)
+		if err != nil {
+			return err
+		}
+
+		return restapi.JSONResponse(c, http.StatusOK, resp)
+	})
+
+	routeGroup.GET(RouteDebugOutputsSpent, func(c echo.Context) error {
+		resp, err := debugSpentOutputsIDs(c)
+		if err != nil {
+			return err
+		}
+
+		return restapi.JSONResponse(c, http.StatusOK, resp)
+	})
+
+	routeGroup.GET(RouteDebugAddresses, func(c echo.Context) error {
+		resp, err := debugAddresses(c)
+		if err != nil {
+			return err
+		}
+
+		return restapi.JSONResponse(c, http.StatusOK, resp)
+	})
+
+	routeGroup.GET(RouteDebugAddressesEd25519, func(c echo.Context) error {
+		resp, err := debugAddressesEd25519(c)
+		if err != nil {
+			return err
+		}
+
+		return restapi.JSONResponse(c, http.StatusOK, resp)
+	})
+
+	routeGroup.GET(RouteDebugMilestoneDiffs, func(c echo.Context) error {
+		resp, err := debugMilestoneDiff(c)
+		if err != nil {
+			return err
+		}
+
+		return restapi.JSONResponse(c, http.StatusOK, resp)
+	})
+
+	routeGroup.GET(RouteDebugRequests, func(c echo.Context) error {
+		resp, err := debugRequests(c)
+		if err != nil {
+			return err
+		}
+
+		return restapi.JSONResponse(c, http.StatusOK, resp)
+	})
+
+	routeGroup.GET(RouteDebugMessageCone, func(c echo.Context) error {
+		resp, err := debugMessageCone(c)
+		if err != nil {
+			return err
+		}
+
+		return restapi.JSONResponse(c, http.StatusOK, resp)
+	})
+}

--- a/plugins/debug/types.go
+++ b/plugins/debug/types.go
@@ -1,0 +1,85 @@
+package debug
+
+import (
+	"github.com/gohornet/hornet/pkg/model/milestone"
+	v1 "github.com/gohornet/hornet/plugins/restapi/v1"
+)
+
+// outputIDsResponse defines the response of a GET debug outputs REST API call.
+type outputIDsResponse struct {
+	// The output IDs (transaction hash + output index) of the outputs.
+	OutputIDs []string `json:"outputIds"`
+}
+
+// address defines the response of a GET debug addresses REST API call.
+type address struct {
+	// The type of the address (0=WOTS, 1=Ed25519).
+	AddressType byte `json:"addressType"`
+	// The hex encoded address.
+	Address string `json:"address"`
+	// The balance of the address.
+	Balance uint64 `json:"balance"`
+}
+
+// addressesResponse defines the response of a GET debug addresses REST API call.
+type addressesResponse struct {
+	// The addresses (type + hex encoded address).
+	Addresses []*address `json:"addresses"`
+}
+
+// outputIDsResponse defines the response of a GET debug milestone diff REST API call.
+type milestoneDiffResponse struct {
+	// The index of the milestone.
+	MilestoneIndex milestone.Index `json:"index"`
+	// The newly created outputs by this milestone diff.
+	Outputs []*v1.OutputResponse `json:"outputs"`
+	// The used outputs (spents) by this milestone diff.
+	Spents []*v1.OutputResponse `json:"spents"`
+}
+
+// request defines an request response.
+type request struct {
+	// The hex encoded message ID of the message.
+	MessageID string `json:"messageId"`
+	// The type of the request.
+	Type string `json:"type"`
+	// Whether the message already exists in the storage layer.
+	MessageExists bool `json:"txExists"`
+	// The time the request was enqueued.
+	EnqueueTimestamp string `json:"enqueueTimestamp"`
+	// The index of the milestone this request belongs to.
+	MilestoneIndex milestone.Index `json:"milestoneIndex"`
+}
+
+// requestsResponse defines the response of a GET debug requests REST API call.
+type requestsResponse struct {
+	// The pending requests of the node.
+	Requests []*request `json:"requests"`
+}
+
+// entryPoint defines an entryPoint with information about the milestone index of the cone it references.
+type entryPoint struct {
+	// The hex encoded message ID of the message.
+	MessageID             string          `json:"messageId"`
+	ReferencedByMilestone milestone.Index `json:"referencedByMilestone"`
+}
+
+// messageWithParents defines a message with information about it's parents.
+type messageWithParents struct {
+	// The hex encoded message ID of the message.
+	MessageID string `json:"messageId"`
+	// The hex encoded message IDs of the parents the message references.
+	Parents []string `json:"parentMessageIds"`
+}
+
+// messageConeResponse defines the response of a GET debug message cone REST API call.
+type messageConeResponse struct {
+	// The count of elements in the cone.
+	ConeElementsCount int `json:"coneElementsCount"`
+	// The count of found entry points.
+	EntryPointsCount int `json:"entryPointsCount"`
+	// The cone of the message.
+	Cone []*messageWithParents `json:"cone"`
+	// The entry points of the cone of this message.
+	EntryPoints []*entryPoint `json:"entryPoints"`
+}

--- a/plugins/restapi/v1/plugin.go
+++ b/plugins/restapi/v1/plugin.go
@@ -54,7 +54,7 @@ const (
 	// GET returns the node info.
 	RouteInfo = "/info"
 
-	// RouteTips is the route for getting two tips.
+	// RouteTips is the route for getting tips.
 	// GET returns the tips.
 	RouteTips = "/tips"
 
@@ -128,43 +128,6 @@ const (
 	// RouteControlSnapshotCreate is the control route to manually create a snapshot file.
 	// GET creates a snapshot. (query parameters: "index")
 	RouteControlSnapshotCreate = "/control/snapshots/create"
-
-	// RouteDebugSolidifier is the debug route to manually trigger the solidifier.
-	// GET triggers the solidifier.
-	RouteDebugSolidifier = "/debug/solidifier"
-
-	// RouteDebugOutputs is the debug route for getting all output IDs.
-	// GET returns the outputIDs for all outputs.
-	RouteDebugOutputs = "/debug/outputs"
-
-	// RouteDebugOutputsUnspent is the debug route for getting all unspent output IDs.
-	// GET returns the outputIDs for all unspent outputs.
-	RouteDebugOutputsUnspent = "/debug/outputs/unspent"
-
-	// RouteDebugOutputsSpent is the debug route for getting all spent output IDs.
-	// GET returns the outputIDs for all spent outputs.
-	RouteDebugOutputsSpent = "/debug/outputs/spent"
-
-	// RouteDebugAddresses is the debug route for getting all known addresses.
-	// GET returns all known addresses encoded in hex.
-	RouteDebugAddresses = "/debug/addresses"
-
-	// RouteDebugAddressesEd25519 is the debug route for getting all known ed25519 addresses.
-	// GET returns all known ed25519 addresses encoded in hex.
-	RouteDebugAddressesEd25519 = "/debug/addresses/ed25519"
-
-	// RouteDebugMilestoneDiffs is the debug route for getting a milestone diff by it's milestoneIndex.
-	// GET returns the utxo diff (new outputs & spents) for the milestone index.
-	RouteDebugMilestoneDiffs = "/debug/ms-diff/:" + ParameterMilestoneIndex
-
-	// RouteDebugRequests is the debug route for getting all pending requests.
-	// GET returns a list of all pending requests.
-	RouteDebugRequests = "/debug/requests"
-
-	// RouteDebugMessageCone is the debug route for traversing a cone of a message.
-	// it traverses the parents of a message until they reference an older milestone than the start message.
-	// GET returns the path of this traversal and the "entry points".
-	RouteDebugMessageCone = "/debug/message-cones/:" + ParameterMessageID
 )
 
 func init() {
@@ -195,7 +158,6 @@ type dependencies struct {
 	Tangle           *tangle.Tangle
 	Manager          *p2p.Manager
 	Service          *gossip.Service
-	RequestQueue     gossip.RequestQueue
 	UTXO             *utxo.Manager
 	PoWHandler       *pow.Handler
 	MessageProcessor *gossip.MessageProcessor
@@ -399,84 +361,6 @@ func configure() {
 
 	routeGroup.GET(RouteControlSnapshotCreate, func(c echo.Context) error {
 		resp, err := createSnapshot(c)
-		if err != nil {
-			return err
-		}
-
-		return restapi.JSONResponse(c, http.StatusOK, resp)
-	})
-
-	routeGroup.GET(RouteDebugSolidifier, func(c echo.Context) error {
-		deps.Tangle.TriggerSolidifier()
-
-		return restapi.JSONResponse(c, http.StatusOK, "solidifier triggered")
-	})
-
-	routeGroup.GET(RouteDebugOutputs, func(c echo.Context) error {
-		resp, err := debugOutputsIDs(c)
-		if err != nil {
-			return err
-		}
-
-		return restapi.JSONResponse(c, http.StatusOK, resp)
-	})
-
-	routeGroup.GET(RouteDebugOutputsUnspent, func(c echo.Context) error {
-		resp, err := debugUnspentOutputsIDs(c)
-		if err != nil {
-			return err
-		}
-
-		return restapi.JSONResponse(c, http.StatusOK, resp)
-	})
-
-	routeGroup.GET(RouteDebugOutputsSpent, func(c echo.Context) error {
-		resp, err := debugSpentOutputsIDs(c)
-		if err != nil {
-			return err
-		}
-
-		return restapi.JSONResponse(c, http.StatusOK, resp)
-	})
-
-	routeGroup.GET(RouteDebugAddresses, func(c echo.Context) error {
-		resp, err := debugAddresses(c)
-		if err != nil {
-			return err
-		}
-
-		return restapi.JSONResponse(c, http.StatusOK, resp)
-	})
-
-	routeGroup.GET(RouteDebugAddressesEd25519, func(c echo.Context) error {
-		resp, err := debugAddressesEd25519(c)
-		if err != nil {
-			return err
-		}
-
-		return restapi.JSONResponse(c, http.StatusOK, resp)
-	})
-
-	routeGroup.GET(RouteDebugMilestoneDiffs, func(c echo.Context) error {
-		resp, err := debugMilestoneDiff(c)
-		if err != nil {
-			return err
-		}
-
-		return restapi.JSONResponse(c, http.StatusOK, resp)
-	})
-
-	routeGroup.GET(RouteDebugRequests, func(c echo.Context) error {
-		resp, err := debugRequests(c)
-		if err != nil {
-			return err
-		}
-
-		return restapi.JSONResponse(c, http.StatusOK, resp)
-	})
-
-	routeGroup.GET(RouteDebugMessageCone, func(c echo.Context) error {
-		resp, err := debugMessageCone(c)
 		if err != nil {
 			return err
 		}

--- a/plugins/restapi/v1/types.go
+++ b/plugins/restapi/v1/types.go
@@ -110,8 +110,8 @@ type milestoneUTXOChangesResponse struct {
 	ConsumedOutputs []string `json:"consumedOutputs"`
 }
 
-// outputResponse defines the response of a GET outputs REST API call.
-type outputResponse struct {
+// OutputResponse defines the response of a GET outputs REST API call.
+type OutputResponse struct {
 	// The hex encoded message ID of the message.
 	MessageID string `json:"messageId"`
 	// The hex encoded transaction id from which this output originated.
@@ -146,85 +146,6 @@ type addressOutputsResponse struct {
 	Count uint32 `json:"count"`
 	// The output IDs (transaction hash + output index) of the outputs on this address.
 	OutputIDs []string `json:"outputIds"`
-}
-
-// outputIDsResponse defines the response of a GET debug outputs REST API call.
-type outputIDsResponse struct {
-	// The output IDs (transaction hash + output index) of the outputs.
-	OutputIDs []string `json:"outputIds"`
-}
-
-// address defines the response of a GET debug addresses REST API call.
-type address struct {
-	// The type of the address (0=WOTS, 1=Ed25519).
-	AddressType byte `json:"addressType"`
-	// The hex encoded address.
-	Address string `json:"address"`
-	// The balance of the address.
-	Balance uint64 `json:"balance"`
-}
-
-// addressesResponse defines the response of a GET debug addresses REST API call.
-type addressesResponse struct {
-	// The addresses (type + hex encoded address).
-	Addresses []*address `json:"addresses"`
-}
-
-// outputIDsResponse defines the response of a GET debug milestone diff REST API call.
-type milestoneDiffResponse struct {
-	// The index of the milestone.
-	MilestoneIndex milestone.Index `json:"index"`
-	// The newly created outputs by this milestone diff.
-	Outputs []*outputResponse `json:"outputs"`
-	// The used outputs (spents) by this milestone diff.
-	Spents []*outputResponse `json:"spents"`
-}
-
-// request defines an request response.
-type request struct {
-	// The hex encoded message ID of the message.
-	MessageID string `json:"messageId"`
-	// The type of the request.
-	Type string `json:"type"`
-	// Whether the message already exists in the storage layer.
-	MessageExists bool `json:"txExists"`
-	// The time the request was enqueued.
-	EnqueueTimestamp string `json:"enqueueTimestamp"`
-	// The index of the milestone this request belongs to.
-	MilestoneIndex milestone.Index `json:"milestoneIndex"`
-}
-
-// requestsResponse defines the response of a GET debug requests REST API call.
-type requestsResponse struct {
-	// The pending requests of the node.
-	Requests []*request `json:"requests"`
-}
-
-// entryPoint defines an entryPoint with information about the milestone index of the cone it references.
-type entryPoint struct {
-	// The hex encoded message ID of the message.
-	MessageID             string          `json:"messageId"`
-	ReferencedByMilestone milestone.Index `json:"referencedByMilestone"`
-}
-
-// messageWithParents defines a message with information about it's parents.
-type messageWithParents struct {
-	// The hex encoded message ID of the message.
-	MessageID string `json:"messageId"`
-	// The hex encoded message IDs of the parents the message references.
-	Parents []string `json:"parentMessageIds"`
-}
-
-// messageConeResponse defines the response of a GET debug message cone REST API call.
-type messageConeResponse struct {
-	// The count of elements in the cone.
-	ConeElementsCount int `json:"coneElementsCount"`
-	// The count of found entry points.
-	EntryPointsCount int `json:"entryPointsCount"`
-	// The cone of the message.
-	Cone []*messageWithParents `json:"cone"`
-	// The entry points of the cone of this message.
-	EntryPoints []*entryPoint `json:"entryPoints"`
 }
 
 // addPeerRequest defines the request for a POST peer REST API call.

--- a/plugins/restapi/v1/utxo.go
+++ b/plugins/restapi/v1/utxo.go
@@ -18,7 +18,7 @@ import (
 	restapiplugin "github.com/gohornet/hornet/plugins/restapi"
 )
 
-func newOutputResponse(output *utxo.Output, spent bool) (*outputResponse, error) {
+func NewOutputResponse(output *utxo.Output, spent bool) (*OutputResponse, error) {
 
 	var rawOutput iotago.Output
 	switch output.OutputType() {
@@ -43,7 +43,7 @@ func newOutputResponse(output *utxo.Output, spent bool) (*outputResponse, error)
 
 	rawRawOutputJSON := json.RawMessage(rawOutputJSON)
 
-	return &outputResponse{
+	return &OutputResponse{
 		MessageID:     output.MessageID().ToHex(),
 		TransactionID: hex.EncodeToString(output.OutputID()[:iotago.TransactionIDLength]),
 		Spent:         spent,
@@ -52,7 +52,7 @@ func newOutputResponse(output *utxo.Output, spent bool) (*outputResponse, error)
 	}, nil
 }
 
-func outputByID(c echo.Context) (*outputResponse, error) {
+func outputByID(c echo.Context) (*OutputResponse, error) {
 	outputIDParam := strings.ToLower(c.Param(ParameterOutputID))
 
 	outputIDBytes, err := hex.DecodeString(outputIDParam)
@@ -81,7 +81,7 @@ func outputByID(c echo.Context) (*outputResponse, error) {
 		return nil, errors.WithMessagef(restapi.ErrInternalError, "reading spent status failed: %s, error: %s", outputIDParam, err)
 	}
 
-	return newOutputResponse(output, !unspent)
+	return NewOutputResponse(output, !unspent)
 }
 
 func ed25519Balance(address *iotago.Ed25519Address) (*addressBalanceResponse, error) {

--- a/plugins/spammer/http.go
+++ b/plugins/spammer/http.go
@@ -16,7 +16,7 @@ const (
 	// query parameters: "cmd" (start, stop)
 	//					 "mpsRateLimit" (optional)
 	//					 "cpuMaxUsage" (optional)
-	RouteSpammer = "/spammer"
+	RouteSpammer = "/api/plugins/spammer"
 )
 
 type spamSettings struct {


### PR DESCRIPTION
This PR moves all REST routes from plugins to `/api/plugins/<name>`.
It also creates a new plugin for all debug API endpoints.