### PR TITLE
Fix/cone root indexes calculation

### DIFF
--- a/core/snapshot/core.go
+++ b/core/snapshot/core.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/gohornet/hornet/pkg/model/hornet"
 	flag "github.com/spf13/pflag"
 	"go.uber.org/dig"
 
@@ -140,9 +139,6 @@ func configure() {
 			log.Panic(err.Error())
 		}
 	}
-
-	// genesis is always a SEP
-	deps.Storage.SolidEntryPointsAdd(hornet.GetNullMessageID(), 1)
 
 }
 

--- a/pkg/dag/cone_root_indexes_test.go
+++ b/pkg/dag/cone_root_indexes_test.go
@@ -76,11 +76,9 @@ func TestConeRootIndexes(t *testing.T) {
 		cachedMsgMeta := te.Storage().GetCachedMessageMetadataOrNil(messages[len(messages)-1])
 		ycri, ocri := dag.GetConeRootIndexes(te.Storage(), cachedMsgMeta, lsmi)
 
-		minOldestConeRootIndex := lsmi
-		if minOldestConeRootIndex > milestone.Index(BelowMaxDepth) {
-			minOldestConeRootIndex -= milestone.Index(BelowMaxDepth)
-		} else {
-			minOldestConeRootIndex = 1
+		minOldestConeRootIndex := milestone.Index(1)
+		if lsmi > milestone.Index(BelowMaxDepth) {
+			minOldestConeRootIndex = lsmi - milestone.Index(BelowMaxDepth)
 		}
 
 		require.GreaterOrEqual(te.TestState, uint32(ocri), uint32(minOldestConeRootIndex))
@@ -99,13 +97,6 @@ func TestConeRootIndexes(t *testing.T) {
 
 	cachedMsgMeta := te.Storage().GetCachedMessageMetadataOrNil(msg.StoredMessageID())
 	ycri, ocri := dag.GetConeRootIndexes(te.Storage(), cachedMsgMeta, lsmi)
-
-	minOldestConeRootIndex := lsmi
-	if minOldestConeRootIndex > milestone.Index(BelowMaxDepth) {
-		minOldestConeRootIndex -= milestone.Index(BelowMaxDepth)
-	} else {
-		minOldestConeRootIndex = 1
-	}
 
 	// NullHash is SEP for index 0
 	require.Equal(te.TestState, uint32(0), uint32(ocri))

--- a/pkg/dag/cone_root_indexes_test.go
+++ b/pkg/dag/cone_root_indexes_test.go
@@ -1,0 +1,113 @@
+package dag_test
+
+import (
+	"fmt"
+	"math/rand"
+	"testing"
+
+	iotago "github.com/iotaledger/iota.go/v2"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gohornet/hornet/pkg/dag"
+	"github.com/gohornet/hornet/pkg/model/hornet"
+	"github.com/gohornet/hornet/pkg/model/milestone"
+	"github.com/gohornet/hornet/pkg/testsuite"
+)
+
+const (
+	MinPowScore   = 10.0
+	BelowMaxDepth = 5
+)
+
+func TestConeRootIndexes(t *testing.T) {
+
+	te := testsuite.SetupTestEnvironment(t, &iotago.Ed25519Address{}, 0, MinPowScore, false)
+	defer te.CleanupTestEnvironment(true)
+
+	messages := hornet.MessageIDs{hornet.GetNullMessageID()}
+	messagesPerMilestones := make([]hornet.MessageIDs, 0)
+
+	const initMessagesCount = 10
+
+	getParents := func() hornet.MessageIDs {
+
+		if len(messages) < initMessagesCount {
+			// reference the first milestone at the beginning
+			return hornet.MessageIDs{te.Milestones[0].GetMilestone().MessageID, hornet.GetNullMessageID()}
+		}
+
+		parents := hornet.MessageIDs{}
+		for j := 2; j <= 2+rand.Intn(7); j++ {
+			msIndex := rand.Intn(BelowMaxDepth)
+			if msIndex > len(messagesPerMilestones)-1 {
+				msIndex = rand.Intn(len(messagesPerMilestones))
+			}
+			milestoneMessages := messagesPerMilestones[len(messagesPerMilestones)-1-msIndex]
+			if len(milestoneMessages) == 0 {
+				// use the milestone hash
+				parents = append(parents, te.Milestones[len(te.Milestones)-1-msIndex].GetMilestone().MessageID)
+				continue
+			}
+			parents = append(parents, milestoneMessages[rand.Intn(len(milestoneMessages))])
+		}
+		parents = parents.RemoveDupsAndSortByLexicalOrder()
+
+		return parents
+	}
+
+	// build a tangle with 30 milestones and 10 - 100 messages between the milestones
+	for msIndex := 2; msIndex < 30; msIndex++ {
+		messagesPerMilestones = append(messagesPerMilestones, hornet.MessageIDs{})
+
+		msgsCount := 10 + rand.Intn(90)
+		for msgCount := 0; msgCount < msgsCount; msgCount++ {
+			msg := te.NewMessageBuilder(fmt.Sprintf("%d_%d", msIndex, msgCount)).Parents(getParents()).BuildIndexation().Store()
+
+			messages = append(messages, msg.StoredMessageID())
+			messagesPerMilestones[len(messagesPerMilestones)-1] = append(messagesPerMilestones[len(messagesPerMilestones)-1], msg.StoredMessageID())
+		}
+
+		// confirm the new cone
+		te.IssueAndConfirmMilestoneOnTip(messages[len(messages)-1], false)
+
+		latestMilestone := te.Milestones[len(te.Milestones)-1]
+		lsmi := latestMilestone.GetMilestone().Index
+
+		cachedMsgMeta := te.Storage().GetCachedMessageMetadataOrNil(messages[len(messages)-1])
+		ycri, ocri := dag.GetConeRootIndexes(te.Storage(), cachedMsgMeta, lsmi)
+
+		minOldestConeRootIndex := lsmi
+		if minOldestConeRootIndex > milestone.Index(BelowMaxDepth) {
+			minOldestConeRootIndex -= milestone.Index(BelowMaxDepth)
+		} else {
+			minOldestConeRootIndex = 1
+		}
+
+		require.GreaterOrEqual(te.TestState, uint32(ocri), uint32(minOldestConeRootIndex))
+		require.LessOrEqual(te.TestState, uint32(ocri), uint32(msIndex))
+
+		require.GreaterOrEqual(te.TestState, uint32(ycri), uint32(minOldestConeRootIndex))
+		require.LessOrEqual(te.TestState, uint32(ycri), uint32(msIndex))
+	}
+
+	latestMilestone := te.Milestones[len(te.Milestones)-1]
+	lsmi := latestMilestone.GetMilestone().Index
+
+	// Use Null hash and last milestone hash as parents
+	parents := hornet.MessageIDs{latestMilestone.GetMilestone().MessageID, hornet.GetNullMessageID()}
+	msg := te.NewMessageBuilder("below max depth").Parents(parents.RemoveDupsAndSortByLexicalOrder()).BuildIndexation().Store()
+
+	cachedMsgMeta := te.Storage().GetCachedMessageMetadataOrNil(msg.StoredMessageID())
+	ycri, ocri := dag.GetConeRootIndexes(te.Storage(), cachedMsgMeta, lsmi)
+
+	minOldestConeRootIndex := lsmi
+	if minOldestConeRootIndex > milestone.Index(BelowMaxDepth) {
+		minOldestConeRootIndex -= milestone.Index(BelowMaxDepth)
+	} else {
+		minOldestConeRootIndex = 1
+	}
+
+	// NullHash is SEP for index 0
+	require.Equal(te.TestState, uint32(0), uint32(ocri))
+	require.LessOrEqual(te.TestState, uint32(ycri), uint32(lsmi))
+}

--- a/pkg/model/coordinator/coordinator.go
+++ b/pkg/model/coordinator/coordinator.go
@@ -123,11 +123,6 @@ func (coo *Coordinator) InitState(bootstrap bool, startIndex milestone.Index) er
 			return fmt.Errorf("previous milestone does not match latest milestone in database! previous: %d, database: %d", startIndex-1, latestMilestoneFromDatabase)
 		}
 
-		if startIndex == 1 {
-			// if we bootstrap a network, NullMessageID has to be set as a solid entry point
-			coo.storage.SolidEntryPointsAdd(hornet.GetNullMessageID(), startIndex)
-		}
-
 		latestMilestoneMessageID := hornet.GetNullMessageID()
 		if startIndex != 1 {
 			// If we don't start a new network, the last milestone has to be referenced

--- a/pkg/tangle/tangle_processor.go
+++ b/pkg/tangle/tangle_processor.go
@@ -62,6 +62,7 @@ func (t *Tangle) RunTangleProcessor() {
 
 		if err := utils.ReturnErrIfCtxDone(t.shutdownCtx, common.ErrOperationAborted); err != nil {
 			// do not process the milestone if the node was shut down
+			cachedMilestone.Release(true) // message -1
 			return
 		}
 

--- a/pkg/tipselect/test/urts_test.go
+++ b/pkg/tipselect/test/urts_test.go
@@ -2,6 +2,7 @@ package test
 
 import (
 	"fmt"
+	"math"
 	"testing"
 
 	iotago "github.com/iotaledger/iota.go/v2"
@@ -77,11 +78,14 @@ func TestTipSelect(t *testing.T) {
 			var youngestConeRootIndex milestone.Index = 0
 			var oldestConeRootIndex milestone.Index = 0
 
+			youngestConeRootIndex = 0
+			oldestConeRootIndex = math.MaxUint32
+
 			updateIndexes := func(ycri milestone.Index, ocri milestone.Index) {
-				if (youngestConeRootIndex == 0) || (youngestConeRootIndex < ycri) {
+				if youngestConeRootIndex < ycri {
 					youngestConeRootIndex = ycri
 				}
-				if (oldestConeRootIndex == 0) || (oldestConeRootIndex > ocri) {
+				if oldestConeRootIndex > ocri {
 					oldestConeRootIndex = ocri
 				}
 			}

--- a/pkg/tipselect/test/urts_test.go
+++ b/pkg/tipselect/test/urts_test.go
@@ -117,18 +117,14 @@ func TestTipSelect(t *testing.T) {
 				}, false, nil)
 			require.NoError(te.TestState, err)
 
-			minOldestConeRootIndex := lsmi
-			if minOldestConeRootIndex > milestone.Index(MaxDeltaMsgOldestConeRootIndexToLSMI) {
-				minOldestConeRootIndex -= milestone.Index(MaxDeltaMsgOldestConeRootIndexToLSMI)
-			} else {
-				minOldestConeRootIndex = 1
+			minOldestConeRootIndex := milestone.Index(1)
+			if lsmi > milestone.Index(MaxDeltaMsgOldestConeRootIndexToLSMI) {
+				minOldestConeRootIndex = lsmi - milestone.Index(MaxDeltaMsgOldestConeRootIndexToLSMI)
 			}
 
-			minYoungestConeRootIndex := lsmi
-			if minYoungestConeRootIndex > milestone.Index(MaxDeltaMsgYoungestConeRootIndexToLSMI) {
-				minYoungestConeRootIndex -= milestone.Index(MaxDeltaMsgYoungestConeRootIndexToLSMI)
-			} else {
-				minYoungestConeRootIndex = 1
+			minYoungestConeRootIndex := milestone.Index(1)
+			if lsmi > milestone.Index(MaxDeltaMsgYoungestConeRootIndexToLSMI) {
+				minYoungestConeRootIndex = lsmi - milestone.Index(MaxDeltaMsgYoungestConeRootIndexToLSMI)
 			}
 
 			require.GreaterOrEqual(te.TestState, uint32(oldestConeRootIndex), uint32(minOldestConeRootIndex))


### PR DESCRIPTION
# Description

This PR fixes a bug in the calculation of the cone root indexes. This caused the coordinator to reference the genesis message, even it was below max depth. Now the genesis message is only valid as a tip for the first `BelowMaxDepth` milestones.

Fixes #(issue)
#876 
#874 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I added a test case.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have tested my code extensively
- [X] I have selected the `develop` branch as the target branch
