### PR TITLE
Makes migrator receipt entries count configurable

### DIFF
--- a/integration-tests/tester/framework/config.go
+++ b/integration-tests/tester/framework/config.go
@@ -410,6 +410,8 @@ func DefaultReceiptValidatorConfig() ReceiptsConfig {
 
 // MigratorConfig defines migrator plugin specific configuration.
 type MigratorConfig struct {
+	// The max amount of entries to include in a receipt.
+	MaxEntries int
 	// Whether to run the migrator plugin in bootstrap mode.
 	Bootstrap bool
 	// The index of the first legacy milestone to migrate.
@@ -422,6 +424,7 @@ type MigratorConfig struct {
 func (migConfig *MigratorConfig) CLIFlags() []string {
 	return []string{
 		fmt.Sprintf("--%s=%v", migrator.CfgMigratorBootstrap, migConfig.Bootstrap),
+		fmt.Sprintf("--%s=%v", migrator.CfgMigratorReceiptMaxEntries, migConfig.MaxEntries),
 		fmt.Sprintf("--%s=%d", migrator.CfgMigratorStartIndex, migConfig.StartIndex),
 		fmt.Sprintf("--%s=%s", migrator.CfgMigratorStateFilePath, migConfig.StateFilePath),
 	}
@@ -431,6 +434,7 @@ func (migConfig *MigratorConfig) CLIFlags() []string {
 func DefaultMigratorConfig() MigratorConfig {
 	return MigratorConfig{
 		Bootstrap:     false,
+		MaxEntries:    iotago.MaxMigratedFundsEntryCount,
 		StartIndex:    1,
 		StateFilePath: "migrator.state",
 	}

--- a/pkg/model/migrator/service_test.go
+++ b/pkg/model/migrator/service_test.go
@@ -25,8 +25,7 @@ func init() {
 }
 
 func TestReceiptFull(t *testing.T) {
-	migrator.MaxMigratedFundsEntryCount = len(serviceTests.entries)
-	s, teardown := newTestService(t, 1)
+	s, teardown := newTestService(t, 1, len(serviceTests.entries))
 	defer teardown()
 
 	receipt1 := s.Receipt()
@@ -41,8 +40,7 @@ func TestReceiptFull(t *testing.T) {
 }
 
 func TestReceiptAfterClose(t *testing.T) {
-	migrator.MaxMigratedFundsEntryCount = len(serviceTests.entries)
-	s, teardown := newTestService(t, 1)
+	s, teardown := newTestService(t, 1, len(serviceTests.entries))
 
 	receipt := s.Receipt()
 	require.NotNil(t, receipt)
@@ -52,8 +50,7 @@ func TestReceiptAfterClose(t *testing.T) {
 }
 
 func TestReceiptBatch(t *testing.T) {
-	migrator.MaxMigratedFundsEntryCount = 2
-	s, teardown := newTestService(t, 1)
+	s, teardown := newTestService(t, 1, 2)
 	defer teardown()
 
 	receipt1 := s.Receipt()
@@ -75,8 +72,7 @@ func TestReceiptBatch(t *testing.T) {
 }
 
 func TestRestoreState(t *testing.T) {
-	migrator.MaxMigratedFundsEntryCount = 2
-	s1, teardown1 := newTestService(t, 1)
+	s1, teardown1 := newTestService(t, 1, 2)
 	defer teardown1()
 
 	receipt1 := s1.Receipt()
@@ -89,7 +85,7 @@ func TestRestoreState(t *testing.T) {
 	require.NoError(t, err)
 
 	// initialize state from file
-	s2, teardown2 := newTestService(t, 0)
+	s2, teardown2 := newTestService(t, 0, 2)
 	defer teardown2()
 
 	receipt2 := s2.Receipt()
@@ -99,8 +95,8 @@ func TestRestoreState(t *testing.T) {
 	require.Subset(t, serviceTests.entries, receipt2.Funds)
 }
 
-func newTestService(t *testing.T, msIndex uint32) (*migrator.MigratorService, func()) {
-	s := migrator.NewService(&mockQueryer{}, stateFileName)
+func newTestService(t *testing.T, msIndex uint32, maxEntries int) (*migrator.MigratorService, func()) {
+	s := migrator.NewService(&mockQueryer{}, stateFileName, maxEntries)
 
 	if msIndex > 0 {
 		// bootstrap

--- a/plugins/migrator/params.go
+++ b/plugins/migrator/params.go
@@ -5,12 +5,16 @@ import (
 
 	flag "github.com/spf13/pflag"
 
+	"github.com/gohornet/hornet/pkg/model/migrator"
+
 	"github.com/gohornet/hornet/pkg/node"
 )
 
 const (
 	// CfgMigratorStateFilePath configures the path to the state file of the migrator.
 	CfgMigratorStateFilePath = "migrator.stateFilePath"
+	// CfgMigratorReceiptMaxEntries defines the max amount of entries to embed within a receipt.
+	CfgMigratorReceiptMaxEntries = "migrator.receiptMaxEntries"
 	// CfgMigratorQueryCooldownPeriod configures the cooldown period for the service to ask for new data
 	// from the legacy node in case the migrator encounters an error.
 	CfgMigratorQueryCooldownPeriod = "migrator.queryCooldownPeriod"
@@ -21,6 +25,7 @@ var params = &node.PluginParams{
 		"nodeConfig": func() *flag.FlagSet {
 			fs := flag.NewFlagSet("", flag.ContinueOnError)
 			fs.String(CfgMigratorStateFilePath, "migrator.state", "path to the state file of the migrator")
+			fs.Int(CfgMigratorReceiptMaxEntries, migrator.SensibleMaxEntriesCount, "the max amount of entries to embed within a receipt")
 			fs.Duration(CfgMigratorQueryCooldownPeriod, 5*time.Second, "the cooldown period of the service to ask for new data")
 			return fs
 		}(),

--- a/plugins/migrator/plugin.go
+++ b/plugins/migrator/plugin.go
@@ -74,7 +74,7 @@ func provide(c *dig.Container) {
 		switch {
 		case maxReceiptEntries > iotago.MaxMigratedFundsEntryCount:
 			panic(fmt.Sprintf("%s (set to %d) can be max %d", CfgMigratorReceiptMaxEntries, maxReceiptEntries, iotago.MaxMigratedFundsEntryCount))
-		case maxReceiptEntries == 0:
+		case maxReceiptEntries <= 0:
 			panic(fmt.Sprintf("%s must be greather than 0", CfgMigratorReceiptMaxEntries))
 		}
 


### PR DESCRIPTION
Default set to 110.