### PR TITLE
Adds retries to milestone signing

### DIFF
--- a/pkg/model/coordinator/coordinator.go
+++ b/pkg/model/coordinator/coordinator.go
@@ -470,7 +470,7 @@ func (coo *Coordinator) IssueCheckpoint(checkpointIndex int, lastCheckpointMessa
 		parents = append(parents, tips[tipStart:tipEnd]...)
 		parents = parents.RemoveDupsAndSortByLexicalOrder()
 
-		msg, err := coo.createCheckpoint(coo.networkID, parents)
+		msg, err := coo.createCheckpoint(parents)
 		if err != nil {
 			return nil, common.SoftError(fmt.Errorf("failed to create checkPoint: %w", err))
 		}

--- a/pkg/model/coordinator/coordinator.go
+++ b/pkg/model/coordinator/coordinator.go
@@ -470,7 +470,7 @@ func (coo *Coordinator) IssueCheckpoint(checkpointIndex int, lastCheckpointMessa
 		parents = append(parents, tips[tipStart:tipEnd]...)
 		parents = parents.RemoveDupsAndSortByLexicalOrder()
 
-		msg, err := createCheckpoint(coo.networkID, parents, coo.opts.powWorkerCount, coo.powHandler)
+		msg, err := coo.createCheckpoint(coo.networkID, parents)
 		if err != nil {
 			return nil, common.SoftError(fmt.Errorf("failed to create checkPoint: %w", err))
 		}

--- a/pkg/model/coordinator/milestones.go
+++ b/pkg/model/coordinator/milestones.go
@@ -10,9 +10,9 @@ import (
 )
 
 // createCheckpoint creates a checkpoint message.
-func (coo *Coordinator) createCheckpoint(networkID uint64, parents hornet.MessageIDs) (*storage.Message, error) {
+func (coo *Coordinator) createCheckpoint(parents hornet.MessageIDs) (*storage.Message, error) {
 	iotaMsg := &iotago.Message{
-		NetworkID: networkID,
+		NetworkID: coo.networkID,
 		Parents:   parents.ToSliceOfArrays(),
 		Payload:   nil,
 	}

--- a/plugins/coordinator/params.go
+++ b/plugins/coordinator/params.go
@@ -10,35 +10,39 @@ import (
 )
 
 const (
-	// the path to the state file of the coordinator
+	// CfgCoordinatorStateFilePath is the path to the state file of the coordinator.
 	CfgCoordinatorStateFilePath = "coordinator.stateFilePath"
-	// the interval milestones are issued
+	// CfgCoordinatorInterval is the interval at which milestones are issued.
 	CfgCoordinatorInterval = "coordinator.interval"
-	// the signing provider the coordinator uses to sign a milestone (local/remote)
+	// CfgCoordinatorSigningProvider the signing provider the coordinator uses to sign a milestone (local/remote).
 	CfgCoordinatorSigningProvider = "coordinator.signing.provider"
-	// the address of the remote signing provider (insecure connection!)
+	// CfgCoordinatorSigningRetryAmount defines the number of signing retries to perform before shutting down the node.
+	CfgCoordinatorSigningRetryAmount = "coordiantor.signing.retryAmount"
+	// CfgCoordinatorSigningRetryTimeout defines the timeout between signing retries.
+	CfgCoordinatorSigningRetryTimeout = "coordiantor.signing.retryTimeout"
+	// CfgCoordinatorSigningRemoteAddress the address of the remote signing provider (insecure connection!).
 	CfgCoordinatorSigningRemoteAddress = "coordinator.signing.remoteAddress"
-	// the amount of workers used for calculating PoW when issuing checkpoints and milestones
+	// CfgCoordinatorPoWWorkerCount the amount of workers used for calculating PoW when issuing checkpoints and milestones.
 	CfgCoordinatorPoWWorkerCount = "coordinator.powWorkerCount"
-	// whether the coordinator quorum is enabled
+	// CfgCoordinatorQuorumEnabled defines whether the coordinator quorum is enabled.
 	CfgCoordinatorQuorumEnabled = "coordinator.quorum.enabled"
-	// the quorum groups used to ask other nodes for correct ledger state of the coordinator
+	// CfgCoordinatorQuorumGroups defines the quorum groups used to ask other nodes for correct ledger state of the coordinator.
 	CfgCoordinatorQuorumGroups = "coordinator.quorum.groups"
-	// the timeout until a node in the quorum must have answered
+	// CfgCoordinatorQuorumTimeout defines the timeout until a node in the quorum must have answered.
 	CfgCoordinatorQuorumTimeout = "coordinator.quorum.timeout"
-	// the maximum amount of known messages for milestone tipselection
-	// if this limit is exceeded, a new checkpoint is issued
+	// CfgCoordinatorCheckpointsMaxTrackedMessages defines the maximum amount of known messages for milestone tipselection
+	// if this limit is exceeded, a new checkpoint is issued.
 	CfgCoordinatorCheckpointsMaxTrackedMessages = "coordinator.checkpoints.maxTrackedMessages"
-	// the minimum threshold of unreferenced messages in the heaviest branch for milestone tipselection
-	// if the value falls below that threshold, no more heaviest branch tips are picked
+	// CfgCoordinatorTipselectMinHeaviestBranchUnreferencedMessagesThreshold defines the minimum threshold of unreferenced messages in the heaviest branch for milestone tipselection
+	// if the value falls below that threshold, no more heaviest branch tips are picked.
 	CfgCoordinatorTipselectMinHeaviestBranchUnreferencedMessagesThreshold = "coordinator.tipsel.minHeaviestBranchUnreferencedMessagesThreshold"
-	// the maximum amount of checkpoint messages with heaviest branch tips that are picked
-	// if the heaviest branch is not below "UnreferencedMessagesThreshold" before
+	// CfgCoordinatorTipselectMaxHeaviestBranchTipsPerCheckpoint defines the maximum amount of checkpoint messages with heaviest branch tips that are picked
+	// if the heaviest branch is not below "UnreferencedMessagesThreshold" before.
 	CfgCoordinatorTipselectMaxHeaviestBranchTipsPerCheckpoint = "coordinator.tipsel.maxHeaviestBranchTipsPerCheckpoint"
-	// the amount of checkpoint messages with random tips that are picked if a checkpoint is issued and at least
-	// one heaviest branch tip was found, otherwise no random tips will be picked
+	// CfgCoordinatorTipselectRandomTipsPerCheckpoint defines the amount of checkpoint messages with random tips that are picked if a checkpoint is issued and at least
+	// one heaviest branch tip was found, otherwise no random tips will be picked.
 	CfgCoordinatorTipselectRandomTipsPerCheckpoint = "coordinator.tipsel.randomTipsPerCheckpoint"
-	// the maximum duration to select the heaviest branch tips
+	// CfgCoordinatorTipselectHeaviestBranchSelectionTimeout defines the maximum duration to select the heaviest branch tips.
 	CfgCoordinatorTipselectHeaviestBranchSelectionTimeout = "coordinator.tipsel.heaviestBranchSelectionTimeout"
 )
 
@@ -48,6 +52,8 @@ var params = &node.PluginParams{
 			fs := flag.NewFlagSet("", flag.ContinueOnError)
 			fs.String(CfgCoordinatorStateFilePath, "coordinator.state", "the path to the state file of the coordinator")
 			fs.Duration(CfgCoordinatorInterval, 10*time.Second, "the interval milestones are issued")
+			fs.Duration(CfgCoordinatorSigningRetryTimeout, 2*time.Second, "defines the timeout between signing retries")
+			fs.Int(CfgCoordinatorSigningRetryAmount, 10, "defines the number of signing retries to perform before shutting down the node")
 			fs.String(CfgCoordinatorSigningProvider, "local", "the signing provider the coordinator uses to sign a milestone (local/remote)")
 			fs.String(CfgCoordinatorSigningRemoteAddress, "localhost:12345", "the address of the remote signing provider (insecure connection!)")
 			fs.Int(CfgCoordinatorPoWWorkerCount, runtime.NumCPU()-1, "the amount of workers used for calculating PoW when issuing checkpoints and milestones")

--- a/plugins/coordinator/plugin.go
+++ b/plugins/coordinator/plugin.go
@@ -173,6 +173,8 @@ func provide(c *dig.Container) {
 				coordinator.WithMilestoneInterval(deps.NodeConfig.Duration(CfgCoordinatorInterval)),
 				coordinator.WithPoWWorkerCount(deps.NodeConfig.Int(CfgCoordinatorPoWWorkerCount)),
 				coordinator.WithQuorum(deps.NodeConfig.Bool(CfgCoordinatorQuorumEnabled), quorumGroups, deps.NodeConfig.Duration(CfgCoordinatorQuorumTimeout)),
+				coordinator.WithSigningRetryAmount(deps.NodeConfig.Int(CfgCoordinatorSigningRetryAmount)),
+				coordinator.WithSigningRetryTimeout(deps.NodeConfig.Duration(CfgCoordinatorSigningRetryTimeout)),
 			)
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
Allows one to define max amount of retries for signing a milestone and timeouts between them before aborting and shutting down the node.