### PR TITLE
Choose snapshot type based on file size of last snapshots

### DIFF
--- a/alphanet/config_alphanet.json
+++ b/alphanet/config_alphanet.json
@@ -69,6 +69,7 @@
     "interval": 200,
     "fullPath": "snapshots/alphanet/full_export.bin",
     "deltaPath": "snapshots/alphanet/delta_export.bin",
+    "deltaSizeThresholdPercentage": 50.0,
     "downloadURLs": []
   },
   "pruning": {

--- a/config.json
+++ b/config.json
@@ -55,6 +55,7 @@
     "interval": 50,
     "fullPath": "snapshots/mainnet/full_snapshot.bin",
     "deltaPath": "snapshots/mainnet/delta_snapshot.bin",
+    "deltaSizeThresholdPercentage": 50.0,
     "downloadURLs": [
       {
         "full": "https://ls.manapotion.io/full_snapshot.bin",

--- a/config_chrysalis_testnet.json
+++ b/config_chrysalis_testnet.json
@@ -57,6 +57,7 @@
     "interval": 200,
     "fullPath": "snapshots/testnet/full_snapshot.bin",
     "deltaPath": "snapshots/testnet/delta_snapshot.bin",
+    "deltaSizeThresholdPercentage": 50.0,
     "downloadURLs": [
       {
         "full": "https://dbfiles.testnet.chrysalis2.com/full_snapshot.bin",

--- a/config_comnet.json
+++ b/config_comnet.json
@@ -57,6 +57,7 @@
     "interval": 200,
     "fullPath": "snapshots/comnet/full_snapshot.bin",
     "deltaPath": "snapshots/comnet/delta_snapshot.bin",
+    "deltaSizeThresholdPercentage": 50.0,
     "downloadURLs": [
       {
         "full": "https://ls.manapotion.io/comnet/full_snapshot.bin",

--- a/config_devnet.json
+++ b/config_devnet.json
@@ -57,6 +57,7 @@
     "interval": 50,
     "fullPath": "snapshots/devnet/full_snapshot.bin",
     "deltaPath": "snapshots/devnet/delta_snapshot.bin",
+    "deltaSizeThresholdPercentage": 50.0,
     "downloadURLs": [
       {
         "full": "https://dbfiles.iota.org/devnet/hornet/full_snapshot.bin",

--- a/core/snapshot/core.go
+++ b/core/snapshot/core.go
@@ -121,6 +121,7 @@ func provide(c *dig.Container) {
 			networkIDSource,
 			deps.NodeConfig.String(CfgSnapshotsFullPath),
 			deps.NodeConfig.String(CfgSnapshotsDeltaPath),
+			deps.NodeConfig.Float64(CfgSnapshotsDeltaSizeThresholdPercentage),
 			downloadTargets,
 			solidEntryPointCheckThresholdPast,
 			solidEntryPointCheckThresholdFuture,

--- a/core/snapshot/params.go
+++ b/core/snapshot/params.go
@@ -22,6 +22,7 @@ const (
 	// path to the delta snapshot file
 	CfgSnapshotsDeltaPath = "snapshots.deltaPath"
 	// create a full snapshot if the size of a delta snapshot reaches a certain percentage of the full snapshot
+	// (0.0 = always create delta snapshot to keep ms diff history)
 	CfgSnapshotsDeltaSizeThresholdPercentage = "snapshots.deltaSizeThresholdPercentage"
 	// URLs to load the snapshot files from.
 	CfgSnapshotsDownloadURLs = "snapshots.downloadURLs"
@@ -38,7 +39,7 @@ var params = &node.PluginParams{
 			fs.Int(CfgSnapshotsInterval, 50, "interval, in milestones, at which snapshot files are created (snapshots are only created if the node is synced)")
 			fs.String(CfgSnapshotsFullPath, "snapshots/mainnet/full_export.bin", "path to the full snapshot file")
 			fs.String(CfgSnapshotsDeltaPath, "snapshots/mainnet/delta_export.bin", "path to the delta snapshot file")
-			fs.Float64(CfgSnapshotsDeltaSizeThresholdPercentage, 50.0, "create a full snapshot if the size of a delta snapshot reaches a certain percentage of the full snapshot")
+			fs.Float64(CfgSnapshotsDeltaSizeThresholdPercentage, 50.0, "create a full snapshot if the size of a delta snapshot reaches a certain percentage of the full snapshot (0.0 = always create delta snapshot to keep ms diff history)")
 			return fs
 		}(),
 	},

--- a/core/snapshot/params.go
+++ b/core/snapshot/params.go
@@ -21,6 +21,8 @@ const (
 	CfgSnapshotsFullPath = "snapshots.fullPath"
 	// path to the delta snapshot file
 	CfgSnapshotsDeltaPath = "snapshots.deltaPath"
+	// create a full snapshot if the size of a delta snapshot reaches a certain percentage of the full snapshot
+	CfgSnapshotsDeltaSizeThresholdPercentage = "snapshots.deltaSizeThresholdPercentage"
 	// URLs to load the snapshot files from.
 	CfgSnapshotsDownloadURLs = "snapshots.downloadURLs"
 )
@@ -36,6 +38,7 @@ var params = &node.PluginParams{
 			fs.Int(CfgSnapshotsInterval, 50, "interval, in milestones, at which snapshot files are created (snapshots are only created if the node is synced)")
 			fs.String(CfgSnapshotsFullPath, "snapshots/mainnet/full_export.bin", "path to the full snapshot file")
 			fs.String(CfgSnapshotsDeltaPath, "snapshots/mainnet/delta_export.bin", "path to the delta snapshot file")
+			fs.Float64(CfgSnapshotsDeltaSizeThresholdPercentage, 50.0, "create a full snapshot if the size of a delta snapshot reaches a certain percentage of the full snapshot")
 			return fs
 		}(),
 	},

--- a/docs/configuration/config.md
+++ b/docs/configuration/config.md
@@ -9,7 +9,7 @@ You can always get the most up-to-date description of the config parameters by r
 
 - [Table of content](#table-of-content)
 - [1. REST API](#1-rest-api)
-  - [Basic auth](#basic-auth)
+  - [JWT Auth](#jwt-auth)
   - [Limits](#limits)
 - [2. Dashboard](#2-dashboard)
   - [Auth](#auth)
@@ -58,7 +58,7 @@ You can always get the most up-to-date description of the config parameters by r
 
 | Name                       | Description                                                                     | Type             |
 | :------------------------- | :------------------------------------------------------------------------------ | :--------------- |
-| [jwtAuth](#jwt-auth)        | config for JWT auth                                                             | object           |
+| [jwtAuth](#jwt-auth)       | config for JWT auth                                                             | object           |
 | permittedRoutes            | the allowed HTTP REST routes which can be called from non whitelisted addresses | array of strings |
 | whitelistedAddresses       | the whitelist of addresses which are allowed to access the REST API             | array of strings |
 | bindAddress                | the bind address on which the REST API listens on                               | string           |
@@ -69,10 +69,10 @@ You can always get the most up-to-date description of the config parameters by r
 
 ### JWT Auth
 
-| Name         | Description                                                                                                                              | Type   |
-| :----------- | :--------------------------------------------------------------------------------------------------------------------------------------- | :----- |
-| enabled      | whether to use JWT auth for the REST API                                                                                                 | bool   |
-| salt         | salt used inside the JWT tokens for the REST API. Change this to a different value to invalidate JWT tokens not matching this new value  | string |
+| Name    | Description                                                                                                                             | Type   |
+| :------ | :-------------------------------------------------------------------------------------------------------------------------------------- | :----- |
+| enabled | whether to use JWT auth for the REST API                                                                                                | bool   |
+| salt    | salt used inside the JWT tokens for the REST API. Change this to a different value to invalidate JWT tokens not matching this new value | string |
 
 
 ### Limits
@@ -176,14 +176,14 @@ Example:
 
 ## 4. Snapshots
 
-| Name                          | Description                                                                                                     | Type             |
-| :---------------------------- | :-------------------------------------------------------------------------------------------------------------- | :--------------- |
-| interval                      | interval, in milestones, at which snapshot files are created (snapshots are only created if the node is synced) | integer          |
-| depth                         | the depth, respectively the starting point, at which a snapshot of the ledger is generated                      | integer          |
-| fullPath                      | path to the full snapshot file                                                                                  | string           |
-| deltaPath                     | path to the delta snapshot file                                                                                 | string           |
-| deltaSizeThresholdPercentage  | create a full snapshot if the size of a delta snapshot reaches a certain percentage of the full snapshot        | float            |
-| [downloadURLs](#downloadurls) | URLs to load the snapshot files from.                                                                           | array of objects |
+| Name                          | Description                                                                                                                                                            | Type             |
+| :---------------------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :--------------- |
+| interval                      | interval, in milestones, at which snapshot files are created (snapshots are only created if the node is synced)                                                        | integer          |
+| depth                         | the depth, respectively the starting point, at which a snapshot of the ledger is generated                                                                             | integer          |
+| fullPath                      | path to the full snapshot file                                                                                                                                         | string           |
+| deltaPath                     | path to the delta snapshot file                                                                                                                                        | string           |
+| deltaSizeThresholdPercentage  | create a full snapshot if the size of a delta snapshot reaches a certain percentage of the full snapshot  (0.0 = always create delta snapshot to keep ms diff history) | float            |
+| [downloadURLs](#downloadurls) | URLs to load the snapshot files from.                                                                                                                                  | array of objects |
 
 ### DownloadURLs
 
@@ -462,12 +462,12 @@ Example:
 
 ## 11. Node
 
-| Name           | Description                               | Type             |
-| :------------- | :---------------------------------------- | :--------------- |
-| alias          | the alias to identify a node              | string           |
-| profile        | the profile the node runs with            | string           |
-| disablePlugins | a list of plugins that shall be disabled  | array of strings |
-| enablePlugins  | a list of plugins that shall be enabled   | array of strings |
+| Name           | Description                              | Type             |
+| :------------- | :--------------------------------------- | :--------------- |
+| alias          | the alias to identify a node             | string           |
+| profile        | the profile the node runs with           | string           |
+| disablePlugins | a list of plugins that shall be disabled | array of strings |
+| enablePlugins  | a list of plugins that shall be enabled  | array of strings |
 
 Example:
 

--- a/docs/configuration/config.md
+++ b/docs/configuration/config.md
@@ -182,6 +182,7 @@ Example:
 | depth                         | the depth, respectively the starting point, at which a snapshot of the ledger is generated                      | integer          |
 | fullPath                      | path to the full snapshot file                                                                                  | string           |
 | deltaPath                     | path to the delta snapshot file                                                                                 | string           |
+| deltaSizeThresholdPercentage  | create a full snapshot if the size of a delta snapshot reaches a certain percentage of the full snapshot        | float            |
 | [downloadURLs](#downloadurls) | URLs to load the snapshot files from.                                                                           | array of objects |
 
 ### DownloadURLs
@@ -199,6 +200,7 @@ Example:
     "depth": 50,
     "fullPath": "snapshots/mainnet/full_export.bin",
     "deltaPath": "snapshots/mainnet/delta_export.bin",
+    "deltaSizeThresholdPercentage": 50.0,
     "downloadURLs": [
       {
         "full": "https://source1.example.com/full_export.bin",

--- a/pkg/snapshot/snapshot.go
+++ b/pkg/snapshot/snapshot.go
@@ -1015,6 +1015,11 @@ func (s *Snapshot) LoadSnapshotFromFile(snapshotType Type, networkID uint64, fil
 // optimalSnapshotType returns the optimal snapshot type
 // based on the file size of the last full and delta snapshot file.
 func (s *Snapshot) optimalSnapshotType() Type {
+	if s.deltaSnapshotSizeThresholdPercentage == 0.0 {
+		// special case => always create a delta snapshot to keep entire milestone diff history
+		return Delta
+	}
+
 	fullSnapshotFileInfo, err := os.Stat(s.snapshotFullPath)
 	fullSnapshotFileExists := !os.IsNotExist(err)
 

--- a/pkg/snapshot/snapshot.go
+++ b/pkg/snapshot/snapshot.go
@@ -65,23 +65,24 @@ type solidEntryPoint struct {
 
 // Snapshot handles reading and writing snapshot data.
 type Snapshot struct {
-	shutdownCtx                         context.Context
-	log                                 *logger.Logger
-	storage                             *storage.Storage
-	utxo                                *utxo.Manager
-	networkID                           uint64
-	networkIDSource                     string
-	snapshotFullPath                    string
-	snapshotDeltaPath                   string
-	downloadTargets                     []DownloadTarget
-	solidEntryPointCheckThresholdPast   milestone.Index
-	solidEntryPointCheckThresholdFuture milestone.Index
-	additionalPruningThreshold          milestone.Index
-	snapshotDepth                       milestone.Index
-	snapshotInterval                    milestone.Index
-	pruningEnabled                      bool
-	pruningDelay                        milestone.Index
-	pruneReceipts                       bool
+	shutdownCtx                          context.Context
+	log                                  *logger.Logger
+	storage                              *storage.Storage
+	utxo                                 *utxo.Manager
+	networkID                            uint64
+	networkIDSource                      string
+	snapshotFullPath                     string
+	snapshotDeltaPath                    string
+	deltaSnapshotSizeThresholdPercentage float64
+	downloadTargets                      []DownloadTarget
+	solidEntryPointCheckThresholdPast    milestone.Index
+	solidEntryPointCheckThresholdFuture  milestone.Index
+	additionalPruningThreshold           milestone.Index
+	snapshotDepth                        milestone.Index
+	snapshotInterval                     milestone.Index
+	pruningEnabled                       bool
+	pruningDelay                         milestone.Index
+	pruneReceipts                        bool
 
 	snapshotLock   syncutils.Mutex
 	statusLock     syncutils.RWMutex
@@ -100,6 +101,7 @@ func New(shutdownCtx context.Context,
 	networkIDSource string,
 	snapshotFullPath string,
 	snapshotDeltaPath string,
+	deltaSnapshotSizeThresholdPercentage float64,
 	downloadTargets []DownloadTarget,
 	solidEntryPointCheckThresholdPast milestone.Index,
 	solidEntryPointCheckThresholdFuture milestone.Index,
@@ -111,23 +113,24 @@ func New(shutdownCtx context.Context,
 	pruneReceipts bool) *Snapshot {
 
 	return &Snapshot{
-		shutdownCtx:                         shutdownCtx,
-		log:                                 log,
-		storage:                             storage,
-		utxo:                                utxo,
-		networkID:                           networkID,
-		networkIDSource:                     networkIDSource,
-		snapshotFullPath:                    snapshotFullPath,
-		snapshotDeltaPath:                   snapshotDeltaPath,
-		downloadTargets:                     downloadTargets,
-		solidEntryPointCheckThresholdPast:   solidEntryPointCheckThresholdPast,
-		solidEntryPointCheckThresholdFuture: solidEntryPointCheckThresholdFuture,
-		additionalPruningThreshold:          additionalPruningThreshold,
-		snapshotDepth:                       snapshotDepth,
-		snapshotInterval:                    snapshotInterval,
-		pruningEnabled:                      pruningEnabled,
-		pruningDelay:                        pruningDelay,
-		pruneReceipts:                       pruneReceipts,
+		shutdownCtx:                          shutdownCtx,
+		log:                                  log,
+		storage:                              storage,
+		utxo:                                 utxo,
+		networkID:                            networkID,
+		networkIDSource:                      networkIDSource,
+		snapshotFullPath:                     snapshotFullPath,
+		snapshotDeltaPath:                    snapshotDeltaPath,
+		deltaSnapshotSizeThresholdPercentage: deltaSnapshotSizeThresholdPercentage,
+		downloadTargets:                      downloadTargets,
+		solidEntryPointCheckThresholdPast:    solidEntryPointCheckThresholdPast,
+		solidEntryPointCheckThresholdFuture:  solidEntryPointCheckThresholdFuture,
+		additionalPruningThreshold:           additionalPruningThreshold,
+		snapshotDepth:                        snapshotDepth,
+		snapshotInterval:                     snapshotInterval,
+		pruningEnabled:                       pruningEnabled,
+		pruningDelay:                         pruningDelay,
+		pruneReceipts:                        pruneReceipts,
 		Events: &Events{
 			SnapshotMilestoneIndexChanged: events.NewEvent(milestone.IndexCaller),
 			SnapshotMetricsUpdated:        events.NewEvent(SnapshotMetricsCaller),
@@ -780,6 +783,15 @@ func (s *Snapshot) createSnapshotWithoutLocking(snapshotType Type, targetIndex m
 		return err
 	}
 
+	if (snapshotType == Full) && (filePath == s.snapshotFullPath) {
+		// if the old full snapshot file is overwritten
+		// we need to remove the old delta snapshot file since it
+		// isn't compatible to the full snapshot file anymore.
+		if err := os.Remove(s.snapshotDeltaPath); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("deleting delta snapshot file failed: %s", err)
+		}
+	}
+
 	timeSetSnapshotInfo := timeStreamSnapshotData
 	timeSnapshotMilestoneIndexChanged := timeStreamSnapshotData
 	if writeToDatabase {
@@ -1000,6 +1012,47 @@ func (s *Snapshot) LoadSnapshotFromFile(snapshotType Type, networkID uint64, fil
 	return nil
 }
 
+// optimalSnapshotType returns the optimal snapshot type
+// based on the file size of the last full and delta snapshot file.
+func (s *Snapshot) optimalSnapshotType() Type {
+	fullSnapshotFileInfo, err := os.Stat(s.snapshotFullPath)
+	fullSnapshotFileExists := !os.IsNotExist(err)
+
+	if !fullSnapshotFileExists {
+		// full snapshot doesn't exist => create a full snapshot
+		return Full
+	}
+
+	deltaSnapshotFileInfo, err := os.Stat(s.snapshotDeltaPath)
+	deltaSnapshotFileExists := !os.IsNotExist(err)
+
+	if !deltaSnapshotFileExists {
+		// delta snapshot doesn't exist => create a delta snapshot
+		return Delta
+	}
+
+	// if the file size of the last delta snapshot is bigger than a certain percentage
+	// of the full snapshot file, it's more efficient to create a new full snapshot.
+	if int64(float64(fullSnapshotFileInfo.Size())*s.deltaSnapshotSizeThresholdPercentage/100.0) < deltaSnapshotFileInfo.Size() {
+		return Full
+	}
+
+	return Delta
+}
+
+// snapshotTypeFilePath returns the default file path
+// for the given snapshot type.
+func (s *Snapshot) snapshotTypeFilePath(snapshotType Type) string {
+	switch snapshotType {
+	case Full:
+		return s.snapshotFullPath
+	case Delta:
+		return s.snapshotDeltaPath
+	default:
+		panic("unknown snapshot type")
+	}
+}
+
 // HandleNewConfirmedMilestoneEvent handles new confirmed milestone events which may trigger a delta snapshot creation and pruning.
 func (s *Snapshot) HandleNewConfirmedMilestoneEvent(confirmedMilestoneIndex milestone.Index, shutdownSignal <-chan struct{}) {
 	if !s.storage.IsNodeAlmostSynced() {
@@ -1011,7 +1064,8 @@ func (s *Snapshot) HandleNewConfirmedMilestoneEvent(confirmedMilestoneIndex mile
 	defer s.snapshotLock.Unlock()
 
 	if s.shouldTakeSnapshot(confirmedMilestoneIndex) {
-		if err := s.createSnapshotWithoutLocking(Delta, confirmedMilestoneIndex-s.snapshotDepth, s.snapshotDeltaPath, true, shutdownSignal); err != nil {
+		snapshotType := s.optimalSnapshotType()
+		if err := s.createSnapshotWithoutLocking(snapshotType, confirmedMilestoneIndex-s.snapshotDepth, s.snapshotTypeFilePath(snapshotType), true, shutdownSignal); err != nil {
 			if errors.Is(err, ErrCritical) {
 				s.log.Panicf("%s %s", ErrSnapshotCreationFailed, err)
 			}


### PR DESCRIPTION
Fixes #987 

The new concept of full and delta snapshots, introduced in chrysalis, is used to reduce the download size of snapshot files.
A full snapshot file always contains the complete ledger state, while a delta snapshot file only contains the milestones including ledger changes since the last full snapshot file.

Creating and applying a delta snapshot file creates more IO pressure on the node, and the file size of a delta snapshot file can grow bigger than the last full snapshot file. Because of these reasons, it makes sense to create a full snapshot file instead of a delta snapshot file, if a certain ratio in the file size of the last snapshots is reached. 