### PR TITLE
Feat/coo quorum

### DIFF
--- a/alphanet/config_alphanet.json
+++ b/alphanet/config_alphanet.json
@@ -97,8 +97,11 @@
       "provider": "local",
       "remoteAddress": "localhost:12345"
     },
-    "quorum": {},
-    "quorumTimeout": "2s"
+    "quorum": {
+      "enabled": false,
+      "groups": {},
+      "timeout": "2s"
+    }
   },
   "receipts": {
     "backup": {

--- a/alphanet/config_alphanet.json
+++ b/alphanet/config_alphanet.json
@@ -96,7 +96,9 @@
     "signing": {
       "provider": "local",
       "remoteAddress": "localhost:12345"
-    }
+    },
+    "quorum": {},
+    "quorumTimeout": "2s"
   },
   "receipts": {
     "backup": {

--- a/config_chrysalis_testnet.json
+++ b/config_chrysalis_testnet.json
@@ -104,7 +104,9 @@
     "signing": {
       "provider": "local",
       "remoteAddress": "localhost:12345"
-    }
+    },
+    "quorum": {},
+    "quorumTimeout": "2s"
   },
   "receipts": {
     "backup": {

--- a/config_chrysalis_testnet.json
+++ b/config_chrysalis_testnet.json
@@ -105,8 +105,11 @@
       "provider": "local",
       "remoteAddress": "localhost:12345"
     },
-    "quorum": {},
-    "quorumTimeout": "2s"
+    "quorum": {
+      "enabled": false,
+      "groups": {},
+      "timeout": "2s"
+    }
   },
   "receipts": {
     "backup": {

--- a/config_comnet.json
+++ b/config_comnet.json
@@ -98,7 +98,9 @@
     "signing": {
       "provider": "local",
       "remoteAddress": "localhost:12345"
-    }
+    },
+    "quorum": {},
+    "quorumTimeout": "2s"
   },
   "tipsel": {
     "maxDeltaMsgYoungestConeRootIndexToCMI": 2,

--- a/config_comnet.json
+++ b/config_comnet.json
@@ -99,8 +99,11 @@
       "provider": "local",
       "remoteAddress": "localhost:12345"
     },
-    "quorum": {},
-    "quorumTimeout": "2s"
+    "quorum": {
+      "enabled": false,
+      "groups": {},
+      "timeout": "2s"
+    }
   },
   "tipsel": {
     "maxDeltaMsgYoungestConeRootIndexToCMI": 2,

--- a/config_devnet.json
+++ b/config_devnet.json
@@ -99,7 +99,9 @@
     "signing": {
       "provider": "local",
       "remoteAddress": "localhost:12345"
-    }
+    },
+    "quorum": {},
+    "quorumTimeout": "2s"
   },
   "tipsel": {
     "maxDeltaMsgYoungestConeRootIndexToCMI": 8,

--- a/config_devnet.json
+++ b/config_devnet.json
@@ -100,8 +100,11 @@
       "provider": "local",
       "remoteAddress": "localhost:12345"
     },
