### PR TITLE
Adds more masked cfg opts

### DIFF
--- a/core/p2p/params.go
+++ b/core/p2p/params.go
@@ -48,5 +48,5 @@ var params = &node.PluginParams{
 			return fs
 		}(),
 	},
-	Masked: nil,
+	Masked: []string{CfgP2PIdentityPrivKey},
 }

--- a/plugins/restapi/params.go
+++ b/plugins/restapi/params.go
@@ -65,5 +65,5 @@ var params = &node.PluginParams{
 			return fs
 		}(),
 	},
-	Masked: nil,
+	Masked: []string{CfgRestAPIAuthSalt},
 }


### PR DESCRIPTION
Masks REST API JWT salt and the identity private key for the peer identity. Closes #1099 