### PR TITLE
gossip/syncing improvements

### DIFF
--- a/alphanet/config_alphanet.json
+++ b/alphanet/config_alphanet.json
@@ -85,6 +85,10 @@
       }
     ]
   },
+  "requests": {
+    "discardOlderThan": "15s",
+    "pendingReEnqueueInterval": "5s"
+  },
   "coordinator": {
     "stateFilePath": "coordinator.state",
     "interval": "10s",

--- a/config_chrysalis_testnet.json
+++ b/config_chrysalis_testnet.json
@@ -93,6 +93,10 @@
       }
     ]
   },
+  "requests": {
+    "discardOlderThan": "15s",
+    "pendingReEnqueueInterval": "5s"
+  },
   "coordinator": {
     "stateFilePath": "coordinator.state",
     "interval": "10s",

--- a/config_comnet.json
+++ b/config_comnet.json
@@ -88,6 +88,10 @@
       }
     ]
   },
+  "requests": {
+    "discardOlderThan": "15s",
+    "pendingReEnqueueInterval": "5s"
+  },
   "coordinator": {
     "stateFilePath": "coordinator.state",
     "interval": "10s",

--- a/config_devnet.json
+++ b/config_devnet.json
@@ -88,6 +88,10 @@
       }
     ]
   },
+  "requests": {
+    "discardOlderThan": "15s",
+    "pendingReEnqueueInterval": "5s"
+  },
   "coordinator": {
     "stateFilePath": "coordinator.state",
     "interval": "10s",

--- a/core/gossip/core.go
+++ b/core/gossip/core.go
@@ -127,12 +127,17 @@ func provide(c *dig.Container) {
 	type requesterdeps struct {
 		dig.In
 		Service      *gossip.Service
+		NodeConfig   *configuration.Configuration `name:"nodeConfig"`
 		RequestQueue gossip.RequestQueue
 		Storage      *storage.Storage
 	}
 
 	if err := c.Provide(func(deps requesterdeps) *gossip.Requester {
-		return gossip.NewRequester(deps.Service, deps.RequestQueue, deps.Storage)
+		return gossip.NewRequester(deps.Service,
+			deps.RequestQueue,
+			deps.Storage,
+			gossip.WithRequesterDiscardRequestsOlderThan(deps.NodeConfig.Duration(CfgRequestsDiscardOlderThan)),
+			gossip.WithRequesterPendingRequestReEnqueueInterval(deps.NodeConfig.Duration(CfgRequestsPendingReEnqueueInterval)))
 	}); err != nil {
 		panic(err)
 	}

--- a/core/gossip/params.go
+++ b/core/gossip/params.go
@@ -9,6 +9,10 @@ import (
 )
 
 const (
+	// Defines the maximum time a request stays in the request queue.
+	CfgRequestsDiscardOlderThan = "requests.discardOlderThan"
+	// Defines the interval the pending requests are re-enqueued.
+	CfgRequestsPendingReEnqueueInterval = "requests.pendingReEnqueueInterval"
 	// Defines the maximum amount of unknown peers a gossip protocol connection is established to.
 	CfgP2PGossipUnknownPeersLimit = "p2p.gossipUnknownPeersLimit"
 	// Defines the read timeout for subsequent reads.
@@ -22,6 +26,8 @@ var params = &node.PluginParams{
 		"nodeConfig": func() *flag.FlagSet {
 			fs := flag.NewFlagSet("", flag.ContinueOnError)
 			fs.Int(CfgP2PGossipUnknownPeersLimit, 4, "maximum amount of unknown peers a gossip protocol connection is established to")
+			fs.Duration(CfgRequestsDiscardOlderThan, 15*time.Second, "the maximum time a request stays in the request queue")
+			fs.Duration(CfgRequestsPendingReEnqueueInterval, 5*time.Second, "the interval the pending requests are re-enqueued")
 			fs.Duration(CfgGossipStreamReadTimeout, 60*time.Second, "the read timeout for reads from the gossip stream")
 			fs.Duration(CfgGossipStreamWriteTimeout, 10*time.Second, "the write timeout for writes to the gossip stream")
 			return fs

--- a/core/tangle/core.go
+++ b/core/tangle/core.go
@@ -96,11 +96,23 @@ func provide(c *dig.Container) {
 		MessageProcessor *gossippkg.MessageProcessor
 		ServerMetrics    *metrics.ServerMetrics
 		ReceiptService   *migrator.ReceiptService `optional:"true"`
+		BelowMaxDepth    int                      `name:"belowMaxDepth"`
 	}
 
 	if err := c.Provide(func(deps tangledeps) *tangle.Tangle {
-		return tangle.New(logger.NewLogger("Tangle"), deps.Storage, deps.RequestQueue, deps.Service, deps.MessageProcessor,
-			deps.ServerMetrics, CorePlugin.Daemon().ContextStopped(), deps.Requester, CorePlugin.Daemon(), deps.ReceiptService, *syncedAtStartup)
+		return tangle.New(
+			logger.NewLogger("Tangle"),
+			deps.Storage,
+			deps.RequestQueue,
+			deps.Service,
+			deps.MessageProcessor,
+			deps.ServerMetrics,
+			deps.Requester,
+			deps.ReceiptService,
+			CorePlugin.Daemon(),
+			CorePlugin.Daemon().ContextStopped(),
+			deps.BelowMaxDepth,
+			*syncedAtStartup)
 	}); err != nil {
 		panic(err)
 	}

--- a/integration-tests/tester/framework/static_network.go
+++ b/integration-tests/tester/framework/static_network.go
@@ -98,7 +98,7 @@ func (n *StaticNetwork) ConnectNodes() error {
 	if err := n.AwaitPeering(peeringCtx); err != nil {
 		return err
 	}
-	log.Printf("static peering took %v", time.Since(s))
+	log.Printf("static peering took %v", time.Since(s).Truncate(time.Millisecond))
 	return nil
 }
 

--- a/pkg/model/storage/message.go
+++ b/pkg/model/storage/message.go
@@ -94,6 +94,16 @@ func (msg *Message) GetParents() hornet.MessageIDs {
 	return hornet.MessageIDsFromSliceOfArrays(msg.GetMessage().Parents)
 }
 
+func (msg *Message) IsMilestone() bool {
+	switch msg.GetMessage().Payload.(type) {
+	case *iotago.Milestone:
+		return true
+	default:
+	}
+
+	return false
+}
+
 func (msg *Message) GetMilestone() (ms *iotago.Milestone) {
 	switch ms := msg.GetMessage().Payload.(type) {
 	case *iotago.Milestone:

--- a/pkg/model/storage/milestones.go
+++ b/pkg/model/storage/milestones.go
@@ -27,6 +27,10 @@ var (
 	ErrInvalidMilestone = errors.New("invalid milestone")
 )
 
+func MilestoneMessageCaller(handler interface{}, params ...interface{}) {
+	handler.(func(msIndex milestone.Index, cachedMsg *CachedMessage))(params[0].(milestone.Index), params[1].(*CachedMessage).Retain())
+}
+
 func MilestoneCaller(handler interface{}, params ...interface{}) {
 	handler.(func(cachedMs *CachedMilestone))(params[0].(*CachedMilestone).Retain())
 }
@@ -271,6 +275,6 @@ func (s *Storage) StoreMilestone(cachedMessage *CachedMessage, ms *iotago.Milest
 	// Force release to store milestones without caching
 	defer cachedMilestone.Release(true) // milestone +-0
 
-	s.Events.ReceivedValidMilestoneMessage.Trigger(cachedMessage) // message pass +1
-	s.Events.ReceivedValidMilestone.Trigger(cachedMilestone)      // milestone pass +1
+	s.Events.ReceivedValidMilestone.Trigger(cachedMilestone)                                 // milestone pass +1
+	s.Events.ReceivedValidMilestoneMessage.Trigger(milestone.Index(ms.Index), cachedMessage) // message pass +1
 }

--- a/pkg/model/storage/storage.go
+++ b/pkg/model/storage/storage.go
@@ -90,7 +90,7 @@ func New(databaseDirectory string, store kvstore.KVStore, cachesProfile *profile
 		utxoManager:             utxoManager,
 		belowMaxDepth:           milestone.Index(belowMaxDepth),
 		Events: &packageEvents{
-			ReceivedValidMilestoneMessage: events.NewEvent(MessageCaller),
+			ReceivedValidMilestoneMessage: events.NewEvent(MilestoneMessageCaller),
 			ReceivedValidMilestone:        events.NewEvent(MilestoneCaller),
 			PruningStateChanged:           events.NewEvent(events.BoolCaller),
 		},

--- a/pkg/protocol/gossip/requester.go
+++ b/pkg/protocol/gossip/requester.go
@@ -22,7 +22,7 @@ type RequestBackPressureFunc func() bool
 
 var defaultRequesterOpts = []RequesterOption{
 	WithRequesterDiscardRequestsOlderThan(10 * time.Second),
-	WithRequesterPendingRequestReEnqueueInterval(1500 * time.Millisecond),
+	WithRequesterPendingRequestReEnqueueInterval(5 * time.Second),
 }
 
 // RequesterOption is a function which sets an option on a RequesterOptions instance.

--- a/pkg/snapshot/pruning.go
+++ b/pkg/snapshot/pruning.go
@@ -234,7 +234,7 @@ func (s *Snapshot) pruneDatabase(targetIndex milestone.Index, abortSignal <-chan
 		snapshotInfo.PruningIndex = milestoneIndex
 		s.storage.SetSnapshotInfo(snapshotInfo)
 
-		s.log.Infof("Pruning milestone (%d) took %v. Pruned %d/%d messages. ", milestoneIndex, time.Since(ts), txCountDeleted, msgCountChecked)
+		s.log.Infof("Pruning milestone (%d) took %v. Pruned %d/%d messages. ", milestoneIndex, time.Since(ts).Truncate(time.Millisecond), txCountDeleted, msgCountChecked)
 
 		s.tangle.Events.PruningMilestoneIndexChanged.Trigger(milestoneIndex)
 	}

--- a/pkg/snapshot/snapshot.go
+++ b/pkg/snapshot/snapshot.go
@@ -759,7 +759,7 @@ func (s *Snapshot) createSnapshotWithoutLocking(snapshotType Type, targetIndex m
 		s.tangle.Events.SnapshotMilestoneIndexChanged.Trigger(targetIndex)
 	}
 
-	s.log.Infof("created %s snapshot for target index %d, took %v", snapshotNames[snapshotType], targetIndex, time.Since(ts))
+	s.log.Infof("created %s snapshot for target index %d, took %v", snapshotNames[snapshotType], targetIndex, time.Since(ts).Truncate(time.Millisecond))
 	return nil
 }
 
@@ -939,7 +939,7 @@ func (s *Snapshot) LoadSnapshotFromFile(snapshotType Type, networkID uint64, fil
 		return fmt.Errorf("unable to import %s snapshot file: %w", snapshotNames[snapshotType], err)
 	}
 
-	s.log.Infof("imported %s snapshot file, took %v", snapshotNames[snapshotType], time.Since(ts))
+	s.log.Infof("imported %s snapshot file, took %v", snapshotNames[snapshotType], time.Since(ts).Truncate(time.Millisecond))
 
 	if err := s.utxo.CheckLedgerState(); err != nil {
 		return err

--- a/pkg/snapshot/snapshot.go
+++ b/pkg/snapshot/snapshot.go
@@ -962,6 +962,11 @@ func (s *Snapshot) LoadSnapshotFromFile(snapshotType Type, networkID uint64, fil
 
 // HandleNewConfirmedMilestoneEvent handles new confirmed milestone events which may trigger a delta snapshot creation and pruning.
 func (s *Snapshot) HandleNewConfirmedMilestoneEvent(confirmedMilestoneIndex milestone.Index, shutdownSignal <-chan struct{}) {
+	if !s.storage.IsNodeSyncedWithThreshold() {
+		// do not prune or create snapshots while we are not synced
+		return
+	}
+
 	s.snapshotLock.Lock()
 	defer s.snapshotLock.Unlock()
 

--- a/pkg/tangle/solidifier.go
+++ b/pkg/tangle/solidifier.go
@@ -575,6 +575,6 @@ func (t *Tangle) searchMissingMilestone(confirmedMilestoneIndex milestone.Index,
 		}
 	}
 
-	t.log.Infof("searchMissingMilestone finished, found: %v, total: %v", milestoneFound, time.Since(ts))
+	t.log.Infof("searchMissingMilestone finished, found: %v, took: %v", milestoneFound, time.Since(ts).Truncate(time.Millisecond))
 	return milestoneFound, nil
 }

--- a/plugins/warpsync/plugin.go
+++ b/plugins/warpsync/plugin.go
@@ -128,7 +128,7 @@ func configureEvents() {
 		// walks the whole cone if there are already paths between newer milestones in the database.
 		warpSyncMilestoneRequester.Cleanup()
 
-		log.Infof("Synchronized %d milestones in %v", deltaSynced, took)
+		log.Infof("Synchronized %d milestones in %v", deltaSynced, took.Truncate(time.Millisecond))
 		deps.RequestQueue.Filter(nil)
 	})
 }


### PR DESCRIPTION
This PR adds some improvements for the whole gossip / syncing process.

The reason I changed the following points:

`Do not process gossip if we are not synced yet`
If we are warp syncing, we don't want to put extra pressure on the disc-IO. If the current network MPS is at a high value, the warpsync process is slowed down because we also store gossip. The second fact is, that it is easier for a node to request the parents of new messages instead of walking the existing milestone cones in the database and figure out which transactions are missing. Especially at higher MPS this becomes a problem if we already receive hundreds of thousands of messages of the latest cone while we are warp syncing.

` - Do not prune or create snapshots while we are not synced`
We shouldn't create extra load on the node during the syncing process. The main goal is to become sync.
Since a node will load a relatively new snapshot anyway, there is no need to create snapshots in between or start pruning.
This will be triggered after the node became sync.

`Add config options for request queue intervals`
The former default value of 1500ms is way too low if we try to sync thousands of messages in a heavy milestone cone.
You can clearly see in the incoming messages vs the new messages that we re-request the same missing messages way to often. After increasing the re-enqueue intervals to 5 seconds, the sync process was massively improved at higher MPS. That's why I made it configurable and increased the defaults.

`Do not broadcast milestones that are below max depth`
With the new gossip on solidification we need to broadcast all milestone messages we received, if they have a valid signature.
The side effect that was introduced by this was, that really old milestones were broadcasted to all our peers if we tried to sync from an older snapshot. This caused a lot of log messages "synced too far back" in our peers. We don't need to broadcast old milestones, since we requested them anyways. I added a check for below max depth to have a reasonable threshold.