### PR TITLE
Add debug endpoint to calculate white flag confirmation

### DIFF
--- a/alphanet/config_alphanet.json
+++ b/alphanet/config_alphanet.json
@@ -88,7 +88,7 @@
       "minHeaviestBranchUnreferencedMessagesThreshold": 20,
       "maxHeaviestBranchTipsPerCheckpoint": 10,
       "randomTipsPerCheckpoint": 2,
-      "heaviestBranchSelectionDeadlineMilliseconds": 100
+      "heaviestBranchSelectionTimeoutMilliseconds": 100
     }
   },
   "tipsel": {

--- a/config_chrysalis_testnet.json
+++ b/config_chrysalis_testnet.json
@@ -97,7 +97,7 @@
       "minHeaviestBranchUnreferencedMessagesThreshold": 20,
       "maxHeaviestBranchTipsPerCheckpoint": 10,
       "randomTipsPerCheckpoint": 2,
-      "heaviestBranchSelectionDeadlineMilliseconds": 100
+      "heaviestBranchSelectionTimeoutMilliseconds": 100
     }
   },
   "tipsel": {

--- a/config_comnet.json
+++ b/config_comnet.json
@@ -91,7 +91,7 @@
       "minHeaviestBranchUnreferencedMessagesThreshold": 20,
       "maxHeaviestBranchTipsPerCheckpoint": 10,
       "randomTipsPerCheckpoint": 2,
-      "heaviestBranchSelectionDeadlineMilliseconds": 100
+      "heaviestBranchSelectionTimeoutMilliseconds": 100
     }
   },
   "tipsel": {

--- a/config_devnet.json
+++ b/config_devnet.json
@@ -92,7 +92,7 @@
       "minHeaviestBranchUnreferencedMessagesThreshold": 20,
       "maxHeaviestBranchTipsPerCheckpoint": 10,
       "randomTipsPerCheckpoint": 2,
-      "heaviestBranchSelectionDeadlineMilliseconds": 100
+      "heaviestBranchSelectionTimeoutMilliseconds": 100
     }
   },
   "tipsel": {

--- a/pkg/model/hornet/message_id.go
+++ b/pkg/model/hornet/message_id.go
@@ -125,12 +125,27 @@ func (m MessageIDs) RemoveDupsAndSortByLexicalOrder() MessageIDs {
 	return result
 }
 
-// MessageIDsFromSliceOfArrays creates slice of MessageIDs from a slice of arrays.
+// MessageIDsFromHex creates a slice of MessageIDs from a slice of hex string representations.
+func MessageIDsFromHex(hexStrings []string) (MessageIDs, error) {
+	results := make(MessageIDs, len(hexStrings))
+
+	for i, hexString := range hexStrings {
+		msgID, err := MessageIDFromHex(hexString)
+		if err != nil {
+			return nil, err
+		}
+		results[i] = msgID
+	}
+
+	return results, nil
+}
+
+// MessageIDsFromSliceOfArrays creates a slice of MessageIDs from a slice of arrays.
 func MessageIDsFromSliceOfArrays(b iotago.MessageIDs) MessageIDs {
-	result := make(MessageIDs, len(b))
+	results := make(MessageIDs, len(b))
 	for i, msgID := range b {
 		// as msgID is reused between iterations, it must be copied
-		result[i] = MessageIDFromArray(msgID)
+		results[i] = MessageIDFromArray(msgID)
 	}
-	return result
+	return results
 }

--- a/pkg/model/mselection/heaviest.go
+++ b/pkg/model/mselection/heaviest.go
@@ -26,7 +26,7 @@ type HeaviestSelector struct {
 	minHeaviestBranchUnreferencedMessagesThreshold int
 	maxHeaviestBranchTipsPerCheckpoint             int
 	randomTipsPerCheckpoint                        int
-	heaviestBranchSelectionDeadline                time.Duration
+	heaviestBranchSelectionTimeout                 time.Duration
 
 	trackedMessages map[string]*trackedMessage // map of all tracked messages
 	tips            *list.List                 // list of available tips
@@ -87,12 +87,12 @@ func (il *trackedMessagesList) removeTip(tip *trackedMessage) {
 }
 
 // New creates a new HeaviestSelector instance.
-func New(minHeaviestBranchUnreferencedMessagesThreshold int, maxHeaviestBranchTipsPerCheckpoint int, randomTipsPerCheckpoint int, heaviestBranchSelectionDeadline time.Duration) *HeaviestSelector {
+func New(minHeaviestBranchUnreferencedMessagesThreshold int, maxHeaviestBranchTipsPerCheckpoint int, randomTipsPerCheckpoint int, heaviestBranchSelectionTimeout time.Duration) *HeaviestSelector {
 	s := &HeaviestSelector{
 		minHeaviestBranchUnreferencedMessagesThreshold: minHeaviestBranchUnreferencedMessagesThreshold,
 		maxHeaviestBranchTipsPerCheckpoint:             maxHeaviestBranchTipsPerCheckpoint,
 		randomTipsPerCheckpoint:                        randomTipsPerCheckpoint,
-		heaviestBranchSelectionDeadline:                heaviestBranchSelectionDeadline,
+		heaviestBranchSelectionTimeout:                 heaviestBranchSelectionTimeout,
 	}
 	s.reset()
 	return s
@@ -180,7 +180,7 @@ func (s *HeaviestSelector) SelectTips(minRequiredTips int) (hornet.MessageIDs, e
 	var tips hornet.MessageIDs
 
 	// run the tip selection for at most 0.1s to keep the view on the tangle recent; this should be plenty
-	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(s.heaviestBranchSelectionDeadline))
+	ctx, cancel := context.WithTimeout(context.Background(), s.heaviestBranchSelectionTimeout)
 	defer cancel()
 
 	deadlineExceeded := false

--- a/pkg/model/storage/milestones.go
+++ b/pkg/model/storage/milestones.go
@@ -103,7 +103,7 @@ func (s *Storage) WaitForNodeSynced(timeout time.Duration) bool {
 		return true
 	}
 
-	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(timeout))
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
 	// we wait either until the node got synced or we reached the deadline

--- a/pkg/p2p/manager.go
+++ b/pkg/p2p/manager.go
@@ -595,7 +595,9 @@ func (m *Manager) reconnectPeer(peerID peer.ID) (bool, error) {
 // if the connection fails, the peer is either cleared from the Manager if its relation is PeerRelationUnknown
 // or a reconnect attempt is scheduled if it is PeerRelationKnown.
 func (m *Manager) connect(addrInfo peer.AddrInfo) error {
-	ctx, _ := context.WithTimeout(context.Background(), connTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), connTimeout)
+	defer cancel()
+
 	err := m.host.Connect(ctx, addrInfo)
 	if err != nil {
 		// unsuccessful connect:

--- a/pkg/protocol/gossip/service.go
+++ b/pkg/protocol/gossip/service.go
@@ -408,7 +408,9 @@ func (s *Service) handleConnected(peer *p2p.Peer, conn network.Conn) (*Protocol,
 
 // opens up a stream to the given peer.
 func (s *Service) openStream(peerID peer.ID) (network.Stream, error) {
-	ctx, _ := context.WithTimeout(context.Background(), s.opts.StreamConnectTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), s.opts.StreamConnectTimeout)
+	defer cancel()
+
 	stream, err := s.host.NewStream(ctx, peerID, s.protocol)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create gossip stream to %s: %w", peerID, err)

--- a/pkg/testsuite/tangle.go
+++ b/pkg/testsuite/tangle.go
@@ -74,10 +74,10 @@ func (te *TestEnvironment) AssertTotalSupplyStillValid() {
 }
 
 func (te *TestEnvironment) AssertMessageConflictReason(messageID hornet.MessageID, conflict storage.Conflict) {
-	metadata := te.storage.GetCachedMessageMetadataOrNil(messageID)
-	require.NotNil(te.TestState, metadata)
-	defer metadata.Release(true)
-	require.Equal(te.TestState, metadata.GetMetadata().GetConflict(), conflict)
+	cachedMsgMeta := te.storage.GetCachedMessageMetadataOrNil(messageID)
+	require.NotNil(te.TestState, cachedMsgMeta)
+	defer cachedMsgMeta.Release(true)
+	require.Equal(te.TestState, cachedMsgMeta.GetMetadata().GetConflict(), conflict)
 }
 
 // generateDotFileFromConfirmation generates a dot file from a whiteflag confirmation cone.

--- a/pkg/utils/sync.go
+++ b/pkg/utils/sync.go
@@ -2,7 +2,6 @@ package utils
 
 import (
 	"context"
-	"time"
 
 	"github.com/iotaledger/hive.go/syncutils"
 )
@@ -73,25 +72,14 @@ func (se *SyncEvent) Trigger(key interface{}) {
 	delete(se.syncMap, key)
 }
 
-// WaitForChannelClosed waits until the channel is closed or the deadline is reached.
-// If the deadline was reached, the event should be deregistered afterwards to clean up memory.
-func WaitForChannelClosed(ch chan struct{}, timeout ...time.Duration) error {
-
-	if len(timeout) > 0 {
-		// wait for at most "timeout" for the channel to be closed
-		ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(timeout[0]))
-		defer cancel()
-
-		// we wait either until the channel got closed or we reached the deadline
-		select {
-		case <-ch:
-			return nil
-		case <-ctx.Done():
-			return context.DeadlineExceeded
-		}
+// WaitForChannelClosed waits until the channel is closed or the context is done.
+// If the context was done, the event should be manually deregistered afterwards to clean up memory.
+func WaitForChannelClosed(ctx context.Context, ch chan struct{}) error {
+	// we wait either until the channel got closed or the context is done
+	select {
+	case <-ch:
+		return nil
+	case <-ctx.Done():
+		return context.DeadlineExceeded
 	}
-
-	// wait until channel is closed
-	<-ch
-	return nil
 }

--- a/plugins/coordinator/params.go
+++ b/plugins/coordinator/params.go
@@ -27,7 +27,7 @@ const (
 	// one heaviest branch tip was found, otherwise no random tips will be picked
 	CfgCoordinatorTipselectRandomTipsPerCheckpoint = "coordinator.tipsel.randomTipsPerCheckpoint"
 	// the maximum duration to select the heaviest branch tips in milliseconds
-	CfgCoordinatorTipselectHeaviestBranchSelectionDeadlineMilliseconds = "coordinator.tipsel.heaviestBranchSelectionDeadlineMilliseconds"
+	CfgCoordinatorTipselectHeaviestBranchSelectionTimeoutMilliseconds = "coordinator.tipsel.heaviestBranchSelectionTimeoutMilliseconds"
 )
 
 var params = &node.PluginParams{
@@ -41,7 +41,7 @@ var params = &node.PluginParams{
 			fs.Int(CfgCoordinatorTipselectMinHeaviestBranchUnreferencedMessagesThreshold, 20, "minimum threshold of unreferenced messages in the heaviest branch")
 			fs.Int(CfgCoordinatorTipselectMaxHeaviestBranchTipsPerCheckpoint, 10, "maximum amount of checkpoint messages with heaviest branch tips")
 			fs.Int(CfgCoordinatorTipselectRandomTipsPerCheckpoint, 3, "amount of checkpoint messages with random tips")
-			fs.Int(CfgCoordinatorTipselectHeaviestBranchSelectionDeadlineMilliseconds, 100, "the maximum duration to select the heaviest branch tips in milliseconds")
+			fs.Int(CfgCoordinatorTipselectHeaviestBranchSelectionTimeoutMilliseconds, 100, "the maximum duration to select the heaviest branch tips in milliseconds")
 			return fs
 		}(),
 	},

--- a/plugins/coordinator/plugin.go
+++ b/plugins/coordinator/plugin.go
@@ -7,6 +7,7 @@ import (
 	"github.com/pkg/errors"
 	flag "github.com/spf13/pflag"
 	"go.uber.org/dig"
+	"golang.org/x/net/context"
 
 	"github.com/iotaledger/hive.go/configuration"
 	"github.com/iotaledger/hive.go/events"
@@ -128,7 +129,7 @@ func initCoordinator(bootstrap bool, startIndex uint32, powHandler *powpackage.H
 		deps.NodeConfig.Int(CfgCoordinatorTipselectMinHeaviestBranchUnreferencedMessagesThreshold),
 		deps.NodeConfig.Int(CfgCoordinatorTipselectMaxHeaviestBranchTipsPerCheckpoint),
 		deps.NodeConfig.Int(CfgCoordinatorTipselectRandomTipsPerCheckpoint),
-		time.Duration(deps.NodeConfig.Int(CfgCoordinatorTipselectHeaviestBranchSelectionDeadlineMilliseconds))*time.Millisecond,
+		time.Duration(deps.NodeConfig.Int(CfgCoordinatorTipselectHeaviestBranchSelectionTimeoutMilliseconds))*time.Millisecond,
 	)
 
 	nextCheckpointSignal = make(chan struct{})
@@ -328,11 +329,11 @@ func sendMessage(msg *storage.Message, msIndex ...milestone.Index) error {
 	}
 
 	// wait until the message is solid
-	utils.WaitForChannelClosed(msgSolidEventChan)
+	utils.WaitForChannelClosed(context.Background(), msgSolidEventChan)
 
 	if len(msIndex) > 0 {
 		// if it was a milestone, also wait until the milestone was confirmed
-		utils.WaitForChannelClosed(milestoneConfirmedEventChan)
+		utils.WaitForChannelClosed(context.Background(), milestoneConfirmedEventChan)
 	}
 
 	return nil

--- a/plugins/debug/params.go
+++ b/plugins/debug/params.go
@@ -1,0 +1,22 @@
+package debug
+
+import (
+	"github.com/gohornet/hornet/pkg/node"
+	flag "github.com/spf13/pflag"
+)
+
+const (
+	// the maximum duration for the parents to become solid during white flag confirmation API call.
+	CfgDebugWhiteFlagParentsSolidTimeoutMilliseconds = "debug.whiteFlagParentsSolidTimeoutMilliseconds"
+)
+
+var params = &node.PluginParams{
+	Params: map[string]*flag.FlagSet{
+		"nodeConfig": func() *flag.FlagSet {
+			fs := flag.NewFlagSet("", flag.ContinueOnError)
+			fs.Int(CfgDebugWhiteFlagParentsSolidTimeoutMilliseconds, 2000, "defines the the maximum duration for the parents to become solid during white flag confirmation API call")
+			return fs
+		}(),
+	},
+	Masked: nil,
+}

--- a/plugins/debug/types.go
+++ b/plugins/debug/types.go
@@ -5,6 +5,20 @@ import (
 	v1 "github.com/gohornet/hornet/plugins/restapi/v1"
 )
 
+// computeWhiteFlagMutationsRequest defines the request for a POST debugComputeWhiteFlagMutations REST API call.
+type computeWhiteFlagMutationsRequest struct {
+	// The index of the milestone.
+	Index milestone.Index `json:"index"`
+	// The hex encoded message IDs of the parents the milestone references.
+	Parents []string `json:"parentMessageIds"`
+}
+
+// computeWhiteFlagMutationsRequest defines the response for a POST debugComputeWhiteFlagMutations REST API call.
+type computeWhiteFlagMutationsResponse struct {
+	// The hex encoded merkle tree hash as a result of the white flag computation.
+	MerkleTreeHash string `json:"merkleTreeHash"`
+}
+
 // outputIDsResponse defines the response of a GET debug outputs REST API call.
 type outputIDsResponse struct {
 	// The output IDs (transaction hash + output index) of the outputs.

--- a/plugins/mqtt/plugin.go
+++ b/plugins/mqtt/plugin.go
@@ -108,11 +108,11 @@ func configure() {
 		topicName := string(topic)
 
 		if messageId := messageIdFromTopic(topicName); messageId != nil {
-			if cachedMetadata := deps.Storage.GetCachedMessageMetadataOrNil(messageId); cachedMetadata != nil {
-				if _, added := messageMetadataWorkerPool.TrySubmit(cachedMetadata); added {
+			if cachedMsgMeta := deps.Storage.GetCachedMessageMetadataOrNil(messageId); cachedMsgMeta != nil {
+				if _, added := messageMetadataWorkerPool.TrySubmit(cachedMsgMeta); added {
 					return // Avoid Release (done inside workerpool task)
 				}
-				cachedMetadata.Release(true)
+				cachedMsgMeta.Release(true)
 			}
 			return
 		}


### PR DESCRIPTION
# Description

This PR adds a debug endpoint to the REST API to calculate the white flag confirmation for a cone of given parents.
This will be used by the coordinator node, to ask other nodes for the MerkleTreeHash to ensure they have the same perception of the ledger state, before a milestone is issued by the coordinator.

Since the nodes may have missed some messages via gossip, the parents may not be solid yet.
That's why the parents are requested if they are not solid yet, and the API endpoint waits for a configured timeout for the messages to become solid, before it returns HTTP code 503 (Service unavailable).

## Type of change

- [X] Enhancement (non-breaking change which adds functionality)
