### PR TITLE
Fix: Set workdir in the Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -45,8 +45,11 @@ EXPOSE 14265/tcp
 EXPOSE 15600/tcp
 EXPOSE 14626/udp
 
-# Copy assets into distroless image
+# Copy the binary
 COPY --from=build /go/bin/hornet /app/hornet
+WORKDIR /app
+
+# Copy the assets
 COPY ./config.json /app/config.json
 COPY ./config_as.json /app/config_as.json
 COPY ./peering.json /app/peering.json


### PR DESCRIPTION
# Description

This PR adds a `WORKDIR` command to the Dockerfile. This assures that when running the default entry point the assets under `/app` can be found without supplying a paht.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Fix

# How Has This Been Tested?

`docker-compose up` now works and loads the `config.json` from the current path.

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have selected the `develop` branch as the target branch
