### PR TITLE
Reset the HeaviestSelector if new milestone is confirmed.

### DIFF
--- a/pkg/model/mselection/heaviest.go
+++ b/pkg/model/mselection/heaviest.go
@@ -102,12 +102,12 @@ func New(minHeaviestBranchUnreferencedMessagesThreshold int, maxHeaviestBranchTi
 		randomTipsPerCheckpoint:                        randomTipsPerCheckpoint,
 		heaviestBranchSelectionTimeout:                 heaviestBranchSelectionTimeout,
 	}
-	s.reset()
+	s.Reset()
 	return s
 }
 
-// reset resets the tracked messages map and tips list of s.
-func (s *HeaviestSelector) reset() {
+// Reset resets the tracked messages map and tips list of s.
+func (s *HeaviestSelector) Reset() {
 	s.Lock()
 	defer s.Unlock()
 
@@ -232,7 +232,7 @@ func (s *HeaviestSelector) SelectTips(minRequiredTips int) (hornet.MessageIDs, e
 	}
 
 	// reset the whole HeaviestSelector if valid tips were found
-	s.reset()
+	s.Reset()
 
 	return tips, nil
 }

--- a/pkg/model/mselection/heaviest_test.go
+++ b/pkg/model/mselection/heaviest_test.go
@@ -291,5 +291,5 @@ func BenchmarkHeaviestSelector_OnNewSolidMessage(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		hps.OnNewSolidMessage(msgs[i%numBenchmarkMsgs])
 	}
-	hps.reset()
+	hps.Reset()
 }


### PR DESCRIPTION
This PR fixes a possible race condition in the COO, which could lead to an automatic shutdown of the COO node.

If a message gets solid and doesn't reference a cone that is below max depth, it is added to the heaviest selector.
Everytime a tipselection happens (checkpoints, milestone), this heaviest selector is resetted and all tracked messages are cleared.

There was a race condition, because messages are added to the heaviest selector between the tipselection for the milestone and the event that the milestone got confirmed in the COO node itself. This way messages could have been added to the tip pool that are already "below max depth". The selector is now resetted with the "onConfirmedMilestoneChanged" event and possible checkpoints are resetted as well.
