### PR TITLE
add cname and remove autodeploy on master branch

### DIFF
--- a/.github/workflows/deploy_docs_to_gh-pages.yml
+++ b/.github/workflows/deploy_docs_to_gh-pages.yml
@@ -3,7 +3,6 @@ name: github pages
 on:
   push:
     branches:
-        - master
         - develop
 
 jobs:
@@ -25,3 +24,4 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_branch: gh-pages
           publish_dir: ./book
+          cname: hornet.docs.iota.org


### PR DESCRIPTION
Add CNAME for docs point to: https://hornet.docs.iota.org/