### PR TITLE
chore: Ignore jwt-go vuln

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,11 @@
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+version: v1.14.1
+# ignores vulnerabilities until expiry date; change duration by modifying expiry date
+ignore:
+  SNYK-GOLANG-GITHUBCOMDGRIJALVAJWTGO-596515:
+    - '*':
+        reason: >-
+          Not vulnerable, see
+          https://github.com/labstack/echo/pull/1663\#issuecomment-749968018
+        expires: 2021-03-13T21:24:02.215Z
+patch: {}


### PR DESCRIPTION
# Description

Silences the alert about [`jwt-go`](https://snyk.io/vuln/SNYK-GOLANG-GITHUBCOMDGRIJALVAJWTGO-596515) for a month, as Hornet is not vulnerable (see https://github.com/gohornet/hornet/pull/822#issue-553285574)

## Type of change

- Chore

# How Has This Been Tested?

N/A

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have selected the `develop` branch as the target branch