-    "quorum": {},
-    "quorumTimeout": "2s"
+    "quorum": {
+      "enabled": false,
+      "groups": {},
+      "timeout": "2s"
+    }
   },
   "tipsel": {
     "maxDeltaMsgYoungestConeRootIndexToCMI": 8,

--- a/core/gracefulshutdown/core.go
+++ b/core/gracefulshutdown/core.go
@@ -50,7 +50,7 @@ func configure() {
 		case <-gracefulStop:
 			log.Warnf("Received shutdown request - waiting (max %d seconds) to finish processing ...", waitToKillTimeInSeconds)
 		case msg := <-nodeSelfShutdown:
-			log.Warnf("Node self-shutdown: %s ;waiting (max %d seconds) to finish processing ...", msg, waitToKillTimeInSeconds)
+			log.Warnf("Node self-shutdown: %s; waiting (max %d seconds) to finish processing ...", msg, waitToKillTimeInSeconds)
 		}
 
 		go func() {

--- a/go.sum
+++ b/go.sum
@@ -387,8 +387,6 @@ github.com/iotaledger/iota.go v1.0.0-beta.15.0.20210120184258-7eac7c1cc80b/go.mo
 github.com/iotaledger/iota.go v1.0.0-beta.15.0.20210212090247-51c40bcebea7 h1:DIVriS1iEEOPrYwQ/vpHLsnVtmUpj4S+2UI4Jl+48ZQ=
 github.com/iotaledger/iota.go v1.0.0-beta.15.0.20210212090247-51c40bcebea7/go.mod h1:RiKYwDyY7aCD1L0YRzHSjOsJ5mUR9yvQpvhZncNcGQI=
 github.com/iotaledger/iota.go/v2 v2.0.0-20210131170834-4209e58f134b/go.mod h1:eW6gagdKBm9cNMEUbLz9I+rIdsJdGWV3M26Ihdm47v0=
-github.com/iotaledger/iota.go/v2 v2.0.0-20210218145050-36683a2a177c h1:A4NUt8BeOhOay24xXlLZS6fjK8Hv4WHZEtt+GrXXgbE=
-github.com/iotaledger/iota.go/v2 v2.0.0-20210218145050-36683a2a177c/go.mod h1:W6ma7/TCwGO9s3+OX9c0AES4vc4/3PhoDuROXFUBqRE=
 github.com/iotaledger/iota.go/v2 v2.0.0-20210301150403-555f6dae0fe0 h1:tniwjetmqmmUelWWmszq0Fr68GMpXVaOQdY3365pppk=
 github.com/iotaledger/iota.go/v2 v2.0.0-20210301150403-555f6dae0fe0/go.mod h1:W6ma7/TCwGO9s3+OX9c0AES4vc4/3PhoDuROXFUBqRE=
 github.com/ipfs/go-cid v0.0.1/go.mod h1:GHWU/WuQdMPmIosc4Yn1bcCT7dSeX4lBafM7iqUPQvM=

--- a/integration-tests/tester/framework/autopeered_network.go
+++ b/integration-tests/tester/framework/autopeered_network.go
@@ -26,7 +26,7 @@ func (n *AutopeeredNetwork) AwaitPeering(minimumPeers int) error {
 	for i := autopeeringMaxTries; i > 0; i-- {
 
 		for _, p := range n.Nodes {
-			peersResponse, err := p.NodeAPIClient.Peers()
+			peersResponse, err := p.DebugNodeAPIClient.Peers()
 			if err != nil {
 				log.Printf("request error: %v\n", err)
 				continue

--- a/integration-tests/tester/framework/debug_web_api_client.go
+++ b/integration-tests/tester/framework/debug_web_api_client.go
@@ -1,142 +1,22 @@
 package framework
 
 import (
-	"bytes"
-	"encoding/json"
-	"fmt"
-	"io"
-	"io/ioutil"
-	"net/http"
-
-	"github.com/pkg/errors"
+	iotago "github.com/iotaledger/iota.go/v2"
 )
 
-var (
-	// ErrBadRequest defines the "bad request" error.
-	ErrBadRequest = errors.New("bad request")
-	// ErrInternalServerError defines the "internal server error" error.
-	ErrInternalServerError = errors.New("internal server error")
-	// ErrNotFound defines the "not found" error.
-	ErrNotFound = errors.New("not found")
-	// ErrUnauthorized defines the "unauthorized" error.
-	ErrUnauthorized = errors.New("unauthorized")
-	// ErrUnknownError defines the "unknown error" error.
-	ErrUnknownError = errors.New("unknown error")
-	// ErrNotImplemented defines the "operation not implemented/supported/available" error.
-	ErrNotImplemented = errors.New("operation not implemented/supported/available")
-)
-
-const (
-	contentTypeJSON = "application/json"
-)
-
-// NewDebugNodeAPI returns a new debug node API instance.
-func NewDebugNodeAPI(baseURL string, httpClient ...http.Client) *DebugNodeAPI {
-	if len(httpClient) > 0 {
-		return &DebugNodeAPI{baseURL: baseURL, httpClient: httpClient[0]}
-	}
-	return &DebugNodeAPI{baseURL: baseURL}
+// NewDebugNodeAPIClient returns a new debug node API instance.
+func NewDebugNodeAPIClient(baseURL string, opts ...iotago.NodeAPIClientOption) *DebugNodeAPIClient {
+	return &DebugNodeAPIClient{NodeAPIClient: iotago.NewNodeAPIClient(baseURL, opts...)}
 }
 
-// DebugNodeAPI is an API wrapper over the debug node API.
-type DebugNodeAPI struct {
-	httpClient http.Client
-	baseURL    string
-}
-
-// HTTPErrorResponse defines the error struct for the HTTPErrorResponseEnvelope.
-type HTTPErrorResponse struct {
-	Code    string `json:"code"`
-	Message string `json:"message"`
-}
-
-// HTTPErrorResponseEnvelope defines the error response schema for node API responses.
-type HTTPErrorResponseEnvelope struct {
-	Error HTTPErrorResponse `json:"error"`
-}
-
-// HTTPOkResponseEnvelope defines the ok response schema for node API responses.
-type HTTPOkResponseEnvelope struct {
-	// The response is encapsulated in the Data field.
-	Data interface{} `json:"data"`
-}
-
-func interpretBody(res *http.Response, decodeTo interface{}) error {
-	resBody, err := ioutil.ReadAll(res.Body)
-	if err != nil {
-		return fmt.Errorf("unable to read response body: %w", err)
-	}
-	defer res.Body.Close()
-
-	if res.StatusCode == http.StatusOK || res.StatusCode == http.StatusCreated {
-		return json.Unmarshal(resBody, decodeTo)
-	}
-
-	errRes := &HTTPErrorResponseEnvelope{}
-	if err := json.Unmarshal(resBody, errRes); err != nil {
-		return fmt.Errorf("unable to read error from response body: %w", err)
-	}
-
-	switch res.StatusCode {
-	case http.StatusInternalServerError:
-		return fmt.Errorf("%w: %s", ErrInternalServerError, errRes.Error)
-	case http.StatusNotFound:
-		return fmt.Errorf("%w: %s", ErrNotFound, res.Request.URL.String())
-	case http.StatusBadRequest:
-		return fmt.Errorf("%w: %s", ErrBadRequest, errRes.Error)
-	case http.StatusUnauthorized:
-		return fmt.Errorf("%w: %s", ErrUnauthorized, errRes.Error)
-	case http.StatusNotImplemented:
-		return fmt.Errorf("%w: %s", ErrNotImplemented, errRes.Error)
-	}
-
-	return fmt.Errorf("%w: %s", ErrUnknownError, errRes.Error)
-}
-
-func (api *DebugNodeAPI) do(method string, reqObj interface{}, resObj interface{}) error {
-	// marshal request object
-	var data []byte
-	if reqObj != nil {
-		var err error
-		data, err = json.Marshal(reqObj)
-		if err != nil {
-			return err
-		}
-	}
-
-	// construct request
-	req, err := http.NewRequest(method, api.baseURL, func() io.Reader {
-		if data == nil {
-			return nil
-		}
-		return bytes.NewReader(data)
-	}())
-	if err != nil {
-		return err
-	}
-
-	if data != nil {
-		req.Header.Set("Content-Type", contentTypeJSON)
-	}
-
-	// make the request
-	res, err := api.httpClient.Do(req)
-	if err != nil {
-		return err
-	}
-
-	if resObj == nil {
-		return nil
-	}
-
-	// write response into response object
-	if err := interpretBody(res, resObj); err != nil {
-		return err
-	}
-	return nil
+// DebugNodeAPIClient is an API wrapper over the debug node API.
+type DebugNodeAPIClient struct {
+	*iotago.NodeAPIClient
 }
 
 // BaseURL returns the baseURL of the API.
-func (api *DebugNodeAPI) BaseURL() string {
-	return api.baseURL
+func (api *DebugNodeAPIClient) BaseURL() string {
+	return api.NodeAPIClient.BaseURL
 }
+
+// Add debug API endpoints here

--- a/integration-tests/tester/framework/network.go
+++ b/integration-tests/tester/framework/network.go
@@ -55,7 +55,7 @@ func (n *Network) AwaitOnline(ctx context.Context) error {
 			if err := returnErrIfCtxDone(ctx, ErrNodesNotOnlineInTime); err != nil {
 				return err
 			}
-			if _, err := node.NodeAPIClient.Info(); err != nil {
+			if _, err := node.DebugNodeAPIClient.Info(); err != nil {
 				continue
 			}
 			break
@@ -72,7 +72,7 @@ func (n *Network) AwaitAllSync(ctx context.Context) error {
 			if err := returnErrIfCtxDone(ctx, ErrNodesDidNotSyncInTime); err != nil {
 				return err
 			}
-			info, err := node.NodeAPIClient.Info()
+			info, err := node.DebugNodeAPIClient.Info()
 			if err != nil {
 				continue
 			}

--- a/integration-tests/tester/framework/node.go
+++ b/integration-tests/tester/framework/node.go
@@ -22,10 +22,8 @@ type Node struct {
 	Config *NodeConfig
 	// The libp2p identifier of the peer.
 	ID peer.ID
-	// The iota.go web API instance used to communicate with the node.
-	NodeAPIClient *iotago.NodeAPIClient
-	// The more specific web API providing more information for debugging purposes.
-	DebugNodeAPI *DebugNodeAPI
+	// The iota.go web API instance with additional information used to communicate with the node.
+	DebugNodeAPIClient *DebugNodeAPIClient
 	// The profiler instance.
 	Profiler
 	// The DockerContainer that this peer is running in
@@ -43,8 +41,7 @@ func newNode(name string, id peer.ID, cfg *NodeConfig, dockerContainer *DockerCo
 		return nil, err
 	}
 
-	nodeAPI := iotago.NewNodeAPIClient(getNodeAPIBaseURL(ip))
-	debugNodeAPI := NewDebugNodeAPI(getNodeAPIBaseURL(ip))
+	debugNodeAPI := NewDebugNodeAPIClient(getNodeAPIBaseURL(ip))
 
 	return &Node{
 		Name: name,
@@ -56,12 +53,11 @@ func newNode(name string, id peer.ID, cfg *NodeConfig, dockerContainer *DockerCo
 				Timeout: 2 * time.Minute,
 			},
 		},
-		IP:              ip,
-		Config:          cfg,
-		ID:              id,
-		NodeAPIClient:   nodeAPI,
-		DebugNodeAPI:    debugNodeAPI,
-		DockerContainer: dockerContainer,
+		IP:                 ip,
+		Config:             cfg,
+		ID:                 id,
+		DebugNodeAPIClient: debugNodeAPI,
+		DockerContainer:    dockerContainer,
 	}, nil
 }
 
@@ -112,7 +108,7 @@ func (p *Node) Spam(dur time.Duration, parallelism int) (int32, error) {
 					Data:  []byte(data)},
 				}
 
-				if _, err := p.NodeAPIClient.SubmitMessage(iotaMsg); err != nil {
+				if _, err := p.DebugNodeAPIClient.SubmitMessage(iotaMsg); err != nil {
 					spamErr = err
 					return
 				}

--- a/integration-tests/tester/framework/static_network.go
+++ b/integration-tests/tester/framework/static_network.go
@@ -84,7 +84,7 @@ func (n *StaticNetwork) ConnectNodes() error {
 			multiAddress := fmt.Sprintf("/ip4/%s/tcp/15600/p2p/%s", peer.IP, peer.ID.String())
 			n.layout[i][peerIndex] = true
 			n.layout[peerIndex][i] = true
-			if _, err := node.NodeAPIClient.AddPeer(multiAddress); err != nil {
+			if _, err := node.DebugNodeAPIClient.AddPeer(multiAddress); err != nil {
 				return fmt.Errorf("%w: couldn't add peer %v", err, multiAddress)
 			}
 			log.Printf("connected %s (%s) with %s (%s)", node.IP, node.ID.String(), peer.IP, peer.ID.String())
@@ -114,7 +114,7 @@ func (n *StaticNetwork) AwaitPeering(ctx context.Context) error {
 				return fmt.Errorf("not enough nodes: %d", len(n.Nodes))
 			}
 
-			peers, err := node.NodeAPIClient.Peers()
+			peers, err := node.DebugNodeAPIClient.Peers()
 			if err != nil {
 				log.Println(fmt.Sprintf("node %s, peering: %s", node.ID.String(), err))
 				continue

--- a/integration-tests/tester/tests/autopeering/network_split_test.go
+++ b/integration-tests/tester/tests/autopeering/network_split_test.go
@@ -22,7 +22,7 @@ func TestNetworkSplit(t *testing.T) {
 	// test that nodes only have peers from same partition
 	for _, partition := range n.Partitions() {
 		for _, peer := range partition.Peers() {
-			peers, err := peer.NodeAPIClient.Peers()
+			peers, err := peer.DebugNodeAPIClient.Peers()
 			require.NoError(t, err)
 			require.Len(t, peers, 2, "should only be connected to %d peers", 2)
 

--- a/integration-tests/tester/tests/migration/migration_test.go
+++ b/integration-tests/tester/tests/migration/migration_test.go
@@ -68,7 +68,7 @@ func TestMigration(t *testing.T) {
 	// eventually all migrations should have happened
 	log.Println("waiting for treasury to be reduced to correct amount after migrations...")
 	require.Eventually(t, func() bool {
-		treasury, err := n.Coordinator().NodeAPIClient.Treasury()
+		treasury, err := n.Coordinator().DebugNodeAPIClient.Treasury()
 		if err != nil {
 			return false
 		}
@@ -77,7 +77,7 @@ func TestMigration(t *testing.T) {
 
 	// checking that funds were migrated in appropriate receipts
 	log.Println("checking receipts...")
-	receiptTuples, err := n.Coordinator().NodeAPIClient.Receipts()
+	receiptTuples, err := n.Coordinator().DebugNodeAPIClient.Receipts()
 	require.NoError(t, err)
 
 	require.Len(t, receiptTuples, 3, "expected 3 receipts in total")
@@ -101,7 +101,7 @@ func TestMigration(t *testing.T) {
 	// check that indeed the funds were correctly minted
 	log.Println("checking that migrated funds are available...")
 	for addr, tuple := range migrations {
-		balance, err := n.Coordinator().NodeAPIClient.BalanceByEd25519Address(addr)
+		balance, err := n.Coordinator().DebugNodeAPIClient.BalanceByEd25519Address(addr)
 		require.NoError(t, err)
 		require.EqualValues(t, tuple.amount, balance.Balance)
 	}

--- a/integration-tests/tester/tests/snapshot/snapshot_test.go
+++ b/integration-tests/tester/tests/snapshot/snapshot_test.go
@@ -43,7 +43,7 @@ func TestSnapshot(t *testing.T) {
 	// check that on each node, the total supply is on an output with ID 999..
 	for _, node := range n.Nodes {
 		require.Eventually(t, func() bool {
-			res, err := node.NodeAPIClient.OutputByID(targetOutputID)
+			res, err := node.DebugNodeAPIClient.OutputByID(targetOutputID)
 			if err != nil {
 				return false
 			}
@@ -58,7 +58,7 @@ func TestSnapshot(t *testing.T) {
 	// check that the treasury output contains total supply - 40'000'000
 	for _, node := range n.Nodes {
 		require.Eventually(t, func() bool {
-			res, err := node.NodeAPIClient.Treasury()
+			res, err := node.DebugNodeAPIClient.Treasury()
 			if err != nil {
 				log.Println(err)
 				return false

--- a/integration-tests/tester/tests/value/value_test.go
+++ b/integration-tests/tester/tests/value/value_test.go
@@ -61,7 +61,7 @@ func TestValue(t *testing.T) {
 
 	// broadcast to a node
 	log.Println("submitting transaction...")
-	submittedMsg, err := n.Nodes[0].NodeAPIClient.SubmitMessage(msg)
+	submittedMsg, err := n.Nodes[0].DebugNodeAPIClient.SubmitMessage(msg)
 	require.NoError(t, err)
 
 	// eventually the message should be confirmed
@@ -70,7 +70,7 @@ func TestValue(t *testing.T) {
 
 	log.Println("checking that the transaction gets confirmed...")
 	require.Eventually(t, func() bool {
-		msgMeta, err := n.Coordinator().NodeAPIClient.MessageMetadataByMessageID(*submittedMsgID)
+		msgMeta, err := n.Coordinator().DebugNodeAPIClient.MessageMetadataByMessageID(*submittedMsgID)
 		if err != nil {
 			return false
 		}
@@ -81,20 +81,20 @@ func TestValue(t *testing.T) {
 	}, 30*time.Second, 100*time.Millisecond)
 
 	// check that indeed the balances are available
-	res, err := n.Coordinator().NodeAPIClient.BalanceByEd25519Address(framework.GenesisAddress.String())
+	res, err := n.Coordinator().DebugNodeAPIClient.BalanceByEd25519Address(framework.GenesisAddress.String())
 	require.NoError(t, err)
 	require.Zero(t, res.Balance)
 
-	res, err = n.Coordinator().NodeAPIClient.BalanceByEd25519Address(target1Addr.String())
+	res, err = n.Coordinator().DebugNodeAPIClient.BalanceByEd25519Address(target1Addr.String())
 	require.NoError(t, err)
 	require.EqualValues(t, target1Deposit, res.Balance)
 
-	res, err = n.Coordinator().NodeAPIClient.BalanceByEd25519Address(target2Addr.String())
+	res, err = n.Coordinator().DebugNodeAPIClient.BalanceByEd25519Address(target2Addr.String())
 	require.NoError(t, err)
 	require.EqualValues(t, target2Deposit, res.Balance)
 
 	// the genesis output should be spent
-	outputRes, err := n.Coordinator().NodeAPIClient.OutputByID(genesisInputID.ID())
+	outputRes, err := n.Coordinator().DebugNodeAPIClient.OutputByID(genesisInputID.ID())
 	require.NoError(t, err)
 	require.True(t, outputRes.Spent)
 }

--- a/pkg/model/coordinator/coordinator.go
+++ b/pkg/model/coordinator/coordinator.go
@@ -40,6 +40,9 @@ var (
 	ErrInvalidSiblingsTrytesLength = errors.New("siblings trytes too long")
 )
 
+// The merkle tree root hash of all messages.
+type MerkleTreeHash [iotago.MilestoneInclusionMerkleProofLength]byte
+
 // Events are the events issued by the coordinator.
 type Events struct {
 	// Fired when a checkpoint message is issued.

--- a/pkg/model/coordinator/coordinator.go
+++ b/pkg/model/coordinator/coordinator.go
@@ -159,8 +159,12 @@ func WithPowWorkerCount(powWorkerCount int) Option {
 
 // WithQuorum defines a quorum, which is used to check the correct ledger state of the coordinator.
 // If no quorumGroups are given, the quorum is disabled.
-func WithQuorum(quorumGroups map[string][]*QuorumClientConfig, timeout time.Duration) Option {
+func WithQuorum(quorumEnabled bool, quorumGroups map[string][]*QuorumClientConfig, timeout time.Duration) Option {
 	return func(opts *Options) {
+		if !quorumEnabled {
+			opts.quorum = nil
+			return
+		}
 		opts.quorum = newQuorum(quorumGroups, timeout)
 	}
 }

--- a/pkg/model/coordinator/debug_node_api.go
+++ b/pkg/model/coordinator/debug_node_api.go
@@ -1,0 +1,70 @@
+package coordinator
+
+import (
+	"encoding/hex"
+	"fmt"
+	"net/http"
+
+	iotago "github.com/iotaledger/iota.go/v2"
+
+	"github.com/gohornet/hornet/pkg/model/hornet"
+	"github.com/gohornet/hornet/pkg/model/milestone"
+)
+
+const (
+	// NodeAPIRouteDebugComputeWhiteFlag is the debug route to compute the white flag confirmation for the cone of the given parents.
+	// POST computes the white flag confirmation.
+	NodeAPIRouteDebugComputeWhiteFlag = "/api/plugins/debug/whiteflag"
+)
+
+// NewDebugNodeAPIClient returns a new DebugNodeAPIClient with the given BaseURL.
+func NewDebugNodeAPIClient(baseURL string, opts ...iotago.NodeAPIClientOption) *DebugNodeAPIClient {
+	return &DebugNodeAPIClient{NodeAPIClient: iotago.NewNodeAPIClient(baseURL, opts...)}
+}
+
+// DebugNodeAPIClient is a client for node HTTP REST APIs.
+type DebugNodeAPIClient struct {
+	*iotago.NodeAPIClient
+}
+
+// computeWhiteFlagMutationsRequest defines the request for a POST debugComputeWhiteFlagMutations REST API call.
+type computeWhiteFlagMutationsRequest struct {
+	// The index of the milestone.
+	Index milestone.Index `json:"index"`
+	// The hex encoded message IDs of the parents the milestone references.
+	Parents []string `json:"parentMessageIds"`
+}
+
+// computeWhiteFlagMutationsRequest defines the response for a POST debugComputeWhiteFlagMutations REST API call.
+type computeWhiteFlagMutationsResponse struct {
+	// The hex encoded merkle tree hash as a result of the white flag computation.
+	MerkleTreeHash string `json:"merkleTreeHash"`
+}
+
+// Whiteflag is the debug route to compute the white flag confirmation for the cone of the given parents.
+// This function returns the merkle tree hash calculated by the node.
+func (api *DebugNodeAPIClient) Whiteflag(index milestone.Index, parents hornet.MessageIDs) (*MerkleTreeHash, error) {
+
+	req := &computeWhiteFlagMutationsRequest{
+		Index:   index,
+		Parents: parents.ToHex(),
+	}
+	res := &computeWhiteFlagMutationsResponse{}
+
+	if _, err := api.Do(http.MethodPost, NodeAPIRouteDebugComputeWhiteFlag, req, res); err != nil {
+		return nil, err
+	}
+
+	merkleTreeHashBytes, err := hex.DecodeString(res.MerkleTreeHash)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(merkleTreeHashBytes) != iotago.MilestoneInclusionMerkleProofLength {
+		return nil, fmt.Errorf("unknown merkle tree hash length (%d)", len(merkleTreeHashBytes))
+	}
+
+	var merkleTreeHash MerkleTreeHash
+	copy(merkleTreeHash[:], merkleTreeHashBytes)
+	return &merkleTreeHash, nil
+}

--- a/pkg/model/coordinator/quorum.go
+++ b/pkg/model/coordinator/quorum.go
@@ -1,0 +1,235 @@
+package coordinator
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"sync"
+	"time"
+
+	"github.com/pkg/errors"
+
+	"github.com/gohornet/hornet/pkg/common"
+	"github.com/gohornet/hornet/pkg/model/hornet"
+	"github.com/gohornet/hornet/pkg/model/milestone"
+	"github.com/iotaledger/hive.go/syncutils"
+	iotago "github.com/iotaledger/iota.go/v2"
+)
+
+var (
+	// ErrQuorumMerkleTreeHashMismatch is fired when a client in the quorum returns a different merkle tree hash.
+	ErrQuorumMerkleTreeHashMismatch = errors.New("coordinator quorum merkle tree hash mismatch")
+	// ErrQuorumGroupNoAnswer is fired when none of the clients in a quorum group answers.
+	ErrQuorumGroupNoAnswer = errors.New("coordinator quorum group did not answer in time")
+)
+
+// QuorumClientConfig holds the configuration of a quorum client.
+type QuorumClientConfig struct {
+	// optional alias of the quorum client.
+	Alias string `json:"alias" koanf:"alias"`
+	// baseURL of the quorum client.
+	BaseURL string `json:"baseURL" koanf:"baseURL"`
+	// optional username for basic auth.
+	UserName string `json:"userName" koanf:"userName"`
+	// optional password for basic auth.
+	Password string `json:"password" koanf:"password"`
+}
+
+// QuorumClientStatistic holds statistics of a quorum client.
+type QuorumClientStatistic struct {
+	// name of the quorum group the client is member of.
+	Group string
+	// optional alias of the quorum client.
+	Alias string
+	// baseURL of the quorum client.
+	BaseURL string
+	// last response time of the whiteflag API call.
+	ResponseTimeMs int64
+	// error of last whiteflag API call.
+	Error error
+	// number of all encountered errors of this quorum client.
+	ErrorCounter int64
+}
+
+// quorumGroupEntry holds the api and statistics of a quorum client.
+type quorumGroupEntry struct {
+	api   *DebugNodeAPIClient
+	stats *QuorumClientStatistic
+}
+
+// quorum is used to check the correct ledger state of the coordinator.
+type quorum struct {
+	// the different groups of the quorum.
+	Groups map[string][]*quorumGroupEntry
+	// the maximim timeout of a quorum request.
+	Timeout time.Duration
+
+	quorumStatsLock syncutils.RWMutex
+}
+
+// newQuorum creates a new quorum, which is used to check the correct ledger state of the coordinator.
+// If no groups are given, nil is returned.
+func newQuorum(quorumGroups map[string][]*QuorumClientConfig, timeout time.Duration) *quorum {
+	if len(quorumGroups) == 0 {
+		// coordinator quorum is disabled
+		return nil
+	}
+
+	groups := make(map[string][]*quorumGroupEntry)
+	for groupName, groupNodes := range quorumGroups {
+		if len(groupNodes) == 0 {
+			panic(fmt.Sprintf("invalid coo quorum group: %s, no nodes given", groupName))
+		}
+
+		groups[groupName] = make([]*quorumGroupEntry, len(groupNodes))
+		for i, client := range groupNodes {
+			var userInfo *url.Userinfo
+			if client.UserName != "" || client.Password != "" {
+				userInfo = url.UserPassword(client.UserName, client.Password)
+			}
+
+			groups[groupName][i] = &quorumGroupEntry{
+				api: NewDebugNodeAPIClient(client.BaseURL,
+					iotago.WithNodeAPIClientHTTPClient(&http.Client{Timeout: timeout}),
+					iotago.WithNodeAPIClientUserInfo(userInfo),
+				),
+				stats: &QuorumClientStatistic{
+					Group:   groupName,
+					Alias:   client.Alias,
+					BaseURL: client.BaseURL,
+				},
+			}
+		}
+	}
+
+	return &quorum{
+		Groups:  groups,
+		Timeout: timeout,
+	}
+}
+
+// checkMerkleTreeHashQuorumGroup asks all nodes in a quorum group for their merkle tree hash based on the given parents.
+// Returns non-critical and critical errors.
+// If no node of the group answers, a non-critical error is returned.
+// If one of the nodes returns a different hash, a critical error is returned.
+func (q *quorum) checkMerkleTreeHashQuorumGroup(cooMerkleTreeHash MerkleTreeHash, quorumGroup []*quorumGroupEntry, wg *sync.WaitGroup, quorumDoneChan chan struct{}, quorumErrChan chan error, index milestone.Index, parents hornet.MessageIDs) {
+	// mark the group as done at the end
+	defer wg.Done()
+
+	// cancel the quorum after a certain timeout
+	ctx, cancel := context.WithTimeout(context.Background(), q.Timeout)
+	defer cancel()
+
+	nodeResultChan := make(chan MerkleTreeHash)
+	defer close(nodeResultChan)
+
+	nodeErrorChan := make(chan error)
+	defer close(nodeErrorChan)
+
+	for _, entry := range quorumGroup {
+		go func(entry *quorumGroupEntry, nodeResultChan chan MerkleTreeHash, nodeErrorChan chan error) {
+			ts := time.Now()
+
+			nodeMerkleTreeHash, err := entry.api.Whiteflag(index, parents)
+
+			// set the stats for the node
+			entry.stats.ResponseTimeMs = time.Since(ts).Milliseconds()
+			entry.stats.Error = err
+
+			if err != nil {
+				entry.stats.ErrorCounter++
+				nodeErrorChan <- err
+				return
+			}
+			nodeResultChan <- *nodeMerkleTreeHash
+		}(entry, nodeResultChan, nodeErrorChan)
+	}
+
+	validResults := 0
+QuorumLoop:
+	for i := 0; i < len(quorumGroup); i++ {
+		// we wait either until the channel got closed or the context is done
+		select {
+		case <-quorumDoneChan:
+			// quorum was aborted
+			return
+
+		case <-nodeErrorChan:
+			// ignore errors of single nodes
+			continue
+
+		case nodeMerkleTreeHash := <-nodeResultChan:
+			if cooMerkleTreeHash != nodeMerkleTreeHash {
+				// mismatch of the merkle tree hash of the node => critical error
+				quorumErrChan <- common.CriticalError{Err: ErrQuorumMerkleTreeHashMismatch}
+				return
+			}
+			validResults++
+
+		case <-ctx.Done():
+			// quorum timeout reached
+			break QuorumLoop
+		}
+	}
+
+	if validResults == 0 {
+		// no node of the group answered, return a non-critical error.
+		quorumErrChan <- common.SoftError{Err: ErrQuorumGroupNoAnswer}
+	}
+}
+
+// checkMerkleTreeHash asks all nodes in the quorum for their merkle tree hash based on the given parents.
+// Returns non-critical and critical errors.
+// If no node of a certain group answers, a non-critical error is returned.
+// If one of the nodes returns a different hash, a critical error is returned.
+func (q *quorum) checkMerkleTreeHash(cooMerkleTreeHash MerkleTreeHash, index milestone.Index, parents hornet.MessageIDs) error {
+	q.quorumStatsLock.Lock()
+	defer q.quorumStatsLock.Unlock()
+
+	wg := &sync.WaitGroup{}
+	quorumDoneChan := make(chan struct{})
+	quorumErrChan := make(chan error)
+
+	for _, quorumGroup := range q.Groups {
+		wg.Add(1)
+
+		// ask all groups in parallel
+		go q.checkMerkleTreeHashQuorumGroup(cooMerkleTreeHash, quorumGroup, wg, quorumDoneChan, quorumErrChan, index, parents)
+	}
+
+	go func(wg *sync.WaitGroup, doneChan chan struct{}) {
+		// wait for all groups to be finished
+		wg.Wait()
+
+		// signal that all groups are finished
+		close(doneChan)
+	}(wg, quorumDoneChan)
+
+	select {
+	case <-quorumDoneChan:
+		// quorum finished successfully
+		close(quorumErrChan)
+		return nil
+
+	case err := <-quorumErrChan:
+		// quorum encountered an error
+		return err
+	}
+}
+
+// quorumStatsSnapshot returns a snapshot of the statistics about the response time and errors of every node in the quorum.
+func (q *quorum) quorumStatsSnapshot() []QuorumClientStatistic {
+	q.quorumStatsLock.RLock()
+	defer q.quorumStatsLock.RUnlock()
+
+	var stats []QuorumClientStatistic
+
+	for _, quorumGroup := range q.Groups {
+		for _, entry := range quorumGroup {
+			stats = append(stats, *entry.stats)
+		}
+	}
+
+	return stats
+}

--- a/pkg/model/coordinator/quorum.go
+++ b/pkg/model/coordinator/quorum.go
@@ -72,8 +72,7 @@ type quorum struct {
 // If no groups are given, nil is returned.
 func newQuorum(quorumGroups map[string][]*QuorumClientConfig, timeout time.Duration) *quorum {
 	if len(quorumGroups) == 0 {
-		// coordinator quorum is disabled
-		return nil
+		panic("coordinator quorum groups not found")
 	}
 
 	groups := make(map[string][]*quorumGroupEntry)

--- a/pkg/tangle/solidifier.go
+++ b/pkg/tangle/solidifier.go
@@ -386,7 +386,7 @@ func (t *Tangle) solidifyMilestone(newMilestoneIndex milestone.Index, force bool
 			if t.receiptService != nil {
 				if t.receiptService.ValidationEnabled {
 					if err := t.receiptService.Validate(rt.Receipt); err != nil {
-						var softErr *common.SoftError
+						var softErr common.SoftError
 						switch {
 						case errors.As(err, &softErr):
 							if !t.receiptService.IgnoreSoftErrors {

--- a/pkg/testsuite/coordinator.go
+++ b/pkg/testsuite/coordinator.go
@@ -39,7 +39,17 @@ func (te *TestEnvironment) configureCoordinator(cooPrivateKeys []ed25519.Private
 
 	inMemoryEd25519MilestoneSignerProvider := coordinator.NewInMemoryEd25519MilestoneSignerProvider(cooPrivateKeys, keyManager, len(cooPrivateKeys))
 
-	coo, err := coordinator.New(te.storage, te.networkID, inMemoryEd25519MilestoneSignerProvider, fmt.Sprintf("%s/coordinator.state", te.tempDir), 10*time.Second, 1, te.PowHandler, nil, nil, storeMessageFunc)
+	coo, err := coordinator.New(
+		te.storage,
+		te.networkID,
+		inMemoryEd25519MilestoneSignerProvider,
+		nil,
+		nil,
+		te.PowHandler,
+		storeMessageFunc,
+		coordinator.WithStateFilePath(fmt.Sprintf("%s/coordinator.state", te.tempDir)),
+		coordinator.WithMilestoneInterval(time.Duration(10)*time.Second),
+	)
 	require.NoError(te.TestState, err)
 	require.NotNil(te.TestState, coo)
 	te.coo = coo

--- a/pkg/testsuite/coordinator.go
+++ b/pkg/testsuite/coordinator.go
@@ -104,9 +104,8 @@ func (te *TestEnvironment) IssueAndConfirmMilestoneOnTip(tip hornet.MessageID, c
 
 	fmt.Printf("Issue milestone %v\n", currentIndex+1)
 
-	milestoneMessageID, noncriticalErr, criticalErr := te.coo.IssueMilestone(hornet.MessageIDs{te.lastMilestoneMessageID, tip})
-	require.NoError(te.TestState, noncriticalErr)
-	require.NoError(te.TestState, criticalErr)
+	milestoneMessageID, err := te.coo.IssueMilestone(hornet.MessageIDs{te.lastMilestoneMessageID, tip})
+	require.NoError(te.TestState, err)
 	te.lastMilestoneMessageID = milestoneMessageID
 
 	te.VerifyLMI(currentIndex + 1)

--- a/plugins/coordinator/params.go
+++ b/plugins/coordinator/params.go
@@ -20,10 +20,12 @@ const (
 	CfgCoordinatorSigningRemoteAddress = "coordinator.signing.remoteAddress"
 	// the amount of workers used for calculating PoW when issuing checkpoints and milestones
 	CfgCoordinatorPoWWorkerCount = "coordinator.powWorkerCount"
+	// whether the coordinator quorum is enabled
+	CfgCoordinatorQuorumEnabled = "coordinator.quorum.enabled"
 	// the quorum groups used to ask other nodes for correct ledger state of the coordinator
-	CfgCoordinatorQuorum = "coordinator.quorum"
+	CfgCoordinatorQuorumGroups = "coordinator.quorum.groups"
 	// the timeout until a node in the quorum must have answered
-	CfgCoordinatorQuorumTimeout = "coordinator.quorumTimeout"
+	CfgCoordinatorQuorumTimeout = "coordinator.quorum.timeout"
 	// the maximum amount of known messages for milestone tipselection
 	// if this limit is exceeded, a new checkpoint is issued
 	CfgCoordinatorCheckpointsMaxTrackedMessages = "coordinator.checkpoints.maxTrackedMessages"
@@ -49,6 +51,7 @@ var params = &node.PluginParams{
 			fs.String(CfgCoordinatorSigningProvider, "local", "the signing provider the coordinator uses to sign a milestone (local/remote)")
 			fs.String(CfgCoordinatorSigningRemoteAddress, "localhost:12345", "the address of the remote signing provider (insecure connection!)")
 			fs.Int(CfgCoordinatorPoWWorkerCount, runtime.NumCPU()-1, "the amount of workers used for calculating PoW when issuing checkpoints and milestones")
+			fs.Bool(CfgCoordinatorQuorumEnabled, false, "whether the coordinator quorum is enabled")
 			fs.Duration(CfgCoordinatorQuorumTimeout, 2*time.Second, "the timeout until a node in the quorum must have answered")
 			fs.Int(CfgCoordinatorCheckpointsMaxTrackedMessages, 10000, "maximum amount of known messages for milestone tipselection")
 			fs.Int(CfgCoordinatorTipselectMinHeaviestBranchUnreferencedMessagesThreshold, 20, "minimum threshold of unreferenced messages in the heaviest branch")

--- a/plugins/coordinator/params.go
+++ b/plugins/coordinator/params.go
@@ -20,6 +20,10 @@ const (
 	CfgCoordinatorSigningRemoteAddress = "coordinator.signing.remoteAddress"
 	// the amount of workers used for calculating PoW when issuing checkpoints and milestones
 	CfgCoordinatorPoWWorkerCount = "coordinator.powWorkerCount"
+	// the quorum groups used to ask other nodes for correct ledger state of the coordinator
+	CfgCoordinatorQuorum = "coordinator.quorum"
+	// the timeout until a node in the quorum must have answered
+	CfgCoordinatorQuorumTimeout = "coordinator.quorumTimeout"
 	// the maximum amount of known messages for milestone tipselection
 	// if this limit is exceeded, a new checkpoint is issued
 	CfgCoordinatorCheckpointsMaxTrackedMessages = "coordinator.checkpoints.maxTrackedMessages"
@@ -45,6 +49,7 @@ var params = &node.PluginParams{
 			fs.String(CfgCoordinatorSigningProvider, "local", "the signing provider the coordinator uses to sign a milestone (local/remote)")
 			fs.String(CfgCoordinatorSigningRemoteAddress, "localhost:12345", "the address of the remote signing provider (insecure connection!)")
 			fs.Int(CfgCoordinatorPoWWorkerCount, runtime.NumCPU()-1, "the amount of workers used for calculating PoW when issuing checkpoints and milestones")
+			fs.Duration(CfgCoordinatorQuorumTimeout, 2*time.Second, "the timeout until a node in the quorum must have answered")
 			fs.Int(CfgCoordinatorCheckpointsMaxTrackedMessages, 10000, "maximum amount of known messages for milestone tipselection")
 			fs.Int(CfgCoordinatorTipselectMinHeaviestBranchUnreferencedMessagesThreshold, 20, "minimum threshold of unreferenced messages in the heaviest branch")
 			fs.Int(CfgCoordinatorTipselectMaxHeaviestBranchTipsPerCheckpoint, 10, "maximum amount of checkpoint messages with heaviest branch tips")

--- a/plugins/coordinator/plugin.go
+++ b/plugins/coordinator/plugin.go
@@ -234,6 +234,7 @@ func initCoordinator(bootstrap bool, startIndex uint32, powHandler *powpackage.H
 		deps.UTXOManager,
 		powHandler,
 		sendMessage,
+		coordinator.WithLogger(log),
 		coordinator.WithStateFilePath(deps.NodeConfig.String(CfgCoordinatorStateFilePath)),
 		coordinator.WithMilestoneInterval(deps.NodeConfig.Duration(CfgCoordinatorInterval)),
 		coordinator.WithPowWorkerCount(deps.NodeConfig.Int(CfgCoordinatorPoWWorkerCount)),
@@ -241,6 +242,10 @@ func initCoordinator(bootstrap bool, startIndex uint32, powHandler *powpackage.H
 	)
 	if err != nil {
 		return nil, err
+	}
+
+	if deps.NodeConfig.Bool(CfgCoordinatorQuorumEnabled) {
+		log.Info("coordinator is running with enabled quorum")
 	}
 
 	if err := coo.InitState(bootstrap, milestone.Index(startIndex)); err != nil {

--- a/plugins/coordinator/plugin.go
+++ b/plugins/coordinator/plugin.go
@@ -205,8 +205,8 @@ func initCoordinator(bootstrap bool, startIndex uint32, powHandler *powpackage.H
 
 	// parse quorum groups config
 	quorumGroups := make(map[string][]*coordinator.QuorumClientConfig)
-	for _, groupName := range deps.NodeConfig.MapKeys(CfgCoordinatorQuorum) {
-		configKey := CfgCoordinatorQuorum + "." + groupName
+	for _, groupName := range deps.NodeConfig.MapKeys(CfgCoordinatorQuorumGroups) {
+		configKey := CfgCoordinatorQuorumGroups + "." + groupName
 
 		groupConfig := []*coordinator.QuorumClientConfig{}
 		if err := deps.NodeConfig.Unmarshal(configKey, &groupConfig); err != nil {
@@ -237,7 +237,7 @@ func initCoordinator(bootstrap bool, startIndex uint32, powHandler *powpackage.H
 		coordinator.WithStateFilePath(deps.NodeConfig.String(CfgCoordinatorStateFilePath)),
 		coordinator.WithMilestoneInterval(deps.NodeConfig.Duration(CfgCoordinatorInterval)),
 		coordinator.WithPowWorkerCount(deps.NodeConfig.Int(CfgCoordinatorPoWWorkerCount)),
-		coordinator.WithQuorum(quorumGroups, deps.NodeConfig.Duration(CfgCoordinatorQuorumTimeout)),
+		coordinator.WithQuorum(deps.NodeConfig.Bool(CfgCoordinatorQuorumEnabled), quorumGroups, deps.NodeConfig.Duration(CfgCoordinatorQuorumTimeout)),
 	)
 	if err != nil {
 		return nil, err

--- a/plugins/coordinator/plugin.go
+++ b/plugins/coordinator/plugin.go
@@ -172,11 +172,6 @@ func initCoordinator(bootstrap bool, startIndex uint32, powHandler *powpackage.H
 		return nil, fmt.Errorf("unknown milestone signing provider: %s", deps.NodeConfig.String(CfgCoordinatorSigningProvider))
 	}
 
-	powWorkerCount := deps.NodeConfig.Int(CfgCoordinatorPoWWorkerCount)
-	if powWorkerCount < 1 {
-		powWorkerCount = 1
-	}
-
 	if deps.MigratorService == nil {
 		log.Info("running Coordinator without migration enabled")
 	}
@@ -185,13 +180,13 @@ func initCoordinator(bootstrap bool, startIndex uint32, powHandler *powpackage.H
 		deps.Storage,
 		deps.NetworkID,
 		signingProvider,
-		deps.NodeConfig.String(CfgCoordinatorStateFilePath),
-		deps.NodeConfig.Duration(CfgCoordinatorInterval),
-		powWorkerCount,
-		powHandler,
 		deps.MigratorService,
 		deps.UTXOManager,
+		powHandler,
 		sendMessage,
+		coordinator.WithStateFilePath(deps.NodeConfig.String(CfgCoordinatorStateFilePath)),
+		coordinator.WithMilestoneInterval(deps.NodeConfig.Duration(CfgCoordinatorInterval)),
+		coordinator.WithPowWorkerCount(deps.NodeConfig.Int(CfgCoordinatorPoWWorkerCount)),
 	)
 	if err != nil {
 		return nil, err

--- a/plugins/migrator/plugin.go
+++ b/plugins/migrator/plugin.go
@@ -90,8 +90,8 @@ func run() {
 	if err := Plugin.Node.Daemon().BackgroundWorker(Plugin.Name, func(shutdownSignal <-chan struct{}) {
 		log.Infof("Starting %s ... done", Plugin.Name)
 		deps.MigratorService.Start(shutdownSignal, func(err error) bool {
-			var critErr *common.CriticalError
-			var softErr *common.SoftError
+			var critErr common.CriticalError
+			var softErr common.SoftError
 			switch {
 			case errors.As(err, &critErr):
 				gracefulshutdown.SelfShutdown(fmt.Sprintf("migrator plugin hit a critical error: %s", err.Error()))

--- a/plugins/prometheus/coordinator.go
+++ b/plugins/prometheus/coordinator.go
@@ -1,0 +1,70 @@
+package prometheus
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/iotaledger/hive.go/events"
+)
+
+var (
+	coordinatorQuorumResponseTimes *prometheus.GaugeVec
+	coordinatorQuorumErrorCounters *prometheus.GaugeVec
+	coordinatorSoftErrEncountered  prometheus.Counter
+)
+
+func configureCoordinator() {
+	coordinatorQuorumResponseTimes = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "iota_coordinator_quorum_response_times",
+			Help: "Latest response time by quorum client.",
+		},
+		[]string{"group", "alias", "baseURL"},
+	)
+
+	coordinatorQuorumErrorCounters = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "iota_coordinator_quorum_error_counters",
+			Help: "Number encountered errors by quorum client.",
+		},
+		[]string{"group", "alias", "baseURL", "error"},
+	)
+
+	coordinatorSoftErrEncountered = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "iota_coordinator_soft_errors",
+			Help: "The coordinator's encountered soft error count.",
+		},
+	)
+
+	registry.MustRegister(coordinatorQuorumResponseTimes)
+	registry.MustRegister(coordinatorQuorumErrorCounters)
+	registry.MustRegister(coordinatorSoftErrEncountered)
+
+	deps.Coordinator.Events.SoftError.Attach(events.NewClosure(func(_ error) {
+		coordinatorSoftErrEncountered.Inc()
+	}))
+
+	addCollect(collectCoordinatorQuorumStats)
+}
+
+func collectCoordinatorQuorumStats() {
+	coordinatorQuorumResponseTimes.Reset()
+	coordinatorQuorumErrorCounters.Reset()
+
+	for _, entry := range deps.Coordinator.QuorumStats() {
+		labelsResponseTime := prometheus.Labels{
+			"group":   entry.Group,
+			"alias":   entry.Alias,
+			"baseURL": entry.BaseURL,
+		}
+		coordinatorQuorumResponseTimes.With(labelsResponseTime).Set(float64(entry.ResponseTimeMs))
+
+		labelsErrorCounters := prometheus.Labels{
+			"group":   entry.Group,
+			"alias":   entry.Alias,
+			"baseURL": entry.BaseURL,
+			"error":   entry.Error.Error(),
+		}
+		coordinatorQuorumErrorCounters.With(labelsErrorCounters).Set(float64(entry.ErrorCounter))
+	}
+}

--- a/plugins/prometheus/plugin.go
+++ b/plugins/prometheus/plugin.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/gohornet/hornet/pkg/app"
 	"github.com/gohornet/hornet/pkg/metrics"
+	"github.com/gohornet/hornet/pkg/model/coordinator"
 	"github.com/gohornet/hornet/pkg/model/migrator"
 	"github.com/gohornet/hornet/pkg/model/storage"
 	"github.com/gohornet/hornet/pkg/node"
@@ -60,6 +61,7 @@ type dependencies struct {
 	MigratorService *migrator.MigratorService `optional:"true"`
 	Manager         *p2p.Manager
 	RequestQueue    gossip.RequestQueue
+	Coordinator     *coordinator.Coordinator `optional:"true"`
 }
 
 func configure() {
@@ -74,6 +76,9 @@ func configure() {
 	}
 	if deps.MigratorService != nil {
 		configureMigrator()
+	}
+	if deps.Coordinator != nil {
+		configureCoordinator()
 	}
 
 	if deps.NodeConfig.Bool(CfgPrometheusGoMetrics) {


### PR DESCRIPTION
This PR adds an optional quorum to the coordinator.
With the quorum, other nodes can be asked for their perception of the ledger state for the tips the coordinator has chosen, before a milestone is issued.

If the quorum has at least one node that has another perception, the coordinator is shut down for security reason.
If none of the nodes of a quorum groups answered in time, the milestone is not issued.

Statistics about the quorum are issued via prometheus.