### PR TITLE
Use common interface of tests and benchmarks

### DIFF
--- a/pkg/dag/cone_root_indexes_test.go
+++ b/pkg/dag/cone_root_indexes_test.go
@@ -81,11 +81,11 @@ func TestConeRootIndexes(t *testing.T) {
 			minOldestConeRootIndex = cmi - milestone.Index(BelowMaxDepth)
 		}
 
-		require.GreaterOrEqual(te.TestState, uint32(ocri), uint32(minOldestConeRootIndex))
-		require.LessOrEqual(te.TestState, uint32(ocri), uint32(msIndex))
+		require.GreaterOrEqual(te.TestInterface, uint32(ocri), uint32(minOldestConeRootIndex))
+		require.LessOrEqual(te.TestInterface, uint32(ocri), uint32(msIndex))
 
-		require.GreaterOrEqual(te.TestState, uint32(ycri), uint32(minOldestConeRootIndex))
-		require.LessOrEqual(te.TestState, uint32(ycri), uint32(msIndex))
+		require.GreaterOrEqual(te.TestInterface, uint32(ycri), uint32(minOldestConeRootIndex))
+		require.LessOrEqual(te.TestInterface, uint32(ycri), uint32(msIndex))
 	}
 
 	latestMilestone := te.Milestones[len(te.Milestones)-1]
@@ -99,6 +99,6 @@ func TestConeRootIndexes(t *testing.T) {
 	ycri, ocri := dag.GetConeRootIndexes(te.Storage(), cachedMsgMeta, cmi)
 
 	// NullHash is SEP for index 0
-	require.Equal(te.TestState, uint32(0), uint32(ocri))
-	require.LessOrEqual(te.TestState, uint32(ycri), uint32(cmi))
+	require.Equal(te.TestInterface, uint32(0), uint32(ocri))
+	require.LessOrEqual(te.TestInterface, uint32(ycri), uint32(cmi))
 }

--- a/pkg/testsuite/coordinator.go
+++ b/pkg/testsuite/coordinator.go
@@ -45,8 +45,8 @@ func (te *TestEnvironment) configureCoordinator(cooPrivateKeys []ed25519.Private
 		coordinator.WithStateFilePath(fmt.Sprintf("%s/coordinator.state", te.tempDir)),
 		coordinator.WithMilestoneInterval(time.Duration(10)*time.Second),
 	)
-	require.NoError(te.TestState, err)
-	require.NotNil(te.TestState, coo)
+	require.NoError(te.TestInterface, err)
+	require.NotNil(te.TestInterface, coo)
 	te.coo = coo
 
 	te.coo.InitState(true, 0)
@@ -55,12 +55,12 @@ func (te *TestEnvironment) configureCoordinator(cooPrivateKeys []ed25519.Private
 	te.storage.SetSnapshotMilestone(te.networkID, 0, 0, 0, time.Now())
 
 	milestoneMessageID, err := te.coo.Bootstrap()
-	require.NoError(te.TestState, err)
+	require.NoError(te.TestInterface, err)
 
 	te.lastMilestoneMessageID = milestoneMessageID
 
 	ms := te.storage.GetCachedMilestoneOrNil(1)
-	require.NotNil(te.TestState, ms)
+	require.NotNil(te.TestInterface, ms)
 
 	te.Milestones = append(te.Milestones, ms)
 
@@ -86,8 +86,8 @@ func (te *TestEnvironment) configureCoordinator(cooPrivateKeys []ed25519.Private
 		func(spent *utxo.Spent) {},
 		nil,
 	)
-	require.NoError(te.TestState, err)
-	require.Equal(te.TestState, 1, confirmedMilestoneStats.MessagesReferenced)
+	require.NoError(te.TestInterface, err)
+	require.Equal(te.TestInterface, 1, confirmedMilestoneStats.MessagesReferenced)
 }
 
 // IssueAndConfirmMilestoneOnTip creates a milestone on top of a given tip.
