### PR TITLE
Move UpdateConeRootIndexes into ConfirmMilestone

### DIFF
--- a/pkg/whiteflag/confirmation.go
+++ b/pkg/whiteflag/confirmation.go
@@ -35,6 +35,7 @@ type ConfirmationMetrics struct {
 	DurationForEachNewOutput                         time.Duration
 	DurationForEachNewSpent                          time.Duration
 	DurationSetConfirmedMilestoneIndex               time.Duration
+	DurationUpdateConeRootIndexes                    time.Duration
 	DurationConfirmedMilestoneChanged                time.Duration
 	DurationConfirmedMilestoneIndexChanged           time.Duration
 	DurationMilestoneConfirmedSyncEvent              time.Duration

--- a/plugins/coordinator/plugin.go
+++ b/plugins/coordinator/plugin.go
@@ -2,7 +2,6 @@ package coordinator
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/pkg/errors"
 	flag "github.com/spf13/pflag"
@@ -27,7 +26,6 @@ import (
 	"github.com/gohornet/hornet/pkg/shutdown"
 	"github.com/gohornet/hornet/pkg/tangle"
 	"github.com/gohornet/hornet/pkg/utils"
-	"github.com/gohornet/hornet/pkg/whiteflag"
 	"github.com/iotaledger/hive.go/configuration"
 	"github.com/iotaledger/hive.go/events"
 	"github.com/iotaledger/hive.go/logger"
@@ -82,10 +80,9 @@ var (
 	lastMilestoneMessageID  hornet.MessageID
 
 	// Closures
-	onMessageSolid       *events.Closure
-	onMilestoneConfirmed *events.Closure
-	onIssuedCheckpoint   *events.Closure
-	onIssuedMilestone    *events.Closure
+	onMessageSolid     *events.Closure
+	onIssuedCheckpoint *events.Closure
+	onIssuedMilestone  *events.Closure
 
 	deps dependencies
 )
@@ -501,20 +498,6 @@ func configureEvents() {
 		}
 	})
 
-	onMilestoneConfirmed = events.NewClosure(func(confirmation *whiteflag.Confirmation) {
-		ts := time.Now()
-
-		// do not propagate during syncing, because it is not needed at all
-		if !deps.Storage.IsNodeAlmostSynced() {
-			return
-		}
-
-		// propagate new cone root indexes to the future cone for heaviest branch tipselection
-		dag.UpdateConeRootIndexes(deps.Storage, confirmation.Mutations.MessagesReferenced, confirmation.MilestoneIndex)
-
-		log.Debugf("UpdateConeRootIndexes finished, took: %v", time.Since(ts).Truncate(time.Millisecond))
-	})
-
 	onIssuedCheckpoint = events.NewClosure(func(checkpointIndex int, tipIndex int, tipsTotal int, messageID hornet.MessageID) {
 		log.Infof("checkpoint (%d) message issued (%d/%d): %v", checkpointIndex+1, tipIndex+1, tipsTotal, messageID.ToHex())
 	})
@@ -526,13 +509,11 @@ func configureEvents() {
 
 func attachEvents() {
 	deps.Tangle.Events.MessageSolid.Attach(onMessageSolid)
-	deps.Tangle.Events.MilestoneConfirmed.Attach(onMilestoneConfirmed)
 	deps.Coordinator.Events.IssuedCheckpointMessage.Attach(onIssuedCheckpoint)
 	deps.Coordinator.Events.IssuedMilestone.Attach(onIssuedMilestone)
 }
 
 func detachEvents() {
 	deps.Tangle.Events.MessageSolid.Detach(onMessageSolid)
-	deps.Tangle.Events.MilestoneConfirmed.Detach(onMilestoneConfirmed)
 	deps.Coordinator.Events.IssuedMilestone.Detach(onIssuedMilestone)
 }

--- a/plugins/prometheus/debug.go
+++ b/plugins/prometheus/debug.go
@@ -155,6 +155,7 @@ func collectDebug() {
 		milestoneConfirmationDurations.WithLabelValues("for_each_new_output").Set(lastConfirmationMetrics.DurationForEachNewOutput.Seconds())
 		milestoneConfirmationDurations.WithLabelValues("for_each_new_spent").Set(lastConfirmationMetrics.DurationForEachNewSpent.Seconds())
 		milestoneConfirmationDurations.WithLabelValues("set_confirmed_milestone_index").Set(lastConfirmationMetrics.DurationSetConfirmedMilestoneIndex.Seconds())
+		milestoneConfirmationDurations.WithLabelValues("update_cone_root_indexes").Set(lastConfirmationMetrics.DurationUpdateConeRootIndexes.Seconds())
 		milestoneConfirmationDurations.WithLabelValues("confirmed_milestone_changed").Set(lastConfirmationMetrics.DurationConfirmedMilestoneChanged.Seconds())
 		milestoneConfirmationDurations.WithLabelValues("confirmed_milestone_index_changed").Set(lastConfirmationMetrics.DurationConfirmedMilestoneIndexChanged.Seconds())
 		milestoneConfirmationDurations.WithLabelValues("milestone_confirmed_sync_event").Set(lastConfirmationMetrics.DurationMilestoneConfirmedSyncEvent.Seconds())

--- a/plugins/urts/plugin.go
+++ b/plugins/urts/plugin.go
@@ -5,7 +5,6 @@ import (
 
 	"go.uber.org/dig"
 
-	"github.com/gohornet/hornet/pkg/dag"
 	"github.com/gohornet/hornet/pkg/metrics"
 	"github.com/gohornet/hornet/pkg/model/storage"
 	"github.com/gohornet/hornet/pkg/node"
@@ -121,17 +120,12 @@ func configureEvents() {
 	})
 
 	onMilestoneConfirmed = events.NewClosure(func(confirmation *whiteflag.Confirmation) {
-		// do not propagate during syncing, because it is not needed at all
+		// do not update tip scores during syncing, because it is not needed at all
 		if !deps.Storage.IsNodeAlmostSynced() {
 			return
 		}
 
-		// propagate new cone root indexes to the future cone for URTS
 		ts := time.Now()
-		dag.UpdateConeRootIndexes(deps.Storage, confirmation.Mutations.MessagesReferenced, confirmation.MilestoneIndex)
-		log.Debugf("UpdateConeRootIndexes finished, took: %v", time.Since(ts).Truncate(time.Millisecond))
-
-		ts = time.Now()
 		removedTipCount := deps.TipSelector.UpdateScores()
 		log.Debugf("UpdateScores finished, removed: %d, took: %v", removedTipCount, time.Since(ts).Truncate(time.Millisecond))
 	})


### PR DESCRIPTION
This is needed, since we now rely on the cone root indexes for message broadcasting.

Before it was done in the plugins, since it was an optional computational overhead, only necessary for tipselection.