### PR TITLE
Fix "Synced too far back"

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-version v1.3.0 // indirect
-	github.com/iotaledger/hive.go v0.0.0-20210407190616-baeca30bf2dd
+	github.com/iotaledger/hive.go v0.0.0-20210414081750-6ea719a58c1d
 	github.com/iotaledger/iota.go v1.0.0-beta.15.0.20210406071024-a52cf8c2c21e
 	github.com/iotaledger/iota.go/v2 v2.0.0-20210409074803-07a6438d40cf
 	github.com/ipfs/go-ds-badger v0.2.6

--- a/go.sum
+++ b/go.sum
@@ -421,8 +421,8 @@ github.com/hydrogen18/memlistener v0.0.0-20141126152155-54553eb933fb/go.mod h1:q
 github.com/imkira/go-interpol v1.1.0/go.mod h1:z0h2/2T3XF8kyEPpRgJ3kmNv+C43p+I/CoI+jC3w2iA=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
-github.com/iotaledger/hive.go v0.0.0-20210407190616-baeca30bf2dd h1:40hi+d6MG7EZzwcMt7eLDMdPYYxwPo9T0xWQOhNKwxs=
-github.com/iotaledger/hive.go v0.0.0-20210407190616-baeca30bf2dd/go.mod h1:NyBg/Ny7FFAdDs59zdwTVoysU2ZbJVQnRwyLIDFKJYA=
+github.com/iotaledger/hive.go v0.0.0-20210414081750-6ea719a58c1d h1:EQ+QY3j6T2rgYmDdSGC2B8dxM93FFUUVKJ6zsHLYj+c=
+github.com/iotaledger/hive.go v0.0.0-20210414081750-6ea719a58c1d/go.mod h1:NyBg/Ny7FFAdDs59zdwTVoysU2ZbJVQnRwyLIDFKJYA=
 github.com/iotaledger/iota.go v1.0.0-beta.15.0.20210120184258-7eac7c1cc80b/go.mod h1:Rn6v5hLAn8YBaJlRu1ZQdPAgKlshJR1PTeLQaft2778=
 github.com/iotaledger/iota.go v1.0.0-beta.15.0.20210212090247-51c40bcebea7/go.mod h1:RiKYwDyY7aCD1L0YRzHSjOsJ5mUR9yvQpvhZncNcGQI=
 github.com/iotaledger/iota.go v1.0.0-beta.15.0.20210406071024-a52cf8c2c21e h1:J8SDeVkkK5u0MKKusDy4hOBK3xRDpuGpuMLZkLCkEyk=

--- a/pkg/model/storage/messages_storage.go
+++ b/pkg/model/storage/messages_storage.go
@@ -335,7 +335,7 @@ func (s *Storage) AddMessageToStorage(message *Message, latestMilestoneIndex mil
 	}
 
 	if ms := s.VerifyMilestone(message); ms != nil {
-		s.StoreMilestone(cachedMessage.Retain(), ms)
+		s.StoreMilestone(cachedMessage.Retain(), ms, requested)
 	}
 
 	return cachedMessage, false

--- a/pkg/model/storage/milestones.go
+++ b/pkg/model/storage/milestones.go
@@ -31,6 +31,10 @@ func MilestoneCaller(handler interface{}, params ...interface{}) {
 	handler.(func(cachedMs *CachedMilestone))(params[0].(*CachedMilestone).Retain())
 }
 
+func MilestoneWithRequestedCaller(handler interface{}, params ...interface{}) {
+	handler.(func(cachedMs *CachedMilestone, requested bool))(params[0].(*CachedMilestone).Retain(), params[1].(bool))
+}
+
 func (s *Storage) KeyManager() *keymanager.KeyManager {
 	return s.keyManager
 }
@@ -284,7 +288,7 @@ func (s *Storage) VerifyMilestone(message *Message) *iotago.Milestone {
 }
 
 // StoreMilestone stores the milestone in the storage layer and triggers the ReceivedValidMilestone event.
-func (s *Storage) StoreMilestone(cachedMessage *CachedMessage, ms *iotago.Milestone) {
+func (s *Storage) StoreMilestone(cachedMessage *CachedMessage, ms *iotago.Milestone, requested bool) {
 	defer cachedMessage.Release(true)
 
 	cachedMilestone, newlyAdded := s.storeMilestoneIfAbsent(milestone.Index(ms.Index), cachedMessage.GetMessage().GetMessageID(), time.Unix(int64(ms.Timestamp), 0))
@@ -295,5 +299,5 @@ func (s *Storage) StoreMilestone(cachedMessage *CachedMessage, ms *iotago.Milest
 	// Force release to store milestones without caching
 	defer cachedMilestone.Release(true) // milestone +-0
 
-	s.Events.ReceivedValidMilestone.Trigger(cachedMilestone) // milestone pass +1
+	s.Events.ReceivedValidMilestone.Trigger(cachedMilestone, requested) // milestone pass +1
 }

--- a/pkg/model/storage/storage.go
+++ b/pkg/model/storage/storage.go
@@ -93,7 +93,7 @@ func New(databaseDirectory string, store kvstore.KVStore, cachesProfile *profile
 		utxoManager:             utxoManager,
 		belowMaxDepth:           milestone.Index(belowMaxDepth),
 		Events: &packageEvents{
-			ReceivedValidMilestone: events.NewEvent(MilestoneCaller),
+			ReceivedValidMilestone: events.NewEvent(MilestoneWithRequestedCaller),
 			PruningStateChanged:    events.NewEvent(events.BoolCaller),
 		},
 	}

--- a/pkg/protocol/gossip/msg_proc.go
+++ b/pkg/protocol/gossip/msg_proc.go
@@ -307,7 +307,7 @@ func (proc *MessageProcessor) processMessageRequest(p *Protocol, data []byte) {
 func (proc *MessageProcessor) processMessage(p *Protocol, data []byte) {
 	cachedWorkUnit, newlyAdded := proc.workUnitFor(data) // workUnit +1
 
-	// force release if not newly added, so the cache time only is active at first receive of the message.
+	// force release if not newly added, so the cache time is only active the first time the message is received.
 	defer cachedWorkUnit.Release(!newlyAdded) // workUnit -1
 
 	workUnit := cachedWorkUnit.WorkUnit()

--- a/pkg/protocol/gossip/warpsync.go
+++ b/pkg/protocol/gossip/warpsync.go
@@ -17,13 +17,13 @@ import (
 // If no advancement func is provided, the WarpSync uses AdvanceAtPercentageReached with DefaultAdvancementThreshold.
 func NewWarpSync(advRange int, advanceCheckpointCriteriaFunc ...AdvanceCheckpointCriteria) *WarpSync {
 	ws := &WarpSync{
+		AdvancementRange: advRange,
 		Events: Events{
 			CheckpointUpdated: events.NewEvent(CheckpointCaller),
 			TargetUpdated:     events.NewEvent(TargetCaller),
 			Start:             events.NewEvent(SyncStartCaller),
 			Done:              events.NewEvent(SyncDoneCaller),
 		},
-		AdvancementRange: advRange,
 	}
 	if len(advanceCheckpointCriteriaFunc) > 0 {
 		ws.advCheckpointCriteria = advanceCheckpointCriteriaFunc[0]
@@ -86,34 +86,40 @@ func AdvanceAtPercentageReached(threshold float64) AdvanceCheckpointCriteria {
 
 // WarpSync is metadata about doing a synchronization via STING messages.
 type WarpSync struct {
-	mu                    sync.Mutex
-	start                 time.Time
+	sync.Mutex
+
+	// The used advancement range per checkpoint.
+	AdvancementRange int
+	// The Events of the warpsync.
+	Events Events
+	// The criteria whether to advance to the next checkpoint.
 	advCheckpointCriteria AdvanceCheckpointCriteria
-	Events                Events
-	// The starting point of the synchronization.
-	Init milestone.Index
+
 	// The current confirmed milestone of the node.
-	CurrentConfirmedMs milestone.Index
+	CurrentConfirmedMilestone milestone.Index
+	// The starting time of the synchronization.
+	StartTime time.Time
+	// The starting point of the synchronization.
+	InitMilestone milestone.Index
 	// The target milestone to which to synchronize to.
-	TargetMs milestone.Index
+	TargetMilestone milestone.Index
 	// The previous checkpoint of the synchronization.
 	PreviousCheckpoint milestone.Index
 	// The current checkpoint of the synchronization.
 	CurrentCheckpoint milestone.Index
-	// The used advancement range per checkpoint.
-	AdvancementRange int
 	// The amount of referenced messages during this warpsync run.
 	referencedMessagesTotal int
 }
 
-// UpdateCurrent updates the current confirmed milestone index state.
-func (ws *WarpSync) UpdateCurrent(current milestone.Index) {
-	ws.mu.Lock()
-	defer ws.mu.Unlock()
-	if current <= ws.CurrentConfirmedMs {
+// UpdateCurrentConfirmedMilestone updates the current confirmed milestone index state.
+func (ws *WarpSync) UpdateCurrentConfirmedMilestone(current milestone.Index) {
+	ws.Lock()
+	defer ws.Unlock()
+
+	if current <= ws.CurrentConfirmedMilestone {
 		return
 	}
-	ws.CurrentConfirmedMs = current
+	ws.CurrentConfirmedMilestone = current
 
 	// synchronization not started
 	if ws.CurrentCheckpoint == 0 {
@@ -121,33 +127,34 @@ func (ws *WarpSync) UpdateCurrent(current milestone.Index) {
 	}
 
 	// finished
-	if ws.TargetMs != 0 && ws.CurrentConfirmedMs >= ws.TargetMs {
-		ws.Events.Done.Trigger(int(ws.TargetMs-ws.Init), ws.referencedMessagesTotal, time.Since(ws.start))
+	if ws.TargetMilestone != 0 && ws.CurrentConfirmedMilestone >= ws.TargetMilestone {
+		ws.Events.Done.Trigger(int(ws.TargetMilestone-ws.InitMilestone), ws.referencedMessagesTotal, time.Since(ws.StartTime))
 		ws.reset()
 		return
 	}
 
 	// check whether advancement criteria is fulfilled
-	if !ws.advCheckpointCriteria(ws.CurrentConfirmedMs, ws.PreviousCheckpoint, ws.CurrentCheckpoint) {
+	if !ws.advCheckpointCriteria(ws.CurrentConfirmedMilestone, ws.PreviousCheckpoint, ws.CurrentCheckpoint) {
 		return
 	}
 
 	oldCheckpoint := ws.CurrentCheckpoint
 	if msRange := ws.advanceCheckpoint(); msRange != 0 {
-		ws.Events.CheckpointUpdated.Trigger(ws.CurrentCheckpoint, oldCheckpoint, msRange, ws.TargetMs)
+		ws.Events.CheckpointUpdated.Trigger(ws.CurrentCheckpoint, oldCheckpoint, msRange, ws.TargetMilestone)
 	}
 }
 
-// UpdateTarget updates the synchronization target if it is higher than the current one and
+// UpdateTargetMilestone updates the synchronization target if it is higher than the current one and
 // triggers a synchronization start if the target was set for the first time.
-func (ws *WarpSync) UpdateTarget(target milestone.Index) {
-	ws.mu.Lock()
-	defer ws.mu.Unlock()
-	if target <= ws.TargetMs {
+func (ws *WarpSync) UpdateTargetMilestone(target milestone.Index) {
+	ws.Lock()
+	defer ws.Unlock()
+
+	if target <= ws.TargetMilestone {
 		return
 	}
 
-	ws.TargetMs = target
+	ws.TargetMilestone = target
 
 	// as a special case, while we are warp syncing and within the last checkpoint range,
 	// new target milestones need to shift the checkpoint to the new target, in order
@@ -155,33 +162,36 @@ func (ws *WarpSync) UpdateTarget(target milestone.Index) {
 	// since we will request missing parents for the new target, it will still solidify
 	// even though we discarded requests for a short period of time parents when the
 	// request filter wasn't yet updated.
-	if ws.TargetMs != 0 && ws.CurrentCheckpoint+milestone.Index(ws.AdvancementRange) > ws.TargetMs {
+	if ws.CurrentCheckpoint != 0 && ws.CurrentCheckpoint+milestone.Index(ws.AdvancementRange) > ws.TargetMilestone {
 		oldCheckpoint := ws.CurrentCheckpoint
-		reqRange := ws.TargetMs - ws.CurrentCheckpoint
-		ws.CurrentCheckpoint = ws.TargetMs
-		ws.Events.CheckpointUpdated.Trigger(ws.CurrentCheckpoint, oldCheckpoint, int32(reqRange), ws.TargetMs)
+		reqRange := ws.TargetMilestone - ws.CurrentCheckpoint
+		ws.CurrentCheckpoint = ws.TargetMilestone
+		ws.Events.CheckpointUpdated.Trigger(ws.CurrentCheckpoint, oldCheckpoint, int32(reqRange), ws.TargetMilestone)
 	}
 
 	if ws.CurrentCheckpoint != 0 {
-		ws.Events.TargetUpdated.Trigger(ws.CurrentCheckpoint, ws.TargetMs)
+		// if synchronization was already started, only update the target
+		ws.Events.TargetUpdated.Trigger(ws.CurrentCheckpoint, ws.TargetMilestone)
 		return
 	}
 
-	if ws.CurrentConfirmedMs >= ws.TargetMs || target-ws.CurrentConfirmedMs <= 1 {
+	// do not start the synchronization if current confirmed is newer than the target or the delta is smaller than 2
+	if ws.CurrentConfirmedMilestone >= ws.TargetMilestone || target-ws.CurrentConfirmedMilestone < 2 {
 		return
 	}
 
-	ws.start = time.Now()
-	ws.Init = ws.CurrentConfirmedMs
-	ws.PreviousCheckpoint = ws.CurrentConfirmedMs
+	// start the synchronization
+	ws.StartTime = time.Now()
+	ws.InitMilestone = ws.CurrentConfirmedMilestone
+	ws.PreviousCheckpoint = ws.CurrentConfirmedMilestone
 	advancementRange := ws.advanceCheckpoint()
-	ws.Events.Start.Trigger(ws.TargetMs, ws.CurrentCheckpoint, advancementRange)
+	ws.Events.Start.Trigger(ws.TargetMilestone, ws.CurrentCheckpoint, advancementRange)
 }
 
 // AddReferencedMessagesCount adds the amount of referenced messages to collect stats.
 func (ws *WarpSync) AddReferencedMessagesCount(referencedMessagesCount int) {
-	ws.mu.Lock()
-	defer ws.mu.Unlock()
+	ws.Lock()
+	defer ws.Unlock()
 
 	ws.referencedMessagesTotal += referencedMessagesCount
 }
@@ -197,16 +207,19 @@ func (ws *WarpSync) advanceCheckpoint() int32 {
 	advRange := milestone.Index(ws.AdvancementRange)
 
 	// make sure we advance max to the target milestone
-	if ws.CurrentConfirmedMs+advRange >= ws.TargetMs || ws.CurrentCheckpoint+advRange >= ws.TargetMs {
-		deltaRange := ws.TargetMs - ws.CurrentCheckpoint
-		ws.CurrentCheckpoint = ws.TargetMs
+	if ws.TargetMilestone-ws.CurrentConfirmedMilestone <= advRange || ws.TargetMilestone-ws.CurrentCheckpoint <= advRange {
+		deltaRange := ws.TargetMilestone - ws.CurrentCheckpoint
+		if deltaRange > ws.TargetMilestone-ws.CurrentConfirmedMilestone {
+			deltaRange = ws.TargetMilestone - ws.CurrentConfirmedMilestone
+		}
+		ws.CurrentCheckpoint = ws.TargetMilestone
 		return int32(deltaRange)
 	}
 
 	// at start simply advance from the current confirmed
 	if ws.CurrentCheckpoint == 0 {
-		ws.CurrentCheckpoint = ws.CurrentConfirmedMs + advRange
-		return int32(ws.AdvancementRange)
+		ws.CurrentCheckpoint = ws.CurrentConfirmedMilestone + advRange
+		return int32(advRange)
 	}
 
 	ws.CurrentCheckpoint = ws.CurrentCheckpoint + advRange
@@ -215,10 +228,11 @@ func (ws *WarpSync) advanceCheckpoint() int32 {
 
 // resets the warp sync.
 func (ws *WarpSync) reset() {
-	ws.CurrentConfirmedMs = 0
+	ws.StartTime = time.Time{}
+	ws.InitMilestone = 0
+	ws.TargetMilestone = 0
+	ws.PreviousCheckpoint = 0
 	ws.CurrentCheckpoint = 0
-	ws.TargetMs = 0
-	ws.Init = 0
 	ws.referencedMessagesTotal = 0
 }
 
@@ -296,5 +310,6 @@ func (w *WarpSyncMilestoneRequester) RequestMissingMilestoneParents(msIndex mile
 func (w *WarpSyncMilestoneRequester) Cleanup() {
 	w.Lock()
 	defer w.Unlock()
+
 	w.traversed = make(map[string]struct{})
 }

--- a/pkg/protocol/gossip/warpsync_test.go
+++ b/pkg/protocol/gossip/warpsync_test.go
@@ -18,29 +18,29 @@ func TestAdvanceAtEightyPercentReached(t *testing.T) {
 func TestWarpSync_Update(t *testing.T) {
 	ws := gossip.NewWarpSync(50, gossip.AdvanceAtPercentageReached(0.8))
 
-	ws.UpdateCurrent(100)
-	ws.UpdateTarget(1000)
+	ws.UpdateCurrentConfirmedMilestone(100)
+	ws.UpdateTargetMilestone(1000)
 
-	assert.EqualValues(t, ws.CurrentConfirmedMs, 100)
+	assert.EqualValues(t, ws.CurrentConfirmedMilestone, 100)
 	assert.EqualValues(t, ws.CurrentCheckpoint, 150)
 
 	// nothing should change besides current confirmed
-	ws.UpdateCurrent(120)
-	assert.EqualValues(t, ws.CurrentConfirmedMs, 120)
+	ws.UpdateCurrentConfirmedMilestone(120)
+	assert.EqualValues(t, ws.CurrentConfirmedMilestone, 120)
 	assert.EqualValues(t, ws.CurrentCheckpoint, 150)
 
 	// nothing should change besides current confirmed
-	ws.UpdateCurrent(130)
-	assert.EqualValues(t, ws.CurrentConfirmedMs, 130)
+	ws.UpdateCurrentConfirmedMilestone(130)
+	assert.EqualValues(t, ws.CurrentConfirmedMilestone, 130)
 	assert.EqualValues(t, ws.CurrentCheckpoint, 150)
 
 	// 80% reached
-	ws.UpdateCurrent(140)
-	assert.EqualValues(t, ws.CurrentConfirmedMs, 140)
+	ws.UpdateCurrentConfirmedMilestone(140)
+	assert.EqualValues(t, ws.CurrentConfirmedMilestone, 140)
 	assert.EqualValues(t, ws.CurrentCheckpoint, 200)
 
 	// shouldn't update anything - simulates non synced peer sending heartbeat
-	ws.UpdateTarget(850)
-	assert.EqualValues(t, ws.CurrentConfirmedMs, 140)
+	ws.UpdateTargetMilestone(850)
+	assert.EqualValues(t, ws.CurrentConfirmedMilestone, 140)
 	assert.EqualValues(t, ws.CurrentCheckpoint, 200)
 }

--- a/pkg/snapshot/snapshot.go
+++ b/pkg/snapshot/snapshot.go
@@ -1061,7 +1061,7 @@ func (s *Snapshot) snapshotTypeFilePath(snapshotType Type) string {
 
 // HandleNewConfirmedMilestoneEvent handles new confirmed milestone events which may trigger a delta snapshot creation and pruning.
 func (s *Snapshot) HandleNewConfirmedMilestoneEvent(confirmedMilestoneIndex milestone.Index, shutdownSignal <-chan struct{}) {
-	if !s.storage.IsNodeAlmostSynced() {
+	if !s.storage.IsNodeSynced() {
 		// do not prune or create snapshots while we are not synced
 		return
 	}

--- a/pkg/snapshot/snapshot.go
+++ b/pkg/snapshot/snapshot.go
@@ -1077,6 +1077,11 @@ func (s *Snapshot) HandleNewConfirmedMilestoneEvent(confirmedMilestoneIndex mile
 			}
 			s.log.Warnf("%s %s", ErrSnapshotCreationFailed, err)
 		}
+
+		if !s.storage.IsNodeSynced() {
+			// do not prune while we are not synced
+			return
+		}
 	}
 
 	if !s.pruningEnabled {

--- a/pkg/tangle/solidifier.go
+++ b/pkg/tangle/solidifier.go
@@ -466,7 +466,7 @@ func (t *Tangle) searchMissingMilestone(confirmedMilestoneIndex milestone.Index,
 			}
 
 			// milestone found!
-			t.storage.StoreMilestone(cachedMessage.Retain(), ms)
+			t.storage.StoreMilestone(cachedMessage.Retain(), ms, false)
 
 			return ErrMissingMilestoneFound // we return this as an error to stop the traverser
 		},

--- a/plugins/warpsync/plugin.go
+++ b/plugins/warpsync/plugin.go
@@ -39,7 +39,6 @@ var (
 	warpSyncMilestoneRequester *gossip.WarpSyncMilestoneRequester
 
 	onGossipProtocolStreamCreated   *events.Closure
-	onLatestMilestoneIndexChanged   *events.Closure
 	onMilestoneConfirmed            *events.Closure
 	onMilestoneSolidificationFailed *events.Closure
 	onWarpSyncCheckpointUpdated     *events.Closure
@@ -81,11 +80,6 @@ func configureEvents() {
 			warpSync.UpdateCurrentConfirmedMilestone(deps.Storage.GetConfirmedMilestoneIndex())
 			warpSync.UpdateTargetMilestone(hb.SolidMilestoneIndex)
 		}))
-	})
-
-	onLatestMilestoneIndexChanged = events.NewClosure(func(msIndex milestone.Index) {
-		warpSync.UpdateCurrentConfirmedMilestone(deps.Storage.GetConfirmedMilestoneIndex())
-		warpSync.UpdateTargetMilestone(msIndex)
 	})
 
 	onMilestoneConfirmed = events.NewClosure(func(confirmation *whiteflag.Confirmation) {
@@ -143,7 +137,6 @@ func configureEvents() {
 
 func attachEvents() {
 	deps.Service.Events.ProtocolStarted.Attach(onGossipProtocolStreamCreated)
-	deps.Tangle.Events.LatestMilestoneIndexChanged.Attach(onLatestMilestoneIndexChanged)
 	deps.Tangle.Events.MilestoneConfirmed.Attach(onMilestoneConfirmed)
 	deps.Tangle.Events.MilestoneSolidificationFailed.Attach(onMilestoneSolidificationFailed)
 	warpSync.Events.CheckpointUpdated.Attach(onWarpSyncCheckpointUpdated)
@@ -154,7 +147,6 @@ func attachEvents() {
 
 func detachEvents() {
 	deps.Service.Events.ProtocolStarted.Detach(onGossipProtocolStreamCreated)
-	deps.Tangle.Events.LatestMilestoneIndexChanged.Detach(onLatestMilestoneIndexChanged)
 	deps.Tangle.Events.MilestoneConfirmed.Detach(onMilestoneConfirmed)
 	deps.Tangle.Events.MilestoneSolidificationFailed.Detach(onMilestoneSolidificationFailed)
 	warpSync.Events.CheckpointUpdated.Detach(onWarpSyncCheckpointUpdated)

--- a/plugins/warpsync/plugin.go
+++ b/plugins/warpsync/plugin.go
@@ -39,12 +39,13 @@ var (
 	warpSyncMilestoneRequester *gossip.WarpSyncMilestoneRequester
 
 	onGossipProtocolStreamCreated   *events.Closure
+	onLatestMilestoneIndexChanged   *events.Closure
 	onMilestoneConfirmed            *events.Closure
 	onMilestoneSolidificationFailed *events.Closure
-	onCheckpointUpdated             *events.Closure
-	onTargetUpdated                 *events.Closure
-	onStart                         *events.Closure
-	onDone                          *events.Closure
+	onWarpSyncCheckpointUpdated     *events.Closure
+	onWarpSyncTargetUpdated         *events.Closure
+	onWarpSyncStart                 *events.Closure
+	onWarpSyncDone                  *events.Closure
 )
 
 type dependencies struct {
@@ -77,25 +78,30 @@ func configureEvents() {
 
 	onGossipProtocolStreamCreated = events.NewClosure(func(p *gossip.Protocol) {
 		p.Events.HeartbeatUpdated.Attach(events.NewClosure(func(hb *gossip.Heartbeat) {
-			warpSync.UpdateCurrent(deps.Storage.GetConfirmedMilestoneIndex())
-			warpSync.UpdateTarget(hb.SolidMilestoneIndex)
+			warpSync.UpdateCurrentConfirmedMilestone(deps.Storage.GetConfirmedMilestoneIndex())
+			warpSync.UpdateTargetMilestone(hb.SolidMilestoneIndex)
 		}))
+	})
+
+	onLatestMilestoneIndexChanged = events.NewClosure(func(msIndex milestone.Index) {
+		warpSync.UpdateCurrentConfirmedMilestone(deps.Storage.GetConfirmedMilestoneIndex())
+		warpSync.UpdateTargetMilestone(msIndex)
 	})
 
 	onMilestoneConfirmed = events.NewClosure(func(confirmation *whiteflag.Confirmation) {
 		warpSync.AddReferencedMessagesCount(len(confirmation.Mutations.MessagesReferenced))
-		warpSync.UpdateCurrent(confirmation.MilestoneIndex)
+		warpSync.UpdateCurrentConfirmedMilestone(confirmation.MilestoneIndex)
 	})
 
 	onMilestoneSolidificationFailed = events.NewClosure(func(msIndex milestone.Index) {
-		if warpSync.CurrentCheckpoint < msIndex {
+		if warpSync.CurrentCheckpoint != 0 && warpSync.CurrentCheckpoint < msIndex {
 			// rerequest since milestone requests could have been lost
 			log.Infof("Requesting missing milestones %d - %d", msIndex, msIndex+milestone.Index(warpSync.AdvancementRange))
 			deps.Broadcaster.BroadcastMilestoneRequests(warpSync.AdvancementRange, nil)
 		}
 	})
 
-	onCheckpointUpdated = events.NewClosure(func(nextCheckpoint milestone.Index, oldCheckpoint milestone.Index, advRange int32, target milestone.Index) {
+	onWarpSyncCheckpointUpdated = events.NewClosure(func(nextCheckpoint milestone.Index, oldCheckpoint milestone.Index, advRange int32, target milestone.Index) {
 		log.Infof("Checkpoint updated to milestone %d (target %d)", nextCheckpoint, target)
 		// prevent any requests in the queue above our next checkpoint
 		deps.RequestQueue.Filter(func(r *gossip.Request) bool {
@@ -104,11 +110,11 @@ func configureEvents() {
 		deps.Broadcaster.BroadcastMilestoneRequests(int(advRange), warpSyncMilestoneRequester.RequestMissingMilestoneParents, oldCheckpoint)
 	})
 
-	onTargetUpdated = events.NewClosure(func(checkpoint milestone.Index, newTarget milestone.Index) {
+	onWarpSyncTargetUpdated = events.NewClosure(func(checkpoint milestone.Index, newTarget milestone.Index) {
 		log.Infof("Target updated to milestone %d (checkpoint %d)", newTarget, checkpoint)
 	})
 
-	onStart = events.NewClosure(func(targetMsIndex milestone.Index, nextCheckpoint milestone.Index, advRange int32) {
+	onWarpSyncStart = events.NewClosure(func(targetMsIndex milestone.Index, nextCheckpoint milestone.Index, advRange int32) {
 		log.Infof("Synchronizing to milestone %d", targetMsIndex)
 		deps.RequestQueue.Filter(func(r *gossip.Request) bool {
 			return r.MilestoneIndex <= nextCheckpoint
@@ -124,7 +130,7 @@ func configureEvents() {
 		}
 	})
 
-	onDone = events.NewClosure(func(deltaSynced int, referencedMessagesTotal int, took time.Duration) {
+	onWarpSyncDone = events.NewClosure(func(deltaSynced int, referencedMessagesTotal int, took time.Duration) {
 		// we need to cleanup all memoized things in the requester, so we have a clean state at next run and free the memory.
 		// we can only reset the "traversed" messages here, because otherwise it may happen that the requester always
 		// walks the whole cone if there are already paths between newer milestones in the database.
@@ -137,20 +143,22 @@ func configureEvents() {
 
 func attachEvents() {
 	deps.Service.Events.ProtocolStarted.Attach(onGossipProtocolStreamCreated)
+	deps.Tangle.Events.LatestMilestoneIndexChanged.Attach(onLatestMilestoneIndexChanged)
 	deps.Tangle.Events.MilestoneConfirmed.Attach(onMilestoneConfirmed)
 	deps.Tangle.Events.MilestoneSolidificationFailed.Attach(onMilestoneSolidificationFailed)
-	warpSync.Events.CheckpointUpdated.Attach(onCheckpointUpdated)
-	warpSync.Events.TargetUpdated.Attach(onTargetUpdated)
-	warpSync.Events.Start.Attach(onStart)
-	warpSync.Events.Done.Attach(onDone)
+	warpSync.Events.CheckpointUpdated.Attach(onWarpSyncCheckpointUpdated)
+	warpSync.Events.TargetUpdated.Attach(onWarpSyncTargetUpdated)
+	warpSync.Events.Start.Attach(onWarpSyncStart)
+	warpSync.Events.Done.Attach(onWarpSyncDone)
 }
 
 func detachEvents() {
 	deps.Service.Events.ProtocolStarted.Detach(onGossipProtocolStreamCreated)
+	deps.Tangle.Events.LatestMilestoneIndexChanged.Detach(onLatestMilestoneIndexChanged)
 	deps.Tangle.Events.MilestoneConfirmed.Detach(onMilestoneConfirmed)
 	deps.Tangle.Events.MilestoneSolidificationFailed.Detach(onMilestoneSolidificationFailed)
-	warpSync.Events.CheckpointUpdated.Detach(onCheckpointUpdated)
-	warpSync.Events.TargetUpdated.Detach(onTargetUpdated)
-	warpSync.Events.Start.Detach(onStart)
-	warpSync.Events.Done.Detach(onDone)
+	warpSync.Events.CheckpointUpdated.Detach(onWarpSyncCheckpointUpdated)
+	warpSync.Events.TargetUpdated.Detach(onWarpSyncTargetUpdated)
+	warpSync.Events.Start.Detach(onWarpSyncStart)
+	warpSync.Events.Done.Detach(onWarpSyncDone)
 }


### PR DESCRIPTION
This PR fixes an edge case, that randomly happened, especially in high load situations.

If a node is syncing with warp sync, the moment the node becomes sync, the internal values of warpsync are resetted.
If during solidification of the last "range" new milestones came in, warpsync would restart automatically directly after it was done to sync the new milestones.

Since the internal values of warpsync were resetted, warpsync tried to request milestones from 0 to the new target index.
If that happened, all the existing cones in the database are walked to find missing transactions for these existing milestones.

If at the same time a pruning job was running (with high chance since the node became newly solid), it could happen that the cone is being deleted the moment warpsync walks that cone to find missing transactions.

This resulted in the problem, that warpsync put requests in the request queue, that should have been deleted already.
The requester then starts to sync hundreds of thousands of transactions, because the node thinks these are missing to become solid.

The node will stay unsync forever, because no neighbor will have the whole history until the genesis message.
It also happened that the heavy walks of these massive cones lead to out of memory of the node.

The problem was fixed by not resetting the confirmed milestone index in warpsync.
To harden against such a situation even more, now no milestones that are below confirmed milestone index of the node are  checked for missing transactions. Additionally the existing solid entry points of the node are not cleared during snapshot generation, but new ones are added before pruning. At the end of the pruning process, only the new solid entry points are kept.

![grafik](https://user-images.githubusercontent.com/32371094/114904596-50fb9200-9e18-11eb-83e4-14210bbb5be5.png)

![grafik](https://user-images.githubusercontent.com/32371094/114902607-450ed080-9e16-11eb-913f-2eed04baf4a0.png)
