### PR TITLE
Add transactions API endpoint

### DIFF
--- a/alphanet/config_alphanet.json
+++ b/alphanet/config_alphanet.json
@@ -9,6 +9,7 @@
     "excludeHealthCheckFromAuth": false,
     "permittedRoutes": [
       "/health",
+      "/mqtt",
       "/api/v1/info",
       "/api/v1/tips",
       "/api/v1/messages/:messageID",
@@ -16,6 +17,7 @@
       "/api/v1/messages/:messageID/raw",
       "/api/v1/messages/:messageID/children",
       "/api/v1/messages",
+      "/api/v1/transactions/:transactionID/included-message",
       "/api/v1/milestones/:milestoneIndex",
       "/api/v1/milestones/:milestoneIndex/utxo-changes",
       "/api/v1/outputs/:outputID",

--- a/config.json
+++ b/config.json
@@ -17,6 +17,7 @@
       "/api/v1/messages/:messageID/raw",
       "/api/v1/messages/:messageID/children",
       "/api/v1/messages",
+      "/api/v1/transactions/:transactionID/included-message",
       "/api/v1/milestones/:milestoneIndex",
       "/api/v1/milestones/:milestoneIndex/utxo-changes",
       "/api/v1/outputs/:outputID",

--- a/config.json
+++ b/config.json
@@ -9,6 +9,7 @@
     "excludeHealthCheckFromAuth": false,
     "permittedRoutes": [
       "/health",
+      "/mqtt",
       "/api/v1/info",
       "/api/v1/tips",
       "/api/v1/messages/:messageID",

--- a/config_chrysalis_testnet.json
+++ b/config_chrysalis_testnet.json
@@ -16,6 +16,7 @@
       "/api/v1/messages/:messageID/raw",
       "/api/v1/messages/:messageID/children",
       "/api/v1/messages",
+      "/api/v1/transactions/:transactionID/included-message",
       "/api/v1/milestones/:milestoneIndex",
       "/api/v1/milestones/:milestoneIndex/utxo-changes",
       "/api/v1/outputs/:outputID",

--- a/config_chrysalis_testnet.json
+++ b/config_chrysalis_testnet.json
@@ -9,6 +9,7 @@
     "excludeHealthCheckFromAuth": false,
     "permittedRoutes": [
       "/health",
+      "/mqtt",
       "/api/v1/info",
       "/api/v1/tips",
       "/api/v1/messages/:messageID",

--- a/config_comnet.json
+++ b/config_comnet.json
@@ -16,6 +16,7 @@
       "/api/v1/messages/:messageID/raw",
       "/api/v1/messages/:messageID/children",
       "/api/v1/messages",
+      "/api/v1/transactions/:transactionID/included-message",
       "/api/v1/milestones/:milestoneIndex",
       "/api/v1/milestones/:milestoneIndex/utxo-changes",
       "/api/v1/outputs/:outputID",

--- a/config_comnet.json
+++ b/config_comnet.json
@@ -9,6 +9,7 @@
     "excludeHealthCheckFromAuth": false,
     "permittedRoutes": [
       "/health",
+      "/mqtt",
       "/api/v1/info",
       "/api/v1/tips",
       "/api/v1/messages/:messageID",

--- a/config_devnet.json
+++ b/config_devnet.json
@@ -16,6 +16,7 @@
       "/api/v1/messages/:messageID/raw",
       "/api/v1/messages/:messageID/children",
       "/api/v1/messages",
+      "/api/v1/transactions/:transactionID/included-message",
       "/api/v1/milestones/:milestoneIndex",
       "/api/v1/milestones/:milestoneIndex/utxo-changes",
       "/api/v1/outputs/:outputID",

--- a/config_devnet.json
+++ b/config_devnet.json
@@ -9,6 +9,7 @@
     "excludeHealthCheckFromAuth": false,
     "permittedRoutes": [
       "/health",
+      "/mqtt",
       "/api/v1/info",
       "/api/v1/tips",
       "/api/v1/messages/:messageID",

--- a/integration-tests/tester/framework/config.go
+++ b/integration-tests/tester/framework/config.go
@@ -256,6 +256,7 @@ func DefaultRestAPIConfig() RestAPIConfig {
 		BindAddress: "0.0.0.0:14265",
 		PermittedRoutes: []string{
 			"/health",
+			"/mqtt",
 			"/api/v1/info",
 			"/api/v1/tips",
 			"/api/v1/messages/:messageID",

--- a/integration-tests/tester/framework/config.go
+++ b/integration-tests/tester/framework/config.go
@@ -264,6 +264,7 @@ func DefaultRestAPIConfig() RestAPIConfig {
 			"/api/v1/messages/:messageID/raw",
 			"/api/v1/messages/:messageID/children",
 			"/api/v1/messages",
+			"/api/v1/transactions/:transactionID/included-message",
 			"/api/v1/milestones/:milestoneIndex",
 			"/api/v1/outputs/:outputID",
 			"/api/v1/addresses/:address",

--- a/plugins/mqtt/plugin.go
+++ b/plugins/mqtt/plugin.go
@@ -24,7 +24,7 @@ import (
 
 func init() {
 	Plugin = &node.Plugin{
-		Status: node.Disabled,
+		Status: node.Enabled,
 		Pluggable: node.Pluggable{
 			Name:      "MQTT",
 			DepsFunc:  func(cDeps dependencies) { deps = cDeps },

--- a/plugins/mqtt/plugin.go
+++ b/plugins/mqtt/plugin.go
@@ -122,6 +122,20 @@ func configure() {
 			return
 		}
 
+		if transactionId := transactionIdFromTopic(topicName); transactionId != nil {
+			// Find the first output of the transaction
+			outputId := &iotago.UTXOInputID{}
+			copy(outputId[:], transactionId[:])
+
+			output, err := deps.Storage.UTXO().ReadOutputByOutputIDWithoutLocking(outputId)
+			if err != nil {
+				return
+			}
+
+			publishTransactionIncludedMessage(transactionId, output.MessageID())
+			return
+		}
+
 		if outputId := outputIdFromTopic(topicName); outputId != nil {
 			output, err := deps.Storage.UTXO().ReadOutputByOutputIDWithoutLocking(outputId)
 			if err != nil {

--- a/plugins/mqtt/topics.go
+++ b/plugins/mqtt/topics.go
@@ -10,6 +10,8 @@ const (
 	topicMessagesIndexation = "messages/indexation/{index}"
 	topicMessagesMetadata   = "messages/{messageId}/metadata"
 
+	topicTransactionsIncludedMessage = "transactions/{transactionId}/included-message"
+
 	topicOutputs = "outputs/{outputId}"
 
 	topicReceipts = "receipts"

--- a/plugins/restapi/params.go
+++ b/plugins/restapi/params.go
@@ -48,6 +48,7 @@ var params = &node.PluginParams{
 					"/api/v1/messages/:messageID/raw",
 					"/api/v1/messages/:messageID/children",
 					"/api/v1/messages",
+					"/api/v1/transactions/:transactionID/included-message",
 					"/api/v1/milestones/:milestoneIndex",
 					"/api/v1/milestones/:milestoneIndex/utxo-changes",
 					"/api/v1/outputs/:outputID",

--- a/plugins/restapi/params.go
+++ b/plugins/restapi/params.go
@@ -41,6 +41,7 @@ var params = &node.PluginParams{
 			fs.StringSlice(CfgRestAPIPermittedRoutes,
 				[]string{
 					"/health",
+					"/mqtt",
 					"/api/v1/info",
 					"/api/v1/tips",
 					"/api/v1/messages/:messageID",

--- a/plugins/restapi/v1/plugin.go
+++ b/plugins/restapi/v1/plugin.go
@@ -34,6 +34,9 @@ const (
 	// ParameterMessageID is used to identify a message by it's ID.
 	ParameterMessageID = "messageID"
 
+	// ParameterTransactionID is used to identify a transaction by it's ID.
+	ParameterTransactionID = "transactionID"
+
 	// ParameterOutputID is used to identify an output by it's ID.
 	ParameterOutputID = "outputID"
 
@@ -76,6 +79,10 @@ const (
 	// GET with query parameter (mandatory) returns all message IDs that fit these filter criteria (query parameters: "index").
 	// POST creates a single new message and returns the new message ID.
 	RouteMessages = "/messages"
+
+	// RouteTransactionsIncludedMessage is the route for getting the message that was included in the ledger for a given transaction ID.
+	// GET returns message data (json).
+	RouteTransactionsIncludedMessage = "/transactions/:" + ParameterTransactionID + "/included-message"
 
 	// RouteMilestone is the route for getting a milestone by it's milestoneIndex.
 	// GET returns the milestone.
@@ -261,6 +268,15 @@ func configure() {
 		}
 		c.Response().Header().Set(echo.HeaderLocation, resp.MessageID)
 		return restapipkg.JSONResponse(c, http.StatusCreated, resp)
+	})
+
+	routeGroup.GET(RouteTransactionsIncludedMessage, func(c echo.Context) error {
+		resp, err := messageByTransactionID(c)
+		if err != nil {
+			return err
+		}
+
+		return restapipkg.JSONResponse(c, http.StatusOK, resp)
 	})
 
 	routeGroup.GET(RouteMilestone, func(c echo.Context) error {

--- a/plugins/restapi/v1/transactions.go
+++ b/plugins/restapi/v1/transactions.go
@@ -1,0 +1,42 @@
+package v1
+
+import (
+	"encoding/hex"
+	"strings"
+
+	"github.com/labstack/echo/v4"
+	"github.com/pkg/errors"
+
+	"github.com/gohornet/hornet/pkg/restapi"
+	iotago "github.com/iotaledger/iota.go/v2"
+)
+
+func messageByTransactionID(c echo.Context) (*iotago.Message, error) {
+	transactionIDHex := strings.ToLower(c.Param(ParameterTransactionID))
+
+	transactionID, err := hex.DecodeString(transactionIDHex)
+	if err != nil {
+		return nil, errors.WithMessagef(restapi.ErrInvalidParameter, "invalid transaction ID: %s, error: %s", transactionIDHex, err)
+	}
+
+	if len(transactionID) != iotago.TransactionIDLength {
+		return nil, errors.WithMessagef(restapi.ErrInvalidParameter, "invalid transaction ID: %s, invalid length: %d", transactionIDHex, len(transactionID))
+	}
+
+	// Get the first output of that transaction (using index 0)
+	outputID := &iotago.UTXOInputID{}
+	copy(outputID[:], transactionID)
+
+	output, err := deps.UTXO.ReadOutputByOutputIDWithoutLocking(outputID)
+	if err != nil {
+		return nil, errors.WithMessagef(restapi.ErrNotFound, "transaction not found: %s", transactionIDHex)
+	}
+
+	cachedMsg := deps.Storage.GetCachedMessageOrNil(output.MessageID())
+	if cachedMsg == nil {
+		return nil, errors.WithMessagef(restapi.ErrNotFound, "transaction not found: %s", transactionIDHex)
+	}
+	defer cachedMsg.Release(true)
+
+	return cachedMsg.GetMessage().GetMessage(), nil
+}

--- a/plugins/restapi/v1/transactions.go
+++ b/plugins/restapi/v1/transactions.go
@@ -29,7 +29,7 @@ func messageByTransactionID(c echo.Context) (*iotago.Message, error) {
 
 	output, err := deps.UTXO.ReadOutputByOutputIDWithoutLocking(outputID)
 	if err != nil {
-		return nil, errors.WithMessagef(restapi.ErrNotFound, "transaction not found: %s", transactionIDHex)
+		return nil, errors.WithMessagef(restapi.ErrNotFound, "output for transaction not found: %s", transactionIDHex)
 	}
 
 	cachedMsg := deps.Storage.GetCachedMessageOrNil(output.MessageID())


### PR DESCRIPTION
- Added `/api/v1/transactions/{transactionId}/included-message` API endpoint to fetch the message that was included in the ledger for a given transaction Id
- Added `transactions/{transactionId}/included-message` MQTT topic that corresponds to the `/api/v1/transactions/{transactionId}/included-message` endpoint
- Enabled MQTT plugin by default
- `/mqtt` is a permitted route by default