### PR TITLE
Fix database revalidation

### DIFF
--- a/pkg/tangle/revalidation.go
+++ b/pkg/tangle/revalidation.go
@@ -555,6 +555,10 @@ func (t *Tangle) applySnapshotLedger(snapshotInfo *storage.SnapshotInfo, snapsho
 
 	t.log.Info("applying snapshot balances to the ledger state...")
 
+	// set the confirmed milestone index to 0.
+	// the correct milestone index will be applied during "ImportSnapshots"
+	t.storage.OverwriteConfirmedMilestoneIndex(0)
+
 	// Restore the ledger state of the last snapshot
 	if err := snapshot.ImportSnapshots(); err != nil {
 		t.log.Panic(err.Error())
@@ -572,9 +576,6 @@ func (t *Tangle) applySnapshotLedger(snapshotInfo *storage.SnapshotInfo, snapsho
 	if snapshotInfo.SnapshotIndex != ledgerIndex {
 		return ErrSnapshotIndexWrong
 	}
-
-	// Set the valid confirmed milestone index
-	t.storage.OverwriteConfirmedMilestoneIndex(snapshotInfo.SnapshotIndex)
 
 	t.log.Info("applying snapshot balances to the ledger state ... done!")
 

--- a/pkg/tangle/revalidation.go
+++ b/pkg/tangle/revalidation.go
@@ -1,6 +1,7 @@
 package tangle
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/pkg/errors"
@@ -70,6 +71,16 @@ func (t *Tangle) RevalidateDatabase(snapshot *snapshot.Snapshot, pruneReceipts b
 
 	if snapshotInfo.SnapshotIndex > latestMilestoneIndex && (latestMilestoneIndex != 0) {
 		return ErrLatestMilestoneOlderThanSnapshotIndex
+	}
+
+	// check if the indexes of the snapshot files fit the revalidation target.
+	snapshotIndex, err := snapshot.GetSnapshotTargetIndex()
+	if err != nil {
+		return err
+	}
+
+	if snapshotIndex != snapshotInfo.SnapshotIndex {
+		return fmt.Errorf("snapshot files (index: %d) do not fit the revalidation target (index: %d)", snapshotIndex, snapshotInfo.SnapshotIndex)
 	}
 
 	t.log.Infof("reverting database state back from %d to snapshot %d (this might take a while)... ", latestMilestoneIndex, snapshotInfo.SnapshotIndex)

--- a/pkg/toolset/snapinfo.go
+++ b/pkg/toolset/snapinfo.go
@@ -23,7 +23,7 @@ func snapshotInfo(nodeConfig *configuration.Configuration, args []string) error 
 	}
 
 	filePath := args[0]
-	readFileHeader, err := snapshot.ReadSnapshotHeader(filePath)
+	readFileHeader, err := snapshot.ReadSnapshotHeaderFromFile(filePath)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Fixes #1086.

There were two possible problems with the database re-validation.

First we need to check if the existing snapshot files contain the correct ledger state we need to apply after re-validation.

Secondly we need to reset the old confirmed milestone index to be able to apply the ledger state from the snapshot files.
Otherwise the node will panic during the snapshot import, because the applied milestones are older than the confirmed milestone index.