### PR TITLE
Build wfmock image directly from its source

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -89,7 +89,7 @@ jobs:
         run: |
           docker pull gaiaadm/pumba:0.7.4
           docker pull gaiadocker/iproute2:latest
-          docker pull lucamoser/wfmock:0.1.0
+          docker build github.com/iotaledger/chrysalis-tools#:wfmock -t wfmock:latest
 
       - name: Run integration tests
         run: docker-compose -f integration-tests/tester/docker-compose.yml up --abort-on-container-exit --exit-code-from tester --build

--- a/integration-tests/runTests.sh
+++ b/integration-tests/runTests.sh
@@ -8,7 +8,7 @@ docker build -f ../docker/Dockerfile.dev -t hornet:dev ../.
 echo "Pull additional Docker images"
 docker pull gaiaadm/pumba:0.7.4
 docker pull gaiadocker/iproute2:latest
-docker pull lucamoser/wfmock:0.1.0
+docker build github.com/iotaledger/chrysalis-tools#:wfmock -t wfmock:latest
 
 echo "Run integration tests"
 

--- a/integration-tests/tester/framework/config.go
+++ b/integration-tests/tester/framework/config.go
@@ -35,7 +35,7 @@ const (
 	autopeeringMaxTries = 50
 
 	containerNodeImage           = "hornet:dev"
-	containerWhiteFlagMockServer = "lucamoser/wfmock:0.1.0"
+	containerWhiteFlagMockServer = "wfmock:latest"
 	containerPumbaImage          = "gaiaadm/pumba:0.7.4"
 	containerIPRouteImage        = "gaiadocker/iproute2"
 


### PR DESCRIPTION
# Description

With the changes from this PR, `wfmock:latest` is build directly from its source at https://github.com/iotaledger/chrysalis-tools instead of relying on alternative published images.
