### PR TITLE
fix: Use LatestSolidSubtangleMilestoneIndex

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,6 +4,8 @@ run:
 linters-settings:
     gofmt:
         simplify: true
+    goimports:
+        local-prefixes: github.com/gohornet,github.com/iotaledger
     golint:
         min-confidence: 0.9
     gocyclo:

--- a/pkg/model/migrator/validator.go
+++ b/pkg/model/migrator/validator.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"math"
 
+	"github.com/gohornet/hornet/pkg/common"
+	"github.com/gohornet/hornet/pkg/whiteflag"
 	"github.com/iotaledger/iota.go/address"
 	"github.com/iotaledger/iota.go/api"
 	"github.com/iotaledger/iota.go/bundle"
@@ -18,9 +20,6 @@ import (
 	"github.com/iotaledger/iota.go/transaction"
 	"github.com/iotaledger/iota.go/trinary"
 	iotago "github.com/iotaledger/iota.go/v2"
-
-	"github.com/gohornet/hornet/pkg/common"
-	"github.com/gohornet/hornet/pkg/whiteflag"
 
 	_ "golang.org/x/crypto/blake2b" // import implementation
 )


### PR DESCRIPTION
Use `LatestSolidSubtangleMilestoneIndex` instead of `LatestMilestoneIndex` to query the latest index that can be queried using the getWhiteFlagConfirmation API call.