### PR TITLE
Makes our Dockerfile.dev support RocksDB

### DIFF
--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -28,8 +28,8 @@ RUN GOOS=linux GOARCH=amd64 go build \
 ############################
 # Image
 ############################
-# https://github.com/GoogleContainerTools/distroless/blob/master/base/README.md
-# using distroless base image, contains: glibc, libssl and openssl
+# https://github.com/GoogleContainerTools/distroless/tree/master/cc
+# using distroless cc image, which includes everything in the base image (glibc, libssl and openssl)
 FROM gcr.io/distroless/cc@sha256:e8a7af65cf92b834e35a7537f6be93e743b48886c83c1eac15ade437b90fc9ab
 
 EXPOSE 8081/tcp

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -21,6 +21,7 @@ COPY . .
 
 # Build the binary
 RUN GOOS=linux GOARCH=amd64 go build \
+      -tags="builtin_static,rocksdb" \
       -ldflags='-w -s' -a \
       -o /go/bin/hornet
 
@@ -29,7 +30,7 @@ RUN GOOS=linux GOARCH=amd64 go build \
 ############################
 # https://github.com/GoogleContainerTools/distroless/blob/master/base/README.md
 # using distroless base image, contains: glibc, libssl and openssl
-FROM gcr.io/distroless/base@sha256:5e0cc69445ed1d8a17198250a7249d56dd4b6966bb6b2118e60ae9194c310647
+FROM gcr.io/distroless/cc@sha256:e8a7af65cf92b834e35a7537f6be93e743b48886c83c1eac15ade437b90fc9ab
 
 EXPOSE 8081/tcp
 EXPOSE 14265/tcp

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -1,6 +1,8 @@
 # golang 1.16.2-buster amd64
 FROM golang@sha256:5a6302e91acb152050d661c9a081a535978c629225225ed91a8b979ad24aafcd AS build
 
+ARG BUILD_TAGS
+
 # Ensure ca-certificates are up to date
 RUN update-ca-certificates
 
@@ -21,7 +23,7 @@ COPY . .
 
 # Build the binary
 RUN GOOS=linux GOARCH=amd64 go build \
-      -tags="builtin_static,rocksdb" \
+      -tags="$BUILD_TAGS" \
       -ldflags='-w -s' -a \
       -o /go/bin/hornet
 


### PR DESCRIPTION
* Adjusts `Dockerfile.dev` to use the `distroless/cc` instead of just `distroless/base` as `cc` includes the needed `libstdc`.
* Makes the go build tags an argument to the image building process; in order therefore to compile with RocksDB support, one can do following: `docker build -f docker/Dockerfile.dev -t hornet:rocksdb . --build-arg BUILD_TAGS="builtin_static,rocksdb"`