### PR TITLE
chore: Update obsolete GoReleaser config options

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -68,7 +68,7 @@ dockers:
     image_templates:
       - "gohornet/hornet:latest"
       - "gohornet/hornet:{{ .Tag }}"
-    binaries:
+    ids:
       - hornet
     dockerfile: docker/Dockerfile.goreleaser
     skip_push: auto
@@ -110,15 +110,34 @@ nfpms:
       - deb
       - rpm
     bindir: /usr/bin
-    files:
-      "nfpm/shared_files/hornet.service": "/lib/systemd/system/hornet.service"
-    config_files:
-      "config.json": "/var/lib/hornet/config.json"
-      "config_comnet.json": "/var/lib/hornet/config_comnet.json"
-      "config_devnet.json": "/var/lib/hornet/config_devnet.json"
-      "peering.json": "/var/lib/hornet/peering.json"
-      "profiles.json": "/var/lib/hornet/profiles.json"
-      "nfpm/shared_files/hornet.env": "/etc/default/hornet"
+    contents:
+      - src: "nfpm/shared_files/hornet.service"
+        dst: "/lib/systemd/system/hornet.service"
+
+      - src: "config.json"
+        dst: "/var/lib/hornet/config.json"
+        type: config
+
+      - src: "config_comnet.json"
+        dst: "/var/lib/hornet/config_comnet.json"
+        type: config
+
+      - src: "config_devnet.json"
+        dst: "/var/lib/hornet/config_devnet.json"
+        type: config
+
+      - src: "peering.json"
+        dst: "/var/lib/hornet/peering.json"
+        type: config
+
+      - src: "profiles.json"
+        dst: "/var/lib/hornet/profiles.json"
+        type: config
+
+      - src: "nfpm/shared_files/hornet.env"
+        dst: "/etc/default/hornet"
+        type: config
+
     dependencies:
       - systemd
       - wget


### PR DESCRIPTION
This PR updates the GoReleaser config file. This is necessary due to obsolete config options.
<https://goreleaser.com/deprecations>
