### PR TITLE
Fix ReadPassword error on Windows 10

### DIFF
--- a/pkg/toolset/pwdhash.go
+++ b/pkg/toolset/pwdhash.go
@@ -36,13 +36,13 @@ func hashPasswordAndSalt(args []string) error {
 	}()
 
 	fmt.Print("Enter a password: ")
-	password, err := terminal.ReadPassword(0)
+	password, err := terminal.ReadPassword(int(syscall.Stdin))
 	if err != nil {
 		return err
 	}
 
 	fmt.Print("\nRe-enter your password: ")
-	passwordReenter, err := terminal.ReadPassword(0)
+	passwordReenter, err := terminal.ReadPassword(int(syscall.Stdin))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
# Description

ReadPassword(0) fails on Windows 10 with `error: The handle is invalid`, since syscall.Stdin is not always equal to 0 on Windows according to golang/go#11914.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have tested my code extensively
- [x] I have selected the `develop` branch as the target branch
