### PR TITLE
Updates iota.go

### DIFF
--- a/core/protocfg/core.go
+++ b/core/protocfg/core.go
@@ -40,7 +40,7 @@ func init() {
 						fs.Float64(CfgProtocolMinPoWScore, 4000, "the minimum PoW score required by the network.")
 						fs.Int(CfgProtocolMilestonePublicKeyCount, 2, "the amount of public keys in a milestone")
 						fs.String(CfgProtocolNetworkIDName, "mainnet1", "the network ID on which this node operates on.")
-						fs.String(CfgProtocolBech32HRP, iotago.PrefixMainnet.String(), "the HRP which should be used for Bech32 addresses.")
+						fs.String(CfgProtocolBech32HRP, string(iotago.PrefixMainnet), "the HRP which should be used for Bech32 addresses.")
 						return fs
 					}(),
 				},
@@ -73,14 +73,9 @@ func provide(c *dig.Container) {
 
 	if err := c.Provide(func(deps tangledeps) protoresult {
 
-		prefix, err := iotago.ParsePrefix(deps.NodeConfig.String(CfgProtocolBech32HRP))
-		if err != nil {
-			panic(err)
-		}
-
 		res := protoresult{
 			NetworkID: iotago.NetworkIDFromString(deps.NodeConfig.String(CfgProtocolNetworkIDName)),
-			Bech32HRP: prefix,
+			Bech32HRP: iotago.NetworkPrefix(deps.NodeConfig.String(CfgProtocolBech32HRP)),
 		}
 
 		// ToDo: Change these defaults to mainnet values

--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/hashicorp/go-version v1.2.1 // indirect
 	github.com/iotaledger/hive.go v0.0.0-20210227133437-68f051e64b99
 	github.com/iotaledger/iota.go v1.0.0-beta.15.0.20210212090247-51c40bcebea7
-	github.com/iotaledger/iota.go/v2 v2.0.0-20210312091857-068d33487f86
+	github.com/iotaledger/iota.go/v2 v2.0.0-20210316125548-8994b0fc100d
 	github.com/ipfs/go-ds-badger v0.2.6
 	github.com/koron/go-ssdp v0.0.2 // indirect
 	github.com/labstack/echo/v4 v4.2.1

--- a/go.sum
+++ b/go.sum
@@ -405,6 +405,8 @@ github.com/iotaledger/iota.go/v2 v2.0.0-20210311103028-90a8ef66bb7b h1:P3eyzJax9
 github.com/iotaledger/iota.go/v2 v2.0.0-20210311103028-90a8ef66bb7b/go.mod h1:W6ma7/TCwGO9s3+OX9c0AES4vc4/3PhoDuROXFUBqRE=
 github.com/iotaledger/iota.go/v2 v2.0.0-20210312091857-068d33487f86 h1:XHvtxZP4fH+FwOJVVdxLR59jX9aiXJAGN4P5BIUg4po=
 github.com/iotaledger/iota.go/v2 v2.0.0-20210312091857-068d33487f86/go.mod h1:W6ma7/TCwGO9s3+OX9c0AES4vc4/3PhoDuROXFUBqRE=
+github.com/iotaledger/iota.go/v2 v2.0.0-20210316125548-8994b0fc100d h1:qsRMOHE5jKxXyz7MNSKqwAOTqGxxzAazrc0b0ms6sHk=
+github.com/iotaledger/iota.go/v2 v2.0.0-20210316125548-8994b0fc100d/go.mod h1:W6ma7/TCwGO9s3+OX9c0AES4vc4/3PhoDuROXFUBqRE=
 github.com/ipfs/go-cid v0.0.1/go.mod h1:GHWU/WuQdMPmIosc4Yn1bcCT7dSeX4lBafM7iqUPQvM=
 github.com/ipfs/go-cid v0.0.2/go.mod h1:GHWU/WuQdMPmIosc4Yn1bcCT7dSeX4lBafM7iqUPQvM=
 github.com/ipfs/go-cid v0.0.3/go.mod h1:GHWU/WuQdMPmIosc4Yn1bcCT7dSeX4lBafM7iqUPQvM=

--- a/plugins/restapi/v1/node.go
+++ b/plugins/restapi/v1/node.go
@@ -46,7 +46,7 @@ func info() (*infoResponse, error) {
 		Version:                 deps.AppInfo.Version,
 		IsHealthy:               deps.Tangle.IsNodeHealthy(),
 		NetworkID:               deps.NodeConfig.String(protocfg.CfgProtocolNetworkIDName),
-		Bech32HRP:               deps.Bech32HRP.String(),
+		Bech32HRP:               string(deps.Bech32HRP),
 		MinPowScore:             deps.NodeConfig.Float64(protocfg.CfgProtocolMinPoWScore),
 		LatestMilestoneIndex:    latestMilestoneIndex,
 		ConfirmedMilestoneIndex: confirmedMilestoneIndex,


### PR DESCRIPTION
Most notably, a change in iota.go makes it so that signature for the same input addresses are only validated once instead of N * <same_input_address> times.

The network prefix or HRP is now also just a string.