### PR TITLE
Use msg id for minted output msg metadata pointer

### DIFF
--- a/pkg/model/utxo/receipt.go
+++ b/pkg/model/utxo/receipt.go
@@ -162,13 +162,13 @@ func (u *Manager) ForEachReceiptTupleMigratedAt(migratedAtIndex milestone.Index,
 }
 
 // ReceiptToOutputs extracts the migrated funds to outputs.
-func ReceiptToOutputs(r *iotago.Receipt, msId *iotago.MilestoneID) ([]*Output, error) {
+func ReceiptToOutputs(r *iotago.Receipt, msgId hornet.MessageID, msId *iotago.MilestoneID) ([]*Output, error) {
 	outputs := make([]*Output, len(r.Funds))
 	for outputIndex, migFundsEntry := range r.Funds {
 		entry := migFundsEntry.(*iotago.MigratedFundsEntry)
 		utxoID := OutputIDForMigratedFunds(*msId, uint16(outputIndex))
 		// we use the milestone hash as the "origin message"
-		outputs[outputIndex] = CreateOutput(&utxoID, hornet.MessageIDFromArray(*msId), iotago.OutputSigLockedSingleOutput, entry.Address.(iotago.Address), entry.Deposit)
+		outputs[outputIndex] = CreateOutput(&utxoID, msgId, iotago.OutputSigLockedSingleOutput, entry.Address.(iotago.Address), entry.Deposit)
 	}
 	return outputs, nil
 }

--- a/pkg/whiteflag/confirmation.go
+++ b/pkg/whiteflag/confirmation.go
@@ -128,7 +128,7 @@ func ConfirmMilestone(
 			return nil, fmt.Errorf("invalid receipt contained within milestone: %w", err)
 		}
 
-		migratedOutputs, err := utxo.ReceiptToOutputs(receipt, msID)
+		migratedOutputs, err := utxo.ReceiptToOutputs(receipt, message.GetMessageID(), msID)
 		if err != nil {
 			return nil, fmt.Errorf("unable to extract migrated outputs from receipt: %w", err)
 		}


### PR DESCRIPTION
We used the ms id as the msg id for how we store outputs. With this change, one can actually point back to the actual message which carried the milestone to get all the data back.