### PR TITLE
Feat/speed up pruning

### DIFF
--- a/pkg/model/storage/children_storage.go
+++ b/pkg/model/storage/children_storage.go
@@ -127,14 +127,14 @@ func (s *Storage) DeleteChild(messageID hornet.MessageID, childMessageID hornet.
 }
 
 // child +-0
-func (s *Storage) DeleteChildren(messageID hornet.MessageID) {
+func (s *Storage) DeleteChildren(messageID hornet.MessageID, iteratorOptions ...objectstorage.IteratorOption) {
 
 	var keysToDelete [][]byte
 
 	s.childrenStorage.ForEachKeyOnly(func(key []byte) bool {
 		keysToDelete = append(keysToDelete, key)
 		return true
-	}, objectstorage.WithIteratorPrefix(messageID))
+	}, append(iteratorOptions, objectstorage.WithIteratorPrefix(messageID))...)
 
 	for _, key := range keysToDelete {
 		s.childrenStorage.Delete(key)

--- a/pkg/model/utxo/utxo.go
+++ b/pkg/model/utxo/utxo.go
@@ -48,10 +48,7 @@ func (u *Manager) WriteUnlockLedger() {
 	u.utxoLock.Unlock()
 }
 
-func (u *Manager) PruneMilestoneIndex(msIndex milestone.Index, pruneReceipts bool, receiptMigratedAtIndex ...uint32) error {
-
-	u.WriteLockLedger()
-	defer u.WriteUnlockLedger()
+func (u *Manager) PruneMilestoneIndexWithoutLocking(msIndex milestone.Index, pruneReceipts bool, receiptMigratedAtIndex ...uint32) error {
 
 	diff, err := u.GetMilestoneDiffWithoutLocking(msIndex)
 	if err != nil {

--- a/pkg/snapshot/pruning.go
+++ b/pkg/snapshot/pruning.go
@@ -57,7 +57,7 @@ func (s *Snapshot) pruneUnreferencedMessages(targetIndex milestone.Index) (msgCo
 // pruneMilestone prunes the milestone metadata and the ledger diffs from the database for the given milestone
 func (s *Snapshot) pruneMilestone(milestoneIndex milestone.Index, receiptMigratedAtIndex ...uint32) error {
 
-	if err := s.utxo.PruneMilestoneIndex(milestoneIndex, s.pruneReceipts, receiptMigratedAtIndex...); err != nil {
+	if err := s.utxo.PruneMilestoneIndexWithoutLocking(milestoneIndex, s.pruneReceipts, receiptMigratedAtIndex...); err != nil {
 		return err
 	}
 

--- a/pkg/snapshot/pruning.go
+++ b/pkg/snapshot/pruning.go
@@ -84,8 +84,9 @@ func (s *Snapshot) pruneMessages(messageIDsToDeleteMap map[string]struct{}) int 
 				s.storage.DeleteChild(parent, msgID)
 			}
 
-			// delete all children of this message
-			s.storage.DeleteChildren(msgID)
+			// We don't need to iterate through the children that reference this message,
+			// since we will never start the walk from this message anymore (we only walk the future cone)
+			// and the references will be deleted together with the children messages when they are pruned.
 
 			indexationPayload := storage.CheckIfIndexation(msg)
 			if indexationPayload != nil {


### PR DESCRIPTION
This PR removes an unnecessary WriteLock of the ledger during pruning.
It is not needed since we never prune info that is necessary for the current ledger state.

It also removes the database iteration to prune the direct children of a message, since the link to the children will be removed anyways if the children are pruned from the database themself. This gives a speedup of around 30%.