### PR TITLE
Adds "ledgerIndex" field to some REST HTTP and MQTT API responses

### DIFF
--- a/core/p2p/core.go
+++ b/core/p2p/core.go
@@ -89,7 +89,8 @@ func provide(c *dig.Container) {
 		if !peerStoreExists {
 			prvKey, err = p2p.CreateIdentity(pubKeyFilePath, identityPrivKey)
 		} else {
-			peerID, err := p2p.LoadIdentityFromFile(pubKeyFilePath)
+			var peerID peer.ID
+			peerID, err = p2p.LoadIdentityFromFile(pubKeyFilePath)
 			if err == nil {
 				prvKey, err = p2p.LoadPrivateKeyFromStore(peerID, peerStore, identityPrivKey)
 			}

--- a/pkg/model/utxo/balances.go
+++ b/pkg/model/utxo/balances.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/gohornet/hornet/pkg/model/milestone"
+
 	"github.com/iotaledger/hive.go/byteutils"
 	"github.com/iotaledger/hive.go/kvstore"
 	"github.com/iotaledger/hive.go/marshalutil"
@@ -90,12 +92,22 @@ func (u *Manager) checkBalancesLedger(treasury uint64) error {
 	return nil
 }
 
-func (u *Manager) AddressBalance(address iotago.Address) (balance uint64, dustAllowed bool, err error) {
+func (u *Manager) AddressBalance(address iotago.Address) (balance uint64, dustAllowed bool, ledgerIndex milestone.Index, err error) {
 
 	u.ReadLockLedger()
 	defer u.ReadUnlockLedger()
 
-	return u.AddressBalanceWithoutLocking(address)
+	ledgerIndex, err = u.ReadLedgerIndexWithoutLocking()
+	if err != nil {
+		return 0, false, 0, err
+	}
+
+	balance, dustAllowed, err = u.AddressBalanceWithoutLocking(address)
+	if err != nil {
+		return 0, false, 0, err
+	}
+
+	return balance, dustAllowed, ledgerIndex, err
 }
 
 func (u *Manager) AddressBalanceWithoutLocking(address iotago.Address) (balance uint64, dustAllowed bool, err error) {

--- a/pkg/tangle/events.go
+++ b/pkg/tangle/events.go
@@ -1,6 +1,7 @@
 package tangle
 
 import (
+	"github.com/gohornet/hornet/pkg/model/milestone"
 	"github.com/gohornet/hornet/pkg/model/utxo"
 	"github.com/gohornet/hornet/pkg/whiteflag"
 	"github.com/iotaledger/hive.go/events"
@@ -31,11 +32,11 @@ func MPSMetricsCaller(handler interface{}, params ...interface{}) {
 }
 
 func UTXOOutputCaller(handler interface{}, params ...interface{}) {
-	handler.(func(*utxo.Output))(params[0].(*utxo.Output))
+	handler.(func(milestone.Index, *utxo.Output))(params[0].(milestone.Index), params[1].(*utxo.Output))
 }
 
 func UTXOSpentCaller(handler interface{}, params ...interface{}) {
-	handler.(func(*utxo.Spent))(params[0].(*utxo.Spent))
+	handler.(func(milestone.Index, *utxo.Spent))(params[0].(milestone.Index), params[1].(*utxo.Spent))
 }
 
 func ReceiptCaller(handler interface{}, params ...interface{}) {

--- a/pkg/tangle/solidifier.go
+++ b/pkg/tangle/solidifier.go
@@ -292,11 +292,11 @@ func (t *Tangle) solidifyMilestone(newMilestoneIndex milestone.Index, force bool
 			t.Events.MilestoneConfirmed.Trigger(confirmation)
 			timeMilestoneConfirmed = time.Now()
 		},
-		func(output *utxo.Output) {
-			t.Events.NewUTXOOutput.Trigger(output)
+		func(index milestone.Index, output *utxo.Output) {
+			t.Events.NewUTXOOutput.Trigger(index, output)
 		},
-		func(spent *utxo.Spent) {
-			t.Events.NewUTXOSpent.Trigger(spent)
+		func(index milestone.Index, spent *utxo.Spent) {
+			t.Events.NewUTXOSpent.Trigger(index, spent)
 		},
 		func(rt *utxo.ReceiptTuple) error {
 			if t.receiptService != nil {

--- a/pkg/testsuite/coordinator.go
+++ b/pkg/testsuite/coordinator.go
@@ -82,8 +82,8 @@ func (te *TestEnvironment) configureCoordinator(cooPrivateKeys []ed25519.Private
 		func(confirmation *whiteflag.Confirmation) {
 			te.storage.SetConfirmedMilestoneIndex(confirmation.MilestoneIndex, true)
 		},
-		func(output *utxo.Output) {},
-		func(spent *utxo.Spent) {},
+		func(index milestone.Index, output *utxo.Output) {},
+		func(index milestone.Index, spent *utxo.Spent) {},
 		nil,
 	)
 	require.NoError(te.TestInterface, err)
@@ -128,8 +128,8 @@ func (te *TestEnvironment) IssueAndConfirmMilestoneOnTips(tips hornet.MessageIDs
 			wfConf = confirmation
 			te.storage.SetConfirmedMilestoneIndex(confirmation.MilestoneIndex, true)
 		},
-		func(output *utxo.Output) {},
-		func(spent *utxo.Spent) {},
+		func(index milestone.Index, output *utxo.Output) {},
+		func(index milestone.Index, spent *utxo.Spent) {},
 		nil,
 	)
 	require.NoError(te.TestInterface, err)

--- a/pkg/testsuite/tangle.go
+++ b/pkg/testsuite/tangle.go
@@ -49,7 +49,7 @@ func (te *TestEnvironment) VerifyLMI(index milestone.Index) {
 
 // AssertAddressBalance generates an address for the given seed and index and checks correct balance.
 func (te *TestEnvironment) AssertWalletBalance(wallet *utils.HDWallet, expectedBalance uint64) {
-	addrBalance, _, err := te.storage.UTXO().AddressBalance(wallet.Address())
+	addrBalance, _, _, err := te.storage.UTXO().AddressBalance(wallet.Address())
 	require.NoError(te.TestInterface, err)
 	computedAddrBalance, _, err := te.storage.UTXO().ComputeBalance(utxo.FilterAddress(wallet.Address()))
 	require.NoError(te.TestInterface, err)

--- a/pkg/whiteflag/confirmation.go
+++ b/pkg/whiteflag/confirmation.go
@@ -55,8 +55,8 @@ func ConfirmMilestone(
 	milestoneMessageID hornet.MessageID,
 	forEachReferencedMessage func(messageMetadata *storage.CachedMetadata, index milestone.Index, confTime uint64),
 	onMilestoneConfirmed func(confirmation *Confirmation),
-	forEachNewOutput func(output *utxo.Output),
-	forEachNewSpent func(spent *utxo.Spent),
+	forEachNewOutput func(index milestone.Index, output *utxo.Output),
+	forEachNewSpent func(index milestone.Index, spent *utxo.Spent),
 	onReceipt func(r *utxo.ReceiptTuple) error) (*ConfirmedMilestoneStats, *ConfirmationMetrics, error) {
 
 	cachedMilestoneMessage := messagesMemcache.GetCachedMessageOrNil(milestoneMessageID)
@@ -255,12 +255,12 @@ func ConfirmMilestone(
 	timeOnMilestoneConfirmed := time.Now()
 
 	for _, output := range newOutputs {
-		forEachNewOutput(output)
+		forEachNewOutput(milestoneIndex, output)
 	}
 	timeForEachNewOutput := time.Now()
 
 	for _, spent := range newSpents {
-		forEachNewSpent(spent)
+		forEachNewSpent(milestoneIndex, spent)
 	}
 	timeForEachNewSpent := time.Now()
 

--- a/plugins/debug/debug.go
+++ b/plugins/debug/debug.go
@@ -310,7 +310,7 @@ func milestoneDiff(c echo.Context) (*milestoneDiffResponse, error) {
 	spents := make([]*v1.OutputResponse, len(diff.Spents))
 
 	for i, output := range diff.Outputs {
-		o, err := v1.NewOutputResponse(output, false)
+		o, err := v1.NewOutputResponse(output, false, diff.Index)
 		if err != nil {
 			return nil, err
 		}
@@ -318,7 +318,7 @@ func milestoneDiff(c echo.Context) (*milestoneDiffResponse, error) {
 	}
 
 	for i, spent := range diff.Spents {
-		o, err := v1.NewOutputResponse(spent.Output(), true)
+		o, err := v1.NewOutputResponse(spent.Output(), true, diff.Index)
 		if err != nil {
 			return nil, err
 		}

--- a/plugins/mqtt/types.go
+++ b/plugins/mqtt/types.go
@@ -47,6 +47,8 @@ type outputPayload struct {
 	OutputIndex uint16 `json:"outputIndex"`
 	// Whether this output is spent.
 	Spent bool `json:"isSpent"`
+	// The ledger index at which this output was available at.
+	LedgerIndex milestone.Index `json:"ledgerIndex"`
 	// The output in its serialized form.
 	RawOutput *json.RawMessage `json:"output"`
 }

--- a/plugins/restapi/v1/types.go
+++ b/plugins/restapi/v1/types.go
@@ -134,6 +134,8 @@ type OutputResponse struct {
 	OutputIndex uint16 `json:"outputIndex"`
 	// Whether this output is spent.
 	Spent bool `json:"isSpent"`
+	// The ledger index at which this output was available at.
+	LedgerIndex milestone.Index `json:"ledgerIndex"`
 	// The output in its serialized form.
 	RawOutput *json.RawMessage `json:"output"`
 }

--- a/plugins/restapi/v1/types.go
+++ b/plugins/restapi/v1/types.go
@@ -164,6 +164,8 @@ type addressOutputsResponse struct {
 	Count uint32 `json:"count"`
 	// The output IDs (transaction hash + output index) of the outputs on this address.
 	OutputIDs []string `json:"outputIds"`
+	// The ledger index at which these outputs where available at.
+	LedgerIndex milestone.Index `json:"ledgerIndex"`
 }
 
 // treasuryResponse defines the response of a GET treasury REST API call.

--- a/plugins/restapi/v1/types.go
+++ b/plugins/restapi/v1/types.go
@@ -148,6 +148,8 @@ type addressBalanceResponse struct {
 	Balance uint64 `json:"balance"`
 	// Indicates if dust is allowed on this address.
 	DustAllowed bool `json:"dustAllowed"`
+	// The ledger index at which this balance was queried at.
+	LedgerIndex milestone.Index `json:"ledgerIndex"`
 }
 
 // addressOutputsResponse defines the response of a GET outputs by address REST API call.

--- a/plugins/restapi/v1/utxo.go
+++ b/plugins/restapi/v1/utxo.go
@@ -84,7 +84,7 @@ func outputByID(c echo.Context) (*OutputResponse, error) {
 
 func ed25519Balance(address *iotago.Ed25519Address) (*addressBalanceResponse, error) {
 
-	balance, dustAllowed, err := deps.UTXO.AddressBalanceWithoutLocking(address)
+	balance, dustAllowed, ledgerIndex, err := deps.UTXO.AddressBalance(address)
 	if err != nil {
 		return nil, errors.WithMessagef(echo.ErrInternalServerError, "reading address balance failed: %s, error: %s", address, err)
 	}
@@ -94,6 +94,7 @@ func ed25519Balance(address *iotago.Ed25519Address) (*addressBalanceResponse, er
 		Address:     address.String(),
 		Balance:     balance,
 		DustAllowed: dustAllowed,
+		LedgerIndex: ledgerIndex,
 	}, nil
 }
 

--- a/plugins/restapi/v1/utxo.go
+++ b/plugins/restapi/v1/utxo.go
@@ -10,6 +10,7 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/pkg/errors"
 
+	"github.com/gohornet/hornet/pkg/model/milestone"
 	"github.com/gohornet/hornet/pkg/model/utxo"
 	"github.com/gohornet/hornet/pkg/restapi"
 	restapiplugin "github.com/gohornet/hornet/plugins/restapi"
@@ -17,7 +18,7 @@ import (
 	iotago "github.com/iotaledger/iota.go/v2"
 )
 
-func NewOutputResponse(output *utxo.Output, spent bool) (*OutputResponse, error) {
+func NewOutputResponse(output *utxo.Output, spent bool, ledgerIndex milestone.Index) (*OutputResponse, error) {
 
 	var rawOutput iotago.Output
 	switch output.OutputType() {
@@ -48,6 +49,7 @@ func NewOutputResponse(output *utxo.Output, spent bool) (*OutputResponse, error)
 		Spent:         spent,
 		OutputIndex:   binary.LittleEndian.Uint16(output.OutputID()[iotago.TransactionIDLength : iotago.TransactionIDLength+iotago.UInt16ByteSize]),
 		RawOutput:     &rawRawOutputJSON,
+		LedgerIndex:   ledgerIndex,
 	}, nil
 }
 
@@ -66,6 +68,15 @@ func outputByID(c echo.Context) (*OutputResponse, error) {
 	var outputID iotago.UTXOInputID
 	copy(outputID[:], outputIDBytes)
 
+	// we need to lock the ledger here to have the correct index for unspent info of the output.
+	deps.UTXO.ReadLockLedger()
+	defer deps.UTXO.ReadUnlockLedger()
+
+	ledgerIndex, err := deps.UTXO.ReadLedgerIndexWithoutLocking()
+	if err != nil {
+		return nil, errors.WithMessagef(echo.ErrInternalServerError, "reading output failed: %s, error: %s", outputIDParam, err)
+	}
+
 	output, err := deps.UTXO.ReadOutputByOutputIDWithoutLocking(&outputID)
 	if err != nil {
 		if errors.Is(err, kvstore.ErrKeyNotFound) {
@@ -79,7 +90,7 @@ func outputByID(c echo.Context) (*OutputResponse, error) {
 		return nil, errors.WithMessagef(echo.ErrInternalServerError, "reading spent status failed: %s, error: %s", outputIDParam, err)
 	}
 
-	return NewOutputResponse(output, !unspent)
+	return NewOutputResponse(output, !unspent, ledgerIndex)
 }
 
 func ed25519Balance(address *iotago.Ed25519Address) (*addressBalanceResponse, error) {


### PR DESCRIPTION
There are endpoints in the API that return the "current" balance of an address or the state of an output.

For the caller it's hard to figure out what that "current" point in time was.
Thats why an additional field was introduced to bind the balance or the output state to the milestone index at which the request was made.
This sorting in time is especially helpful for balance reconcilation use-cases.

Example response:
```json
{
  "data": {
    "addressType": 0,
    "address": "efdc112efe262b304bcf379b26c31bad029f616ee3ec4aa6345a366e4c9e43a3",
    "balance": 1338263,
    "dustAllowed": true,
    "ledgerIndex": 422153
  }
}
```
To summarize, following endpoints were modified:
- `/api/v1/addresses/{address}`
- `/api/v1/addresses/ed25519/{address}`
- `/api​/v1​/addresses​/{address}​/outputs`
- `/api​/v1​/addresses​/ed25519/{address}​/outputs`
- `/api/v1/outputs/{outputId}`
