### PR TITLE
Makes p2p identity docs and tool clearer

### DIFF
--- a/docs/post_installation/post_installation.md
+++ b/docs/post_installation/post_installation.md
@@ -1,61 +1,76 @@
 # Post-installation
+
 Once Hornet is deployed, all parameters are set via configuration files.
 
 ## Configuration
+
 The most important ones are:
+
 * `config.json`: includes all configuration flags and their values
 * `peering.json`: includes all connection details to your static peers (neighbors)
 
-> Hornet version 0.5.x targets legacy IOTA 1.0 network. Hornet version 0.6.x targets IOTA 1.5 network aka Chrysalis which is the focus of this documentation
+> Hornet version 0.5.x targets legacy IOTA 1.0 network. Hornet version 1.x.x targets IOTA 1.5 network aka Chrysalis which is the focus of this documentation.
 
-Depending on the installation path you selected, default configuration files may be also part of the installation process and so you may see the following configuration files at your deployment directory:
+Depending on the installation path you selected, default configuration files may be also part of the installation
+process and so you may see the following configuration files at your deployment directory:
+
 ```bash
 config.json
 config_chrysalis_testnet.json
-config_comnet.json
-config_devnet.json
 peering.json
 profiles.json
 ```
 
 ### Default configuration
-By default, Hornet searches for configuration files in the working directory and expects default names, such as `config.json` and `peering.json`.
+
+By default, Hornet searches for configuration files in the working directory and expects default names, such
+as `config.json` and `peering.json`.
 
 This behavior can be changed by running Hornet with some altering arguments.
 
-Please see the [config.json](./config.md) and [peering.json](./peering.md) chapters for more information regarding respective configuration files.
+Please see the [config.json](./config.md) and [peering.json](./peering.md) chapters for more information regarding
+the respective configuration files.
 
-Once Hornet is executed, it outputs all loaded configuration parameters to `stdout` to show what configuration was actually loaded.
+Once Hornet is executed, it outputs all loaded configuration parameters to `stdout` to show what configuration was
+actually loaded (omitting values for things like passwords etc.).
 
-All other altering command line parameters can be obtained by running `hornet --help` or with more granular output `hornet --help --full`.
-
+All other altering command line parameters can be obtained by running `hornet --help` or with a more granular
+output `hornet --help --full`.
 
 ## Dashboard
-There is an admin dashboard/web interface plugin available (port 8081) and it is enabled by default. It provides some useful information regarding the node, its internal activity and its consumed resources, such as allocated memory, peer activity, transactions per second rate, etc.
 
-This plugin only listens on localhost:8081 per default. If you want to make it accessible from the Internet, you will need to change the default configuration. It can be changed via the following `config.json` file section:
+Per default an admin dashboard/web interface plugin is available on port 8081. It provides some useful information
+regarding the node's health, peering/neighbors, overall network health and consumed system resources.
+
+The dashboard plugin only listens on localhost:8081 per default. If you want to make it accessible from the Internet,
+you will need to change the default configuration. It can be changed via the following `config.json` file section:
 
 ```json
 "dashboard": {
-    "bindAddress": "localhost:8081",
-    "auth": {
-      "sessionTimeout": "72h",
-      "username": "admin",
-      "passwordHash": "0000000000000000000000000000000000000000000000000000000000000000",
-      "passwordSalt": "0000000000000000000000000000000000000000000000000000000000000000"
-    }
+  "bindAddress": "localhost:8081",
+  "auth": {
+    "sessionTimeout": "72h",
+    "username": "admin",
+    "passwordHash": "0000000000000000000000000000000000000000000000000000000000000000",
+    "passwordSalt": "0000000000000000000000000000000000000000000000000000000000000000"
   }
+}
 ```
-* to enable Dashboard to be reachable from the Internet, it can be changed to `"bindAddress": "0.0.0.0:8081"`
 
-Even if accessible from the Internet, any visitor still needs a valid combination of username and password to access a management section of the Dashboard.
+Change `dashboard.bindAddress` to either `0.0.0.0:8081` to listen on all available interfaces, or the
+specific interface address accordingly.
 
-It can be generated using integrated command-line Hornet tools, specifically `pwdhash`:
+Even if accessible from the Internet, any visitor still needs a valid combination of the username and password to access
+the management section of the dashboard.
+
+The password hash and salt can be generated using the integrated `pwdhash` CLI tool:
+
 ```bash
-hornet tools pwdhash
+./hornet tools pwdhash
 ```
 
 Output example:
+
 ```plaintext
 Enter a password:
 Re-enter your password:
@@ -63,119 +78,140 @@ Success!
 Your hash: 24c832e35dc542901b90888321dbfc4b1d9617332cbc124709204e6edf7e49f9
 Your salt: 6c71f4753f6fb52d7a4bb5471281400c8fef760533f0589026a0e646bc03acd4
 ```
-* `pwdhash` tool provides a combination of `passwordHash` and `passwordSalt` based on your input password
-* both values should be copied to the respective configuration values above, specifically the following keys: `passwordHash` and `passwordSalt`
 
-Once Hornet is restarted, then the Dashboard is protected by the given credentials.
+> `pwdhash` tool outputs the `passwordHash` and `passwordSalt` based on your input password
 
+Copy both values to their corresponding configuration options: `dashboard.auth.passwordHash` and
+`dashboard.auth.passwordSalt` respectively.
+
+In order for the new pasword to take effect, you must restart Hornet.
 
 ## Peer neighbors
-The IOTA network is a distributed network in which data is broadcasted among IOTA nodes. IOTA nodes broadcast messages to other IOTA nodes using a gossip protocol. To be able to participate in a network communication, each node has to establish a secure connection to some other nodes in the network - to its peer neighbors - and mutually exchange messages. This is the way how the data is spread within the IOTA network.
+
+The IOTA network is a distributed network in which data is broadcasted among IOTA nodes through a gossip protocol. To be
+able to participate in a network, each node has to establish a secure connection to other nodes in the network - to its
+peer neighbors - and mutually exchange messages.
 
 ### Node identity
-Each node is uniquely identified by a `peer identity`. `Peer identity` (also called `PeerId`) is represented by a public and private key pair. Then `PeerId` represents a verifiable link between the given peer and its public key, since `PeerId` is a cryptographic hash of peer's public key. It enables individual peers to establish a secure communication channel as the hash can be used to verify an identity of the peer.
 
-Hornet, when started for the first time, generates `peerId` automatically and stores it to `./p2pstore` directory including generated private key. This `peerId` then serves as an unique `peer identity` of the given node.
+Each node is uniquely identified by a `peer identity`. `Peer identity` (also called `PeerId`) is represented by a public
+and private key pair. The `PeerId` represents a verifiable link between the given peer and its public key,
+since `PeerId` is a cryptographic hash of peer's public key. It enables individual peers to establish a secure
+communication channel as the hash can be used to verify an identity of the peer.
 
-This information is also reported in the log:
+Hornet automatically generates a `PeerId` when it is started for the first time, and saves the identity's public key in
+a file `./p2pstore/key.pub` and the private key within a BadgerDB within `./p2pstore`. The generated identity is kept
+between subsequent restarts.
+
+Each time Hornet starts, the `PeerId` is written to stdout:
+
 ```plaintext
 2021-04-19T14:27:55Z  INFO    P2P     never share your ./p2pstore folder as it contains your node's private key!
 2021-04-19T14:27:55Z  INFO    P2P     generating a new peer identity...
 2021-04-19T14:27:55Z  INFO    P2P     stored public key under p2pstore/key.pub
 2021-04-19T14:27:55Z  INFO    P2P     peer configured, ID: 12D3KooWEWunsQWGvSWYN2VR7wNNoHgae4XikBqwSre8K8sVTefu
 ```