@@ -99,14 +99,14 @@ func (te *TestEnvironment) IssueAndConfirmMilestoneOnTip(tip hornet.MessageID, c
 	fmt.Printf("Issue milestone %v\n", currentIndex+1)
 
 	milestoneMessageID, err := te.coo.IssueMilestone(hornet.MessageIDs{te.lastMilestoneMessageID, tip})
-	require.NoError(te.TestState, err)
+	require.NoError(te.TestInterface, err)
 	te.lastMilestoneMessageID = milestoneMessageID
 
 	te.VerifyLMI(currentIndex + 1)
 
 	milestoneIndex := currentIndex + 1
 	ms := te.storage.GetCachedMilestoneOrNil(milestoneIndex)
-	require.NotNil(te.TestState, ms)
+	require.NotNil(te.TestInterface, ms)
 
 	messagesMemcache := storage.NewMessagesMemcache(te.storage)
 	metadataMemcache := storage.NewMetadataMemcache(te.storage)
@@ -132,9 +132,9 @@ func (te *TestEnvironment) IssueAndConfirmMilestoneOnTip(tip hornet.MessageID, c
 		func(spent *utxo.Spent) {},
 		nil,
 	)
-	require.NoError(te.TestState, err)
+	require.NoError(te.TestInterface, err)
 
-	require.Equal(te.TestState, currentIndex+1, confirmedMilestoneStats.Index)
+	require.Equal(te.TestInterface, currentIndex+1, confirmedMilestoneStats.Index)
 	te.VerifyCMI(confirmedMilestoneStats.Index)
 
 	te.AssertTotalSupplyStillValid()
@@ -142,8 +142,8 @@ func (te *TestEnvironment) IssueAndConfirmMilestoneOnTip(tip hornet.MessageID, c
 	if createConfirmationGraph {
 		dotFileContent := te.generateDotFileFromConfirmation(wfConf)
 		if te.showConfirmationGraphs {
-			dotFilePath := fmt.Sprintf("%s/%s_%d.png", te.tempDir, te.TestState.Name(), confirmedMilestoneStats.Index)
-			utils.ShowDotFile(te.TestState, dotFileContent, dotFilePath)
+			dotFilePath := fmt.Sprintf("%s/%s_%d.png", te.tempDir, te.TestInterface.Name(), confirmedMilestoneStats.Index)
+			utils.ShowDotFile(te.TestInterface, dotFileContent, dotFilePath)
 		} else {
 			fmt.Println(dotFileContent)
 		}

--- a/pkg/testsuite/utils.go
+++ b/pkg/testsuite/utils.go
@@ -85,23 +85,23 @@ func (b *MessageBuilder) UsingOutput(output *utxo.Output) *MessageBuilder {
 
 func (b *MessageBuilder) BuildIndexation() *Message {
 
-	require.NotEmpty(b.te.TestState, b.indexation)
+	require.NotEmpty(b.te.TestInterface, b.indexation)
 
 	parents := [][]byte{}
-	require.NotNil(b.te.TestState, b.parents)
+	require.NotNil(b.te.TestInterface, b.parents)
 	for _, parent := range b.parents {
-		require.NotNil(b.te.TestState, parent)
+		require.NotNil(b.te.TestInterface, parent)
 		parents = append(parents, parent[:])
 	}
 
 	msg, err := iotago.NewMessageBuilder().Parents(parents).Payload(&iotago.Indexation{Index: []byte(b.indexation), Data: nil}).Build()
-	require.NoError(b.te.TestState, err)
+	require.NoError(b.te.TestInterface, err)
 
 	err = b.te.PoWHandler.DoPoW(msg, nil, 1)
-	require.NoError(b.te.TestState, err)
+	require.NoError(b.te.TestInterface, err)
 
 	message, err := storage.NewMessage(msg, iotago.DeSeriModePerformValidation)
-	require.NoError(b.te.TestState, err)
+	require.NoError(b.te.TestInterface, err)
 
 	return &Message{
 		builder: b,
@@ -111,7 +111,7 @@ func (b *MessageBuilder) BuildIndexation() *Message {
 
 func (b *MessageBuilder) Build() *Message {
 
-	require.True(b.te.TestState, b.amount > 0)
+	require.True(b.te.TestInterface, b.amount > 0)
 
 	builder := iotago.NewTransactionBuilder()
 
@@ -137,7 +137,7 @@ func (b *MessageBuilder) Build() *Message {
 		}
 	}
 
-	require.NotEmpty(b.te.TestState, outputsThatCanBeConsumed)
+	require.NotEmpty(b.te.TestInterface, outputsThatCanBeConsumed)
 
 	for _, utxo := range outputsThatCanBeConsumed {
 
@@ -163,7 +163,7 @@ func (b *MessageBuilder) Build() *Message {
 		builder.AddOutput(&iotago.SigLockedSingleOutput{Address: fromAddr, Amount: remainderAmount})
 	}
 
-	require.NotEmpty(b.te.TestState, b.indexation)
+	require.NotEmpty(b.te.TestInterface, b.indexation)
 	builder.AddIndexationPayload(&iotago.Indexation{Index: []byte(b.indexation), Data: nil})
 
 	// Sign transaction
@@ -171,18 +171,18 @@ func (b *MessageBuilder) Build() *Message {
 	inputAddrSigner := iotago.NewInMemoryAddressSigner(iotago.AddressKeys{Address: fromAddr, Keys: inputPrivateKey})
 
 	transaction, err := builder.Build(inputAddrSigner)
-	require.NoError(b.te.TestState, err)
+	require.NoError(b.te.TestInterface, err)
 
-	require.NotNil(b.te.TestState, b.parents)
+	require.NotNil(b.te.TestInterface, b.parents)
 
 	msg, err := iotago.NewMessageBuilder().Parents(b.parents.ToSliceOfSlices()).Payload(transaction).Build()
-	require.NoError(b.te.TestState, err)
+	require.NoError(b.te.TestInterface, err)
 
 	err = b.te.PoWHandler.DoPoW(msg, nil, 1)
-	require.NoError(b.te.TestState, err)
+	require.NoError(b.te.TestInterface, err)
 
 	message, err := storage.NewMessage(msg, iotago.DeSeriModePerformValidation)
-	require.NoError(b.te.TestState, err)
+	require.NoError(b.te.TestInterface, err)
 
 	var outputType string
 	if b.dustUnlock {
@@ -214,7 +214,7 @@ func (b *MessageBuilder) Build() *Message {
 	txEssence := messageTx.Essence.(*iotago.TransactionEssence)
 	for i := range txEssence.Outputs {
 		output, err := utxo.NewOutput(message.GetMessageID(), messageTx, uint16(i))
-		require.NoError(b.te.TestState, err)
+		require.NoError(b.te.TestInterface, err)
 
 		if output.Address().String() == toAddr.String() && output.Amount() == b.amount {
 			sentOutput = output
@@ -236,14 +236,14 @@ func (b *MessageBuilder) Build() *Message {
 }
 
 func (m *Message) Store() *Message {
-	require.Nil(m.builder.te.TestState, m.storedMessageID)
+	require.Nil(m.builder.te.TestInterface, m.storedMessageID)
 	m.storedMessageID = m.builder.te.StoreMessage(m.message).GetMessage().GetMessageID()
 	return m
 }
 
 func (m *Message) BookOnWallets() *Message {
 
-	require.False(m.builder.te.TestState, m.booked)
+	require.False(m.builder.te.TestInterface, m.booked)
 	m.builder.fromWallet.BookSpents(m.consumedOutputs)
 	m.builder.toWallet.BookOutput(m.sentOutput)
 	m.builder.fromWallet.BookOutput(m.remainderOutput)
@@ -253,12 +253,12 @@ func (m *Message) BookOnWallets() *Message {
 }
 
 func (m *Message) GeneratedUTXO() *utxo.Output {
-	require.NotNil(m.builder.te.TestState, m.sentOutput)
+	require.NotNil(m.builder.te.TestInterface, m.sentOutput)
 	return m.sentOutput
 }
 
 func (m *Message) StoredMessageID() hornet.MessageID {
-	require.NotNil(m.builder.te.TestState, m.storedMessageID)
+	require.NotNil(m.builder.te.TestInterface, m.storedMessageID)
 	return m.storedMessageID
 }
 

--- a/pkg/testsuite/utils/dot_file.go
+++ b/pkg/testsuite/utils/dot_file.go
@@ -45,17 +45,17 @@ func ShortenedIndex(cachedMessage *storage.CachedMessage) string {
 }
 
 // ShowDotFile creates a png file with dot and shows it in an external application.
-func ShowDotFile(t *testing.T, dotCommand string, outFilePath string) {
+func ShowDotFile(testInterface testing.TB, dotCommand string, outFilePath string) {
 
 	cmd := exec.Command("dot", "-Tpng", "-o"+outFilePath)
 
 	stdin, err := cmd.StdinPipe()
 	if err != nil {
-		t.Fatal(err)
+		testInterface.Fatal(err)
 	}
 
 	if err := cmd.Start(); err != nil {
-		t.Fatal(err)
+		testInterface.Fatal(err)
 	}
 
 	stdin.Write([]byte(dotCommand))
@@ -66,14 +66,14 @@ func ShowDotFile(t *testing.T, dotCommand string, outFilePath string) {
 	switch os := runtime.GOOS; os {
 	case "darwin":
 		if err := exec.Command("open", outFilePath).Start(); err != nil {
-			t.Fatal(err)
+			testInterface.Fatal(err)
 		}
 	case "linux":
 		if err := exec.Command("xdg-open", outFilePath).Start(); err != nil {
-			t.Fatal(err)
+			testInterface.Fatal(err)
 		}
 	default:
 		// freebsd, openbsd, plan9, windows...
-		t.Fatalf("OS %s not supported", os)
+		testInterface.Fatalf("OS %s not supported", os)
 	}
 }

--- a/pkg/tipselect/test/urts_test.go
+++ b/pkg/tipselect/test/urts_test.go
@@ -67,11 +67,11 @@ func TestTipSelect(t *testing.T) {
 
 	for i := 0; i < 1000; i++ {
 		tips, err := ts.SelectNonLazyTips()
-		require.NoError(te.TestState, err)
-		require.NotNil(te.TestState, tips)
+		require.NoError(te.TestInterface, err)
+		require.NotNil(te.TestInterface, tips)
 
-		require.GreaterOrEqual(te.TestState, len(tips), 1)
-		require.LessOrEqual(te.TestState, len(tips), 8)
+		require.GreaterOrEqual(te.TestInterface, len(tips), 1)
+		require.LessOrEqual(te.TestInterface, len(tips), 8)
 
 		cmi := te.Storage().GetConfirmedMilestoneIndex()
 
@@ -117,7 +117,7 @@ func TestTipSelect(t *testing.T) {
 					at, _ := te.Storage().SolidEntryPointsIndex(messageID)
 					updateIndexes(at, at)
 				}, false, nil)
-			require.NoError(te.TestState, err)
+			require.NoError(te.TestInterface, err)
 
 			minOldestConeRootIndex := milestone.Index(1)
 			if cmi > milestone.Index(MaxDeltaMsgOldestConeRootIndexToCMI) {
@@ -129,11 +129,11 @@ func TestTipSelect(t *testing.T) {
 				minYoungestConeRootIndex = cmi - milestone.Index(MaxDeltaMsgYoungestConeRootIndexToCMI)
 			}
 
-			require.GreaterOrEqual(te.TestState, uint32(oldestConeRootIndex), uint32(minOldestConeRootIndex))
-			require.LessOrEqual(te.TestState, uint32(oldestConeRootIndex), uint32(cmi))
+			require.GreaterOrEqual(te.TestInterface, uint32(oldestConeRootIndex), uint32(minOldestConeRootIndex))
+			require.LessOrEqual(te.TestInterface, uint32(oldestConeRootIndex), uint32(cmi))
 
-			require.GreaterOrEqual(te.TestState, uint32(youngestConeRootIndex), uint32(minYoungestConeRootIndex))
-			require.LessOrEqual(te.TestState, uint32(youngestConeRootIndex), uint32(cmi))
+			require.GreaterOrEqual(te.TestInterface, uint32(youngestConeRootIndex), uint32(minYoungestConeRootIndex))
+			require.LessOrEqual(te.TestInterface, uint32(youngestConeRootIndex), uint32(cmi))
 		}
 
 		msg := te.NewMessageBuilder(fmt.Sprintf("%d", msgCount)).Parents(tips).BuildIndexation().Store()
@@ -149,5 +149,5 @@ func TestTipSelect(t *testing.T) {
 		}
 	}
 
-	require.Equal(te.TestState, 1+100, len(te.Milestones)) // genesis + all created milestones
+	require.Equal(te.TestInterface, 1+100, len(te.Milestones)) // genesis + all created milestones
 }


### PR DESCRIPTION
This change is needed to call `testsuite.SetupTestEnvironment` with `b *testing.B` (benchmarks) as well.