### PR TITLE
Adds new signer pub key and bumps warp sync adv. range for resync

### DIFF
--- a/config.json
+++ b/config.json
@@ -92,6 +92,11 @@
         "key": "365fb85e7568b9b32f7359d6cbafa9814472ad0ecbad32d77beaf5dd9e84c6ba",
         "start": 0,
         "end": 1555200
+      },
+      {
+        "key": "ba6d07d1a1aea969e7e435f9f7d1b736ea9e0fcb8de400bf855dba7f2a57e947",
+        "start": 552960,
+        "end": 2108160
       }
     ]
   },
@@ -177,7 +182,7 @@
     ]
   },
   "warpsync": {
-    "advancementRange": 150
+    "advancementRange": 10000
   },
   "spammer": {
     "message": "IOTA - A new dawn",


### PR DESCRIPTION
Bumps the warp sync advancement range to allow nodes to resync even if they already received the milestones for which they did not have the right public key beforehand. Adds also that key to the default config.