### PR TITLE
Check valid PoW score for messages with nonce 0

### DIFF
--- a/core/gossip/core.go
+++ b/core/gossip/core.go
@@ -9,7 +9,6 @@ import (
 	"github.com/libp2p/go-libp2p-core/protocol"
 	"go.uber.org/dig"
 
-	"github.com/gohornet/hornet/core/protocfg"
 	"github.com/gohornet/hornet/pkg/metrics"
 	"github.com/gohornet/hornet/pkg/model/milestone"
 	"github.com/gohornet/hornet/pkg/model/storage"
@@ -87,12 +86,13 @@ func provide(c *dig.Container) {
 		NodeConfig    *configuration.Configuration `name:"nodeConfig"`
 		NetworkID     uint64                       `name:"networkId"`
 		BelowMaxDepth int                          `name:"belowMaxDepth"`
+		MinPowScore   float64                      `name:"minPowScore"`
 		Profile       *profile.Profile
 	}
 
 	if err := c.Provide(func(deps msgprocdependencies) *gossip.MessageProcessor {
 		return gossip.NewMessageProcessor(deps.Storage, deps.RequestQueue, deps.Manager, deps.ServerMetrics, &gossip.Options{
-			MinPoWScore:       deps.NodeConfig.Float64(protocfg.CfgProtocolMinPoWScore),
+			MinPoWScore:       deps.MinPowScore,
 			NetworkID:         deps.NetworkID,
 			BelowMaxDepth:     milestone.Index(deps.BelowMaxDepth),
 			WorkUnitCacheOpts: deps.Profile.Caches.IncomingMessagesFilter,

--- a/core/pow/core.go
+++ b/core/pow/core.go
@@ -5,7 +5,6 @@ import (
 
 	"go.uber.org/dig"
 
-	"github.com/gohornet/hornet/core/protocfg"
 	"github.com/gohornet/hornet/pkg/node"
 	powpackage "github.com/gohornet/hornet/pkg/pow"
 	"github.com/gohornet/hornet/pkg/shutdown"
@@ -44,7 +43,8 @@ type dependencies struct {
 func provide(c *dig.Container) {
 	type handlerdeps struct {
 		dig.In
-		NodeConfig *configuration.Configuration `name:"nodeConfig"`
+		NodeConfig  *configuration.Configuration `name:"nodeConfig"`
+		MinPowScore float64                      `name:"minPowScore"`
 	}
 
 	if err := c.Provide(func(deps handlerdeps) *powpackage.Handler {
@@ -53,7 +53,7 @@ func provide(c *dig.Container) {
 		if err != nil && len(powsrvAPIKey) > 12 {
 			powsrvAPIKey = powsrvAPIKey[:12]
 		}
-		return powpackage.New(log, deps.NodeConfig.Float64(protocfg.CfgProtocolMinPoWScore), powsrvAPIKey, powsrvInitCooldown)
+		return powpackage.New(log, deps.MinPowScore, powsrvAPIKey, powsrvInitCooldown)
 	}); err != nil {
 		panic(err)
 	}

--- a/core/protocfg/core.go
+++ b/core/protocfg/core.go
@@ -69,13 +69,15 @@ func provide(c *dig.Container) {
 		PublicKeyRanges coordinator.PublicKeyRanges
 		NetworkID       uint64               `name:"networkId"`
 		Bech32HRP       iotago.NetworkPrefix `name:"bech32HRP"`
+		MinPowScore     float64              `name:"minPowScore"`
 	}
 
 	if err := c.Provide(func(deps tangledeps) protoresult {
 
 		res := protoresult{
-			NetworkID: iotago.NetworkIDFromString(deps.NodeConfig.String(CfgProtocolNetworkIDName)),
-			Bech32HRP: iotago.NetworkPrefix(deps.NodeConfig.String(CfgProtocolBech32HRP)),
+			NetworkID:   iotago.NetworkIDFromString(deps.NodeConfig.String(CfgProtocolNetworkIDName)),
+			Bech32HRP:   iotago.NetworkPrefix(deps.NodeConfig.String(CfgProtocolBech32HRP)),
+			MinPowScore: deps.NodeConfig.Float64(CfgProtocolMinPoWScore),
 		}
 
 		// ToDo: Change these defaults to mainnet values

--- a/pkg/protocol/gossip/msg_proc.go
+++ b/pkg/protocol/gossip/msg_proc.go
@@ -155,11 +155,7 @@ func (proc *MessageProcessor) Emit(msg *storage.Message) error {
 		return fmt.Errorf("msg has invalid network ID %d instead of %d", msg.GetNetworkID(), proc.opts.NetworkID)
 	}
 
-	score, err := msg.GetMessage().POW()
-	if err != nil {
-		return err
-	}
-
+	score := pow.Score(msg.GetData())
 	if score < proc.opts.MinPoWScore {
 		return fmt.Errorf("msg has insufficient PoW score %0.2f", score)
 	}
@@ -267,7 +263,7 @@ func (proc *MessageProcessor) processMilestoneRequest(p *Protocol, data []byte) 
 
 // processes the given message request by parsing it and then replying to the peer with it.
 func (proc *MessageProcessor) processMessageRequest(p *Protocol, data []byte) {
-	if len(data) != 32 {
+	if len(data) != iotago.MessageIDLength {
 		return
 	}
 

--- a/pkg/protocol/gossip/sting.go
+++ b/pkg/protocol/gossip/sting.go
@@ -153,7 +153,7 @@ func NewMilestoneRequestMsg(requestedMilestoneIndex milestone.Index) ([]byte, er
 
 // ExtractRequestedMilestoneIndex extracts the requested milestone index from the given source.
 func ExtractRequestedMilestoneIndex(source []byte) (milestone.Index, error) {
-	if len(source) != 4 {
+	if len(source) != iotago.UInt32ByteSize {
 		return 0, ErrInvalidSourceLength
 	}
 

--- a/plugins/restapi/v1/node.go
+++ b/plugins/restapi/v1/node.go
@@ -47,7 +47,7 @@ func info() (*infoResponse, error) {
 		IsHealthy:               deps.Tangle.IsNodeHealthy(),
 		NetworkID:               deps.NodeConfig.String(protocfg.CfgProtocolNetworkIDName),
 		Bech32HRP:               string(deps.Bech32HRP),
-		MinPowScore:             deps.NodeConfig.Float64(protocfg.CfgProtocolMinPoWScore),
+		MinPowScore:             deps.MinPowScore,
 		LatestMilestoneIndex:    latestMilestoneIndex,
 		ConfirmedMilestoneIndex: confirmedMilestoneIndex,
 		PruningIndex:            pruningIndex,

--- a/plugins/restapi/v1/plugin.go
+++ b/plugins/restapi/v1/plugin.go
@@ -182,6 +182,7 @@ type dependencies struct {
 	PeeringConfigManager *p2ppkg.ConfigManager
 	NetworkID            uint64               `name:"networkId"`
 	BelowMaxDepth        int                  `name:"belowMaxDepth"`
+	MinPowScore          float64              `name:"minPowScore"`
 	Bech32HRP            iotago.NetworkPrefix `name:"bech32HRP"`
 	TipSelector          *tipselect.TipSelector
 	Echo                 *echo.Echo


### PR DESCRIPTION
This PR fixes the behavior of the sendMessage API call.

If a message with `nonce==0` is sent via API, the node tries to do the PoW for the message itself. 
If the remote PoW is disabled, the messages are rejected, even if the PoWScore may be already sufficient.
This happens quite often for private networks with low PoWScore, since the PoW miner stats with nonce 0.

Now the node checks if the PoWScore is already sufficient, before rejecting the message or doing the PoW itself.