### PR TITLE
Read/write state files of coo and migrator as JSON

### DIFF
--- a/pkg/model/coordinator/coordinator.go
+++ b/pkg/model/coordinator/coordinator.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/gohornet/hornet/pkg/utils"
+
 	"github.com/gohornet/hornet/pkg/common"
 	"github.com/gohornet/hornet/pkg/model/hornet"
 	"github.com/gohornet/hornet/pkg/model/migrator"
@@ -263,8 +265,7 @@ func (coo *Coordinator) InitState(bootstrap bool, startIndex milestone.Index) er
 		return fmt.Errorf("state file not found: %v", coo.opts.stateFilePath)
 	}
 
-	coo.state, err = loadStateFile(coo.opts.stateFilePath)
-	if err != nil {
+	if err := utils.ReadJSONFromFile(coo.opts.stateFilePath, coo.state); err != nil {
 		return err
 	}
 
@@ -378,7 +379,7 @@ func (coo *Coordinator) createAndSendMilestone(parents hornet.MessageIDs, newMil
 	coo.state.LatestMilestoneIndex = newMilestoneIndex
 	coo.state.LatestMilestoneTime = time.Now()
 
-	if err := coo.state.storeStateFile(coo.opts.stateFilePath); err != nil {
+	if err := utils.WriteJSONToFile(coo.opts.stateFilePath, coo.state, 0660); err != nil {
 		return common.CriticalError(fmt.Errorf("failed to update coordinator state file: %w", err))
 	}
 

--- a/pkg/model/coordinator/state.go
+++ b/pkg/model/coordinator/state.go
@@ -1,11 +1,8 @@
 package coordinator
 
 import (
-	"encoding"
-	"encoding/binary"
-	"fmt"
-	"io/ioutil"
-	"os"
+	"encoding/hex"
+	"encoding/json"
 	"time"
 
 	"github.com/gohornet/hornet/pkg/model/hornet"
@@ -14,95 +11,40 @@ import (
 
 // State stores the latest state of the coordinator.
 type State struct {
-	encoding.BinaryMarshaler
-	encoding.BinaryUnmarshaler
-
 	LatestMilestoneIndex     milestone.Index
 	LatestMilestoneMessageID hornet.MessageID
 	LatestMilestoneTime      time.Time
 }
 
-// MarshalBinary returns the binary representation of the coordinator state.
-func (cs *State) MarshalBinary() (data []byte, err error) {
-
-	/*
-		 4 bytes uint32 			LatestMilestoneIndex
-		32 bytes     			    LatestMilestoneMessageID
-		 8 bytes uint64 			LatestMilestoneTime
-	*/
-
-	data = make([]byte, 4+32+8)
-
-	binary.LittleEndian.PutUint32(data[0:4], uint32(cs.LatestMilestoneIndex))
-	copy(data[4:36], cs.LatestMilestoneMessageID)
-	binary.LittleEndian.PutUint64(data[36:44], uint64(cs.LatestMilestoneTime.UnixNano()))
-
-	return data, nil
+// jsoncoostate is the JSON representation of a coordinator state.
+type jsoncoostate struct {
+	LatestMilestoneIndex     uint32 `json:"latestMilestoneIndex"`
+	LatestMilestoneMessageID string `json:"latestMilestoneMessageID"`
+	LatestMilestoneTime      int64  `json:"latestMilestoneTime"`
 }
 
-// UnmarshalBinary parses the binary encoded representation of the coordinator state.
-func (cs *State) UnmarshalBinary(data []byte) error {
-
-	/*
-		 4 bytes uint32 			LatestMilestoneIndex
-		32 bytes     			    LatestMilestoneMessageID
-		 8 bytes uint64 			LatestMilestoneTime
-	*/
-
-	if len(data) < 44 {
-		return fmt.Errorf("not enough bytes to unmarshal state, expected: 44, got: %d", len(data))
-	}
-
-	cs.LatestMilestoneIndex = milestone.Index(binary.LittleEndian.Uint32(data[0:4]))
-	cs.LatestMilestoneMessageID = hornet.MessageIDFromSlice(data[4:36])
-	cs.LatestMilestoneTime = time.Unix(0, int64(binary.LittleEndian.Uint64(data[36:44])))
-
-	return nil
+func (cs *State) MarshalJSON() ([]byte, error) {
+	return json.Marshal(&jsoncoostate{
+		LatestMilestoneIndex:     uint32(cs.LatestMilestoneIndex),
+		LatestMilestoneMessageID: hex.EncodeToString(cs.LatestMilestoneMessageID),
+		LatestMilestoneTime:      cs.LatestMilestoneTime.UnixNano(),
+	})
 }
 
-// loadStateFile loads the binary state file and unmarshals it.
-func loadStateFile(filePath string) (*State, error) {
-
-	stateFile, err := os.OpenFile(filePath, os.O_RDONLY, 0666)
-	if err != nil {
-		return nil, err
-	}
-	defer stateFile.Close()
-
-	data, err := ioutil.ReadAll(stateFile)
-	if err != nil {
-		return nil, err
+func (cs *State) UnmarshalJSON(data []byte) error {
+	jsonCooState := &jsoncoostate{}
+	if err := json.Unmarshal(data, jsonCooState); err != nil {
+		return err
 	}
 
-	result := &State{}
-	if err := result.UnmarshalBinary(data); err != nil {
-		return nil, err
-	}
-
-	return result, nil
-}
-
-// storeStateFile stores the state file for the coordinator in binary format.
-func (cs *State) storeStateFile(filePath string) error {
-
-	data, err := cs.MarshalBinary()
+	var err error
+	cs.LatestMilestoneMessageID, err = hex.DecodeString(jsonCooState.LatestMilestoneMessageID)
 	if err != nil {
 		return err
 	}
 
-	stateFile, err := os.OpenFile(filePath, os.O_RDWR|os.O_CREATE, 0660)
-	if err != nil {
-		return err
-	}
-	defer stateFile.Close()
-
-	if _, err := stateFile.Write(data); err != nil {
-		return err
-	}
-
-	if err := stateFile.Sync(); err != nil {
-		return err
-	}
+	cs.LatestMilestoneIndex = milestone.Index(jsonCooState.LatestMilestoneIndex)
+	cs.LatestMilestoneTime = time.Unix(0, jsonCooState.LatestMilestoneTime)
 
 	return nil
 }

--- a/pkg/model/migrator/service.go
+++ b/pkg/model/migrator/service.go
@@ -62,13 +62,9 @@ type MigratorService struct {
 
 // State stores the latest state of the MigratorService.
 type State struct {
-	/*
-	   4 bytes uint32 			LatestMigratedAtIndex
-	   4 bytes uint32 			LatestIncludedIndex
-	*/
-	LatestMigratedAtIndex uint32
-	LatestIncludedIndex   uint32
-	SendingReceipt        bool
+	LatestMigratedAtIndex uint32 `json:"latestMigratedAtIndex"`
+	LatestIncludedIndex   uint32 `json:"latestIncludedIndex"`
+	SendingReceipt        bool   `json:"sendingReceipt"`
 }
 
 type migrationResult struct {
@@ -120,7 +116,7 @@ func (s *MigratorService) PersistState(sendingReceipt bool) error {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 	s.state.SendingReceipt = sendingReceipt
-	return utils.WriteToFile(s.stateFilePath, &s.state, 0660)
+	return utils.WriteJSONToFile(s.stateFilePath, &s.state, 0660)
 }
 
 // InitState initializes the state of s.
@@ -135,7 +131,7 @@ func (s *MigratorService) InitState(msIndex *uint32, utxoManager *utxo.Manager) 
 	var state State
 	if msIndex == nil {
 		// restore state from file
-		if err := utils.ReadFromFile(s.stateFilePath, &state); err != nil {
+		if err := utils.ReadJSONFromFile(s.stateFilePath, &state); err != nil {
 			return fmt.Errorf("failed to load state file: %w", err)
 		}
 	} else {

--- a/pkg/utils/io.go
+++ b/pkg/utils/io.go
@@ -2,6 +2,9 @@ package utils
 
 import (
 	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
 	"os"
 )
 
@@ -34,4 +37,46 @@ func WriteToFile(filename string, data interface{}, perm os.FileMode) (err error
 		}
 	}()
 	return binary.Write(f, binary.LittleEndian, data)
+}
+
+// ReadJSONFromFile reads JSON data from the file named by filename to data.
+// ReadJSONFromFile uses json.Unmarshal to decode data. Data must be a pointer to a fixed-size value or a slice
+// of fixed-size values.
+func ReadJSONFromFile(filename string, data interface{}) error {
+	jsonData, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return fmt.Errorf("unable to read JSON file %s: %w", filename, err)
+	}
+	return json.Unmarshal(jsonData, data)
+}
+
+// WriteJSONToFile writes the JSON representation of data to a file named by filename.
+// If the file does not exist, WriteJSONToFile creates it with permissions perm
+// (before umask); otherwise WriteJSONToFile truncates it before writing, without changing permissions.
+// WriteJSONToFile uses json.MarshalIndent to encode data. Data must be a pointer to a fixed-size value or a slice
+// of fixed-size values.
+func WriteJSONToFile(filename string, data interface{}, perm os.FileMode) (err error) {
+	f, err := os.OpenFile(filename, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, perm)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if closeErr := f.Close(); err == nil {
+			err = closeErr
+		}
+	}()
+	jsonData, err := json.MarshalIndent(data, "", "  ")
+	if err != nil {
+		return fmt.Errorf("unable to marshal data to JSON: %w", err)
+	}
+
+	if _, err := f.Write(jsonData); err != nil {
+		return fmt.Errorf("unable to write JSON data to %s: %w", filename, err)
+	}
+
+	if err := f.Sync(); err != nil {
+		return fmt.Errorf("unable to fsync file content to %s: %w", filename, err)
+	}
+
+	return
 }


### PR DESCRIPTION
Makes the state files for the `Coordinator` and `Migrator` be written as pretty formatted JSON in order to make crash recovery easier.

For the `Coordinator` state, an auxiliary struct is used which marshals the `LatestMilestoneMessageID` as a hex encoded string instead of as a base64 string and the `LatestMilestoneTime` is written/read as a nano seconds timestamp.

Calls to `WriteJSONToFile` are `f.Sync()`ed before the function returns to ensure data durability. (Just calling `f.Close()` might flush content to disk afterwards).