### PR TITLE
Rebase "Avoid trying linking statically (#834)" on develop-legacy

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -12,8 +12,6 @@ builds:
   # Linux AMD64
   - id: hornet-linux-amd64
     binary: hornet
-    env:
-      - CGO_ENABLED=1
     ldflags:
       - -s -w -X github.com/gohornet/hornet/plugins/cli.AppVersion={{.Version}}
     flags:

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -20,16 +20,16 @@ RUN go mod verify
 COPY . .
 
 # Build the binary
-RUN CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build -tags="pow_avx" \
-      -ldflags='-w -s -extldflags "-static"' -a \
-       -o /go/bin/hornet
+RUN GOOS=linux GOARCH=amd64 go build -tags="pow_avx" \
+      -ldflags='-w -s' -a \
+      -o /go/bin/hornet
 
 ############################
 # Image
 ############################
-# using static nonroot image
-# user:group is nonroot:nonroot, uid:gid = 65532:65532
-FROM gcr.io/distroless/static@sha256:23aa732bba4c8618c0d97c26a72a32997363d591807b0d4c31b0bbc8a774bddf
+# https://github.com/GoogleContainerTools/distroless/blob/master/base/README.md
+# using distroless base image, contains: glibc, libssl and openssl
+FROM gcr.io/distroless/base@sha256:5e0cc69445ed1d8a17198250a7249d56dd4b6966bb6b2118e60ae9194c310647
 
 EXPOSE 8081/tcp
 EXPOSE 14265/tcp


### PR DESCRIPTION
# Description

* Fix `net` runtime problems for lack of glibc
* Avoid SEGFAULTs by not trying linking statically
* Remove CGO_ENABLED from Amd64 go releaser

Just like PR #834

Tested 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Initial snapshot download fails due to DNS resolution without this patch.