-* `peerId` presented in the output is your node's `peerId` that is essential component when communicating with your peer neighbor(s)
-* as a convention, it is usually refereed to in a form `/p2p/12D3KooWEWunsQWGvSWYN2VR7wNNoHgae4XikBqwSre8K8sVTefu`
-* the given `peerId` is also visible in the Hornet [Dashboard](#dashboard)
 
-Alternatively, you can also generate a new peer identity using hornet tools, specifically `p2pidentity`:
+Your `PeerId` is an essential part of your `multiaddr` used to configure neighbors, such
+as `/dns/example.com/tcp/15600/p2p/12D3KooWHiPg9gzmy1cbTFAUekyLHQKQKvsKmhzB7NJ5xnhK4WKq`,
+where `12D3KooWHiPg9gzmy1cbTFAUekyLHQKQKvsKmhzB7NJ5xnhK4WKq`
+corresponds to your `PeerId`. Your `PeerId` is also visible on the start page of the dashboard.
+
+It is recommended however to pre-generate the identity, so you can pre-communicate it to your peers before you even
+start your node and also to retain the identity in case you delete your `./p2pstore` by accident.
+
+You can use the `p2pidentity` CLI tool to generate a `PeerId` which simply generates a key pair and logs it to stdout:
+
 ```bash
-hornet tools p2pidentity
+./hornet tools p2pidentity
 ```
 
 Sample output:
+
 ```plaintext
 Your p2p private key:  7ea40ae657e2b8d46069f2ea6fe8f6ab209fb3f6f6630bc025a11a97e17e5d0675a575803660978d323fef05e871f54ecd94602b15181ba56183f9aba121ede7
 Your p2p public key:  75a575803660978d323fef05e871f54ecd94602b15181ba56183f9aba121ede7
 Your p2p PeerID:  12D3KooWHjcCgWPnUEP8wNdbL2fx63Cmosk16xyZ25iUZagxmHb4
 ```
 
-The generated private key can then be injected to `identityPrivateKey` value in `config.json` file:
-```json
-"p2p": {
-    "bindMultiAddresses": [
-      "/ip4/0.0.0.0/tcp/15600"
-    ],
-    "connectionManager": {
-      "highWatermark": 10,
-      "lowWatermark": 5
-    },
-    "gossipUnknownPeersLimit": 4,
-    "identityPrivateKey": "",
-    "peerStore": {
-      "path": "./p2pstore"
-    },
-    "reconnectInterval": "30s"
-  }
-```
+Now simply copy the value of `Your p2p private key` to the `p2p.identityPrivateKey` configuration option.
 
-More information regarding `peerId` is also available at [libp2p](https://docs.libp2p.io/concepts/peer-id/).
+Your Hornet node will now use the specified private key in `p2p.identityPrivateKey` to generate the `PeerId` (which will
+ultimately be stored in `./p2pstore`).
+
+> In case there already is a `./p2pstore` with another identity, Hornet will panic and tell you that you have a previous identity which does not match with what is defined via `p2p.identityPrivateKey` (
+in that case either delete the `./p2pstore` or reset the `p2p.identityPrivateKey`).
+
+More information regarding the `PeerId` is available on the [libp2p docs page](https://docs.libp2p.io/concepts/peer-id/)
+.
 
 ### Addressing peer neighbors
-In order to communicate to your peer neighbors, you also need an address to reach them. Hornet uses `multiaddress` (also known as `multiaddr`) format to achieve that.
 
-`Multiaddr` is a convention how to encode multiple layers of addressing information into a single path structure that is future-proof. In other words, `multiaddr` is able to combine several different pieces of information in a single human-readable and machine-optimized string, including network protocol and [peerId](#node-identity).
+In order to communicate to your peer neighbors, you also need an address to reach them. Hornet uses
+the `MultiAddresses` format (also known as `multiaddr`) to achieve that.
 
-For example, a node is reachable using IPv4 `100.1.1.1` using `TCP` on port `15600` and its `peerId` is `12D3KooWHjcCgWPnUEP8wNdbL2fx63Cmosk16xyZ25iUZagxmHb4`.
+`multiAddr` is a convention how to encode multiple layers of addressing information into a single path structure that is
+future-proof. In other words, `multiaddr` is able to combine several different pieces of information in a single
+human-readable and machine-optimized string, including network protocol and [`PeerId`](#node-identity).
 
-Then the `multiaddr` is composed as:
+For example, a node is reachable using IPv4 `100.1.1.1` using `TCP` on port `15600` and its `PeerId`
+is `12D3KooWHjcCgWPnUEP8wNdbL2fx63Cmosk16xyZ25iUZagxmHb4`.
+
+A `multiaddr` encoding such information would look like this:
+
 ```plaintext
 /ip4/100.1.1.1/tcp/15600/p2p/12D3KooWHjcCgWPnUEP8wNdbL2fx63Cmosk16xyZ25iUZagxmHb4
 ```
 
-If a node is reachable using DNS name (node01.iota.org) instead of IP address, then the given `multiaddr` would be:
+> Note how `ip4` is used. A common mistake is to use `ipv4`.
+
+If a node is reachable using a DNS name (for example `node01.iota.org`), then the given `multiaddr` would be:
+
 ```plaintext
 /dns/node01.iota.org/tcp/15600/p2p/12D3KooWHjcCgWPnUEP8wNdbL2fx63Cmosk16xyZ25iUZagxmHb4
 ```
 
-So node's `multiaddr` can be composed based on generated unique `peerId`, and `bindMultiAddresses` that exists in the `config.json` file under the `p2p` section :
-```json
-"p2p": {
-    "bindMultiAddresses": [
-      "/ip4/0.0.0.0/tcp/15600"
-    ],
-  }
-```
-* `/ip4/0.0.0.0/tcp/15600`: means it listens to your peer neighbors on IPv4 interface on port 15600 and accepts incoming requests from the Internet
-* thanks to used `peer identity`, both parties are able to establish a secure communication channel in which both sides are cryptographically verified and so their mutual identities are confirmed
+In order to find out your own `multiaddr` to give to your peers for neighboring, combine the `peerId` you have gotten
+from the stdout when the Hornet node started up (or which was shown via the `p2pidentity` CLI tool) and your
+configured `p2p.bindAddress`. Obviously replace the `/ip4/<ip_address>`/`/dns/<hostname>` segments with the actual
+information.
 
-More information regarding `multiaddr` is also available at [libp2p](https://docs.libp2p.io/concepts/addressing/).
+More information about `multiaddr` is available at the [libp2p docs page](https://docs.libp2p.io/concepts/addressing/).
 
 ### Adding node peers
-Once your node has an unique `multiaddr`, then it can be exchanged with other node owners to establish a mutual peer connection.
 
-*Where to find your future neighbors?*
+Once you know your node's own `multiaddr`, it can be exchanged with other node owners to establish a mutual peer
+connection.
 
-Go to the official IOTA Discord server and `#fullnodes` channel and describe your node location (Europe / Germany / Asia, etc.) with your allocated HW resources and ask for some neighbors. Do not publicly disclose your node `multiaddr` to all readers but wait for an individual direct chat.
+*Where to find neighbors?*
 
-Each peer can then be added using the Hornet [Dashboard](#dashboard) (admin section) or [peering.json](./peering.md) file.
+Join the official IOTA Discord server and join the `#fullnodes` channel and describe your node location (Europe /
+Germany / Asia, etc.) with your allocated HW resources and ask for neighbors. Do not publicly disclose your
+node `multiaddr`
+to all readers but wait for an individual direct chat.
 
-A recommended number of peer neighbors is 4-6, since some of them can be offline from time to time.
+Each peer can then be added using the Hornet [dashboard](#dashboard) (admin section) or [peering.json](./peering.md)
+file.
+
+A recommended number of peer neighbors is 4-6 to get some degree of redundancy.
 
 *Happy peering*
 
-
 ## Configuring HTTP REST API
-One of the [tasks that node is responsible for](../getting_started/nodes_101.md) is exposing HTTP REST API for clients that would like to interacts with the IOTA network, such as crypto wallets, exchanges, IoT devices, etc.
 
-By default, HTTP REST API is publicly exposed on the port 14265 and ready to accept incoming connections from the Internet.
+One of the [tasks that the node is responsible for](../getting_started/nodes_101.md) is exposing a HTTP REST API for
+clients that would like to interacts with the IOTA network, such as crypto wallets, exchanges, IoT devices, etc.
 
-Since use of the given interface consumes resources of your node, there are plethora options how to control it.
+By default, the HTTP REST API is publicly exposed on port 14265 and ready to accept incoming connections from the
+Internet.
 
-REST-API-related options exists under the section `restAPI` in the `config.json` file:
+Since offering the HTTP REST API to the public can consume resources of your node, there are options to restrict which
+routes can be called and other request limitations.
+
+HTTP REST API related options exists under the section `restAPI` within the `config.json` file:
 
 ```json
-"restAPI": {
+  "restAPI": {
     "jwtAuth": {
       "enabled": false,
       "salt": "HORNET"
@@ -215,14 +251,19 @@ REST-API-related options exists under the section `restAPI` in the `config.json`
   }
 ```
 
-First, there is a key named `bindAddress` that can be changed to, for example `localhost:14265`, meaning the given node accepts incoming connections from localhost only and so effectively turning the node into a private node which is completely valid use case.
+If you want to make the HTTP REST API only accessible from localhost, change the `restAPI.bindAddress` config option
+accordingly.
 
-Then, you can granularly control which REST API calls are accepted - key `permittedRoutes`.
+`restAPI.permittedRoutes` defines which routes can be called from foreign addresses which are not defined under
+`restAPI.whitelistedAddresses`.
 
-REST API clients may also request your node to perform so called `proof of work` that is necessary when sending messages to the network.
+If you are concerned with resource consumption, consider turning off `restAPI.powEnabled`, which makes it so that
+clients must perform Proof-of-Work locally, before submitting a message for broadcast. In case you'd like to offer
+Proof-of-Work for clients, consider upping `restAPI.powWorkerCount` to provide a faster message submission experience.
 
-It is a CPU-bound task that takes some time and may have negative impact on your available resources. So, one should consider whether to allow remote PoW to be performed on the node - key `powEnabled`. If enabled, then you can also control how many parallel workers are dedicated to PoW - key `powWorkerCount`.
+We suggest that you provide your HTTP REST API behind a reverse proxy, such as nginx or Traefik configured with TLS.
 
-Needless to say, Hornet supports standard HTTP REST API calls that can be also controlled by a reverse proxy. Please, see some of our additional security recommendations [here](../getting_started/security_101.md).
+Please see some of our additional security recommendations [here](../getting_started/security_101.md).
 
-Feel free to explore more details regarding different API calls at [IOTA client library documentation](https://chrysalis.docs.iota.org/libraries/client.html).
+Feel free to explore more details regarding different API calls
+at the [IOTA client library documentation](https://chrysalis.docs.iota.org/libraries/client.html).

--- a/pkg/toolset/p2p_identity.go
+++ b/pkg/toolset/p2p_identity.go
@@ -39,6 +39,8 @@ func generateP2PIdentity(args []string) error {
 	fmt.Println("Your p2p private key: ", hex.EncodeToString(privateKeyBytes))
 	fmt.Println("Your p2p public key: ", hex.EncodeToString(publicKeyBytes))
 	fmt.Println("Your p2p PeerID: ", pid.String())
+	fmt.Println()
+	fmt.Println("Make sure to specify the private key within the 'p2p.identityPrivateKey' config option to use it for your node's identity")
 
 	return nil
 }

--- a/pkg/toolset/p2p_identity_extract.go
+++ b/pkg/toolset/p2p_identity_extract.go
@@ -25,7 +25,7 @@ func extractP2PIdentity(args []string) error {
 
 	if len(args) != 1 {
 		printUsage()
-		return fmt.Errorf("wrong argument count '%s'", ToolSnapInfo)
+		return fmt.Errorf("wrong argument count '%s'", ToolP2PExtractIdentity)
 	}
 
 	dirPath := args[0]

--- a/pkg/toolset/p2p_identity_extract.go
+++ b/pkg/toolset/p2p_identity_extract.go
@@ -52,6 +52,9 @@ func extractP2PIdentity(args []string) error {
 		log.Panicf("unable to unmarshal public key from public key identity file: %v", err)
 	}
 	peerID, err := peer.IDFromPublicKey(pubKey)
+	if err != nil {
+		log.Panicf("unable to convert read public key to peer ID: %v", err)
+	}
 
 	// retrieve this node's private key from the peer store
 	prvKey := peerStore.PrivKey(peerID)

--- a/pkg/toolset/p2p_identity_extract.go
+++ b/pkg/toolset/p2p_identity_extract.go
@@ -1,0 +1,78 @@
+package toolset
+
+import (
+	"context"
+	"encoding/hex"
+	"fmt"
+	"io/ioutil"
+	"log"
+
+	badger "github.com/ipfs/go-ds-badger"
+	"github.com/libp2p/go-libp2p-core/crypto"
+	"github.com/libp2p/go-libp2p-core/peer"
+	"github.com/libp2p/go-libp2p-peerstore/pstoreds"
+)
+
+func extractP2PIdentity(args []string) error {
+	printUsage := func() {
+		println("Usage:")
+		println(fmt.Sprintf("	%s [P2P_STORE_PATH]", ToolP2PExtractIdentity))
+		println()
+		println("	[P2P_STORE_PATH]	- the path to the p2p store")
+		println()
+		println(fmt.Sprintf("example: %s %s", ToolP2PExtractIdentity, "./p2pstore"))
+	}
+
+	if len(args) != 1 {
+		printUsage()
+		return fmt.Errorf("wrong argument count '%s'", ToolSnapInfo)
+	}
+
+	dirPath := args[0]
+
+	badgerStore, err := badger.NewDatastore(dirPath, &badger.DefaultOptions)
+	if err != nil {
+		log.Panicf("unable to initialize data store for peer store: %s", err)
+	}
+
+	peerStore, err := pstoreds.NewPeerstore(context.Background(), badgerStore, pstoreds.DefaultOpts())
+	if err != nil {
+		log.Panicf("unable to initialize peer store: %s", err)
+	}
+
+	pubKeyFilePath := fmt.Sprintf("%s/key.pub", dirPath)
+	log.Printf("retrieving existing peer identity from %s", pubKeyFilePath)
+	existingPubKeyBytes, err := ioutil.ReadFile(pubKeyFilePath)
+	if err != nil {
+		log.Panicf("unable to read public key identity file: %v", err)
+	}
+
+	pubKey, err := crypto.UnmarshalPublicKey(existingPubKeyBytes)
+	if err != nil {
+		log.Panicf("unable to unmarshal public key from public key identity file: %v", err)
+	}
+	peerID, err := peer.IDFromPublicKey(pubKey)
+
+	// retrieve this node's private key from the peer store
+	prvKey := peerStore.PrivKey(peerID)
+
+	prvKeyBytes, err := prvKey.Raw()
+	if err != nil {
+		log.Panicf("unable to convert private key to bytes: %v", err)
+	}
+
+	pubKeyBytes, err := pubKey.Raw()
+	if err != nil {
+		log.Panicf("unable to convert public key to bytes: %v", err)
+	}
+
+	pid, err := peer.IDFromPublicKey(pubKey)
+	if err != nil {
+		log.Panicf("unable to obtain peer identity from public key: %v", err)
+	}
+
+	fmt.Println("Your p2p private key: ", hex.EncodeToString(prvKeyBytes))
+	fmt.Println("Your p2p public key: ", hex.EncodeToString(pubKeyBytes))
+	fmt.Println("Your p2p PeerID: ", pid.String())
+	return nil
+}

--- a/pkg/toolset/toolset.go
+++ b/pkg/toolset/toolset.go
@@ -7,15 +7,16 @@ import (
 )
 
 const (
-	ToolPwdHash      = "pwdhash"
-	ToolP2PIdentity  = "p2pidentity"
-	ToolEd25519Key   = "ed25519key"
-	ToolEd25519Addr  = "ed25519addr"
-	ToolSnapGen      = "snapgen"
-	ToolSnapMerge    = "snapmerge"
-	ToolSnapInfo     = "snapinfo"
-	ToolBenchmarkIO  = "bench-io"
-	ToolBenchmarkCPU = "bench-cpu"
+	ToolPwdHash            = "pwdhash"
+	ToolP2PIdentity        = "p2pidentity"
+	ToolP2PExtractIdentity = "p2pidentityextract"
+	ToolEd25519Key         = "ed25519key"
+	ToolEd25519Addr        = "ed25519addr"
+	ToolSnapGen            = "snapgen"
+	ToolSnapMerge          = "snapmerge"
+	ToolSnapInfo           = "snapinfo"
+	ToolBenchmarkIO        = "bench-io"
+	ToolBenchmarkCPU       = "bench-cpu"
 )
 
 // HandleTools handles available tools.
@@ -42,15 +43,16 @@ func HandleTools() {
 	}
 
 	tools := map[string]func([]string) error{
-		ToolPwdHash:      hashPasswordAndSalt,
-		ToolEd25519Key:   generateEd25519Key,
-		ToolEd25519Addr:  generateEd25519Address,
-		ToolSnapGen:      snapshotGen,
-		ToolSnapMerge:    snapshotMerge,
-		ToolSnapInfo:     snapshotInfo,
-		ToolP2PIdentity:  generateP2PIdentity,
-		ToolBenchmarkIO:  benchmarkIO,
-		ToolBenchmarkCPU: benchmarkCPU,
+		ToolPwdHash:            hashPasswordAndSalt,
+		ToolEd25519Key:         generateEd25519Key,
+		ToolEd25519Addr:        generateEd25519Address,
+		ToolSnapGen:            snapshotGen,
+		ToolSnapMerge:          snapshotMerge,
+		ToolSnapInfo:           snapshotInfo,
+		ToolP2PIdentity:        generateP2PIdentity,
+		ToolP2PExtractIdentity: extractP2PIdentity,
+		ToolBenchmarkIO:        benchmarkIO,
+		ToolBenchmarkCPU:       benchmarkCPU,
 	}
 
 	tool, exists := tools[strings.ToLower(args[1])]


### PR DESCRIPTION
- Revamps some of the docs regarding post installation steps, mainly the `PeerId` and `multiaddr` portions.
- Adds one more print to the `p2pidentity` CLI tool which tells the user to specify the private key in the `p2p.identityPrivateKey` config option, as some users were confused https://github.com/gohornet/hornet/issues/1089.
- Adds `p2pidentityextract` which extracts the private/public/peer-id from a specified `p2pstore` dir.