### PR TITLE
Run autopeering entry node in standalone mode

### DIFF
--- a/core/app/app.go
+++ b/core/app/app.go
@@ -62,10 +62,11 @@ var (
 func init() {
 	InitPlugin = &node.InitPlugin{
 		Pluggable: node.Pluggable{
-			Name:      "App",
-			Params:    params,
-			Provide:   provide,
-			Configure: configure,
+			Name:           "App",
+			Params:         params,
+			InitConfigPars: initConfigPars,
+			Provide:        provide,
+			Configure:      configure,
 		},
 		Configs: map[string]*configuration.Configuration{
 			"nodeConfig":    nodeConfig,
@@ -131,6 +132,28 @@ Command line flags:
 	}, nil
 }
 
+func initConfigPars(c *dig.Container) {
+
+	type cfgResult struct {
+		dig.Out
+		NodeConfig            *configuration.Configuration `name:"nodeConfig"`
+		PeeringConfig         *configuration.Configuration `name:"peeringConfig"`
+		ProfileConfig         *configuration.Configuration `name:"profilesConfig"`
+		PeeringConfigFilePath string                       `name:"peeringConfigFilePath"`
+	}
+
+	if err := c.Provide(func() cfgResult {
+		return cfgResult{
+			NodeConfig:            nodeConfig,
+			PeeringConfig:         peeringConfig,
+			ProfileConfig:         profileConfig,
+			PeeringConfigFilePath: *peeringCfgFilePath,
+		}
+	}); err != nil {
+		InitPlugin.Panic(err)
+	}
+}
+
 func provide(c *dig.Container) {
 
 	if err := c.Provide(func() *app.AppInfo {
@@ -140,26 +163,6 @@ func provide(c *dig.Container) {
 			LatestGitHubVersion: "",
 		}
 	}); err != nil {
-		InitPlugin.Panic(err)
-	}
-	if err := c.Provide(func() *configuration.Configuration {
-		return nodeConfig
-	}, dig.Name("nodeConfig")); err != nil {
-		InitPlugin.Panic(err)
-	}
-	if err := c.Provide(func() *configuration.Configuration {
-		return peeringConfig
-	}, dig.Name("peeringConfig")); err != nil {
-		InitPlugin.Panic(err)
-	}
-	if err := c.Provide(func() *configuration.Configuration {
-		return profileConfig
-	}, dig.Name("profilesConfig")); err != nil {
-		InitPlugin.Panic(err)
-	}
-	if err := c.Provide(func() string {
-		return *peeringCfgFilePath
-	}, dig.Name("peeringConfigFilePath")); err != nil {
 		InitPlugin.Panic(err)
 	}
 }

--- a/core/gracefulshutdown/core.go
+++ b/core/gracefulshutdown/core.go
@@ -29,6 +29,7 @@ type dependencies struct {
 }
 
 func provide(c *dig.Container) {
+
 	if err := c.Provide(func() *shutdown.ShutdownHandler {
 		return shutdown.NewShutdownHandler(CorePlugin.Logger(), CorePlugin.Daemon())
 	}); err != nil {

--- a/core/p2p/core.go
+++ b/core/p2p/core.go
@@ -3,7 +3,6 @@ package p2p
 
 import (
 	"context"
-	"fmt"
 	"path/filepath"
 	"time"
 
@@ -26,12 +25,13 @@ import (
 func init() {
 	CorePlugin = &node.CorePlugin{
 		Pluggable: node.Pluggable{
-			Name:      "P2P",
-			DepsFunc:  func(cDeps dependencies) { deps = cDeps },
-			Params:    params,
-			Provide:   provide,
-			Configure: configure,
-			Run:       run,
+			Name:           "P2P",
+			DepsFunc:       func(cDeps dependencies) { deps = cDeps },
+			Params:         params,
+			InitConfigPars: initConfigPars,
+			Provide:        provide,
+			Configure:      configure,
+			Run:            run,
 		},
 	}
 }
@@ -51,35 +51,53 @@ type dependencies struct {
 	PeeringConfigManager *p2p.ConfigManager
 }
 
-func provide(c *dig.Container) {
-	type hostdeps struct {
-		dig.In
+func initConfigPars(c *dig.Container) {
 
-		NodeConfig     *configuration.Configuration `name:"nodeConfig"`
-		DatabaseEngine database.Engine              `name:"databaseEngine"`
+	type cfgDeps struct {
+		dig.In
+		NodeConfig *configuration.Configuration `name:"nodeConfig"`
+	}
+
+	type cfgResult struct {
+		dig.Out
+		P2PDatabasePath       string   `name:"p2pDatabasePath"`
+		P2PBindMultiAddresses []string `name:"p2pBindMultiAddresses"`
+	}
+
+	if err := c.Provide(func(deps cfgDeps) cfgResult {
+		return cfgResult{
+			P2PDatabasePath:       deps.NodeConfig.String(CfgP2PDatabasePath),
+			P2PBindMultiAddresses: deps.NodeConfig.Strings(CfgP2PBindMultiAddresses),
+		}
+	}); err != nil {
+		CorePlugin.Panic(err)
+	}
+}
+
+func provide(c *dig.Container) {
+
+	type hostDeps struct {
+		dig.In
+		NodeConfig            *configuration.Configuration `name:"nodeConfig"`
+		DatabaseEngine        database.Engine              `name:"databaseEngine"`
+		P2PDatabasePath       string                       `name:"p2pDatabasePath"`
+		P2PBindMultiAddresses []string                     `name:"p2pBindMultiAddresses"`
 	}
 
 	type p2presult struct {
 		dig.Out
-
-		P2PDatabasePath       string   `name:"p2pDatabasePath"`
-		P2PBindMultiAddresses []string `name:"p2pBindMultiAddresses"`
-		PeerStoreContainer    *p2p.PeerStoreContainer
-		NodePrivateKey        crypto.PrivKey `name:"nodePrivateKey"`
-		Host                  host.Host
+		PeerStoreContainer *p2p.PeerStoreContainer
+		NodePrivateKey     crypto.PrivKey `name:"nodePrivateKey"`
+		Host               host.Host
 	}
 
-	if err := c.Provide(func(deps hostdeps) (p2presult, error) {
+	if err := c.Provide(func(deps hostDeps) p2presult {
 
 		res := p2presult{}
 
-		p2pDatabasePath := deps.NodeConfig.String(CfgP2PDatabasePath)
-		res.P2PDatabasePath = p2pDatabasePath
-		res.P2PBindMultiAddresses = deps.NodeConfig.Strings(CfgP2PBindMultiAddresses)
+		privKeyFilePath := filepath.Join(deps.P2PDatabasePath, p2p.PrivKeyFileName)
 
-		privKeyFilePath := filepath.Join(p2pDatabasePath, p2p.PrivKeyFileName)
-
-		peerStoreContainer, err := p2p.NewPeerStoreContainer(filepath.Join(p2pDatabasePath, "peers"), deps.DatabaseEngine, true)
+		peerStoreContainer, err := p2p.NewPeerStoreContainer(filepath.Join(deps.P2PDatabasePath, "peers"), deps.DatabaseEngine, true)
 		if err != nil {
 			CorePlugin.Panic(err)
 		}
@@ -88,7 +106,7 @@ func provide(c *dig.Container) {
 		// TODO: temporary migration logic
 		// this should be removed after some time / hornet versions (20.08.21: muXxer)
 		identityPrivKey := deps.NodeConfig.String(CfgP2PIdentityPrivKey)
-		migrated, err := p2p.MigrateDeprecatedPeerStore(p2pDatabasePath, identityPrivKey, peerStoreContainer)
+		migrated, err := p2p.MigrateDeprecatedPeerStore(deps.P2PDatabasePath, identityPrivKey, peerStoreContainer)
 		if err != nil {
 			CorePlugin.Panicf("migration of deprecated peer store failed: %s", err)
 		}
@@ -100,10 +118,10 @@ Your node identity private key can now be found at "%s".
 		}
 
 		// make sure nobody copies around the peer store since it contains the private key of the node
-		CorePlugin.LogInfof(`WARNING: never share your "%s" folder as it contains your node's private key!`, p2pDatabasePath)
+		CorePlugin.LogInfof(`WARNING: never share your "%s" folder as it contains your node's private key!`, deps.P2PDatabasePath)
 
 		// load up the previously generated identity or create a new one
-		privKey, newlyCreated, err := p2p.LoadOrCreateIdentityPrivateKey(p2pDatabasePath, identityPrivKey)
+		privKey, newlyCreated, err := p2p.LoadOrCreateIdentityPrivateKey(deps.P2PDatabasePath, identityPrivKey)
 		if err != nil {
 			CorePlugin.Panic(err)
 		}
@@ -117,7 +135,7 @@ Your node identity private key can now be found at "%s".
 
 		createdHost, err := libp2p.New(context.Background(),
 			libp2p.Identity(privKey),
-			libp2p.ListenAddrStrings(deps.NodeConfig.Strings(CfgP2PBindMultiAddresses)...),
+			libp2p.ListenAddrStrings(deps.P2PBindMultiAddresses...),
 			libp2p.Peerstore(peerStoreContainer.Peerstore()),
 			libp2p.DefaultTransports,
 			libp2p.ConnectionManager(connmgr.NewConnManager(
@@ -128,24 +146,23 @@ Your node identity private key can now be found at "%s".
 			libp2p.NATPortMap(),
 		)
 		if err != nil {
-			return res, fmt.Errorf("unable to initialize peer: %w", err)
+			CorePlugin.Panicf("unable to initialize peer: %s", err)
 		}
 		res.Host = createdHost
 
-		return res, nil
+		return res
 	}); err != nil {
 		CorePlugin.Panic(err)
 	}
 
-	type mngdeps struct {
+	type mngDeps struct {
 		dig.In
-
 		Host                      host.Host
 		Config                    *configuration.Configuration `name:"nodeConfig"`
 		AutopeeringRunAsEntryNode bool                         `name:"autopeeringRunAsEntryNode"`
 	}
 
-	if err := c.Provide(func(deps mngdeps) *p2p.Manager {
+	if err := c.Provide(func(deps mngDeps) *p2p.Manager {
 		if !deps.AutopeeringRunAsEntryNode {
 			return p2p.NewManager(deps.Host,
 				p2p.WithManagerLogger(logger.NewLogger("P2P-Manager")),
@@ -159,7 +176,6 @@ Your node identity private key can now be found at "%s".
 
 	type configManagerDeps struct {
 		dig.In
-
 		PeeringConfig         *configuration.Configuration `name:"peeringConfig"`
 		PeeringConfigFilePath string                       `name:"peeringConfigFilePath"`
 	}

--- a/core/pow/core.go
+++ b/core/pow/core.go
@@ -39,13 +39,14 @@ type dependencies struct {
 }
 
 func provide(c *dig.Container) {
-	type handlerdeps struct {
+
+	type handlerDeps struct {
 		dig.In
 		NodeConfig  *configuration.Configuration `name:"nodeConfig"`
 		MinPoWScore float64                      `name:"minPoWScore"`
 	}
 
-	if err := c.Provide(func(deps handlerdeps) *pow.Handler {
+	if err := c.Provide(func(deps handlerDeps) *pow.Handler {
 		// init the pow handler with all possible settings
 		powsrvAPIKey, err := utils.LoadStringFromEnvironment("POWSRV_API_KEY")
 		if err == nil && len(powsrvAPIKey) > 12 {

--- a/core/profile/core.go
+++ b/core/profile/core.go
@@ -40,12 +40,13 @@ type dependencies struct {
 }
 
 func provide(c *dig.Container) {
-	type deps struct {
+
+	type profileDeps struct {
 		dig.In
 		NodeConfig     *configuration.Configuration `name:"nodeConfig"`
 		ProfilesConfig *configuration.Configuration `name:"profilesConfig"`
 	}
-	if err := c.Provide(func(d deps) *profile.Profile {
+	if err := c.Provide(func(d profileDeps) *profile.Profile {
 		return loadProfile(d.NodeConfig, d.ProfilesConfig)
 	}); err != nil {
 		CorePlugin.Panic(err)
@@ -53,6 +54,7 @@ func provide(c *dig.Container) {
 }
 
 func configure() {
+
 	if deps.NodeConfig.String(CfgNodeProfile) == AutoProfileName {
 		CorePlugin.LogInfof("Profile mode 'auto', Using profile '%s'", deps.Profile.Name)
 	} else {

--- a/core/protocfg/core.go
+++ b/core/protocfg/core.go
@@ -6,27 +6,10 @@ import (
 	flag "github.com/spf13/pflag"
 	"go.uber.org/dig"
 
-	databaseCore "github.com/gohornet/hornet/core/database"
-	"github.com/gohornet/hornet/pkg/database"
 	"github.com/gohornet/hornet/pkg/model/coordinator"
 	"github.com/gohornet/hornet/pkg/node"
 	"github.com/iotaledger/hive.go/configuration"
 	iotago "github.com/iotaledger/iota.go/v2"
-)
-
-const (
-	// the network ID on which this node operates on.
-	CfgProtocolNetworkIDName = "protocol.networkID"
-	// the HRP which should be used for Bech32 addresses.
-	CfgProtocolBech32HRP = "protocol.bech32HRP"
-	// the minimum PoW score required by the network.
-	CfgProtocolMinPoWScore = "protocol.minPoWScore"
-	// the amount of public keys in a milestone.
-	CfgProtocolMilestonePublicKeyCount = "protocol.milestonePublicKeyCount"
-	// the ed25519 public key of the coordinator in hex representation.
-	CfgProtocolPublicKeyRanges = "protocol.publicKeyRanges"
-	// the ed25519 public key of the coordinator in hex representation.
-	CfgProtocolPublicKeyRangesJSON = "publicKeyRanges"
 )
 
 func init() {
@@ -34,21 +17,9 @@ func init() {
 
 	CorePlugin = &node.CorePlugin{
 		Pluggable: node.Pluggable{
-			Name: "ProtoCfg",
-			Params: &node.PluginParams{
-				Params: map[string]*flag.FlagSet{
-					"nodeConfig": func() *flag.FlagSet {
-						fs := flag.NewFlagSet("", flag.ContinueOnError)
-						fs.String(CfgProtocolNetworkIDName, "chrysalis-mainnet", "the network ID on which this node operates on.")
-						fs.String(CfgProtocolBech32HRP, string(iotago.PrefixMainnet), "the HRP which should be used for Bech32 addresses.")
-						fs.Float64(CfgProtocolMinPoWScore, 4000, "the minimum PoW score required by the network.")
-						fs.Int(CfgProtocolMilestonePublicKeyCount, 2, "the amount of public keys in a milestone")
-						return fs
-					}(),
-				},
-				Masked: nil,
-			},
-			Provide: provide,
+			Name:           "ProtoCfg",
+			Params:         params,
+			InitConfigPars: initConfigPars,
 		},
 	}
 }
@@ -59,37 +30,31 @@ var (
 	cooPubKeyRangesFlag = flag.String(CfgProtocolPublicKeyRangesJSON, "", "overwrite public key ranges (JSON)")
 )
 
-func provide(c *dig.Container) {
-	type tangledeps struct {
+func initConfigPars(c *dig.Container) {
+
+	type cfgDeps struct {
 		dig.In
 		NodeConfig *configuration.Configuration `name:"nodeConfig"`
 	}
 
-	type protoresult struct {
+	type cfgResult struct {
 		dig.Out
-
 		PublicKeyRanges         coordinator.PublicKeyRanges
 		NetworkID               uint64               `name:"networkId"`
 		NetworkIDName           string               `name:"networkIdName"`
 		Bech32HRP               iotago.NetworkPrefix `name:"bech32HRP"`
 		MinPoWScore             float64              `name:"minPoWScore"`
 		MilestonePublicKeyCount int                  `name:"milestonePublicKeyCount"`
-		DatabaseEngine          database.Engine      `name:"databaseEngine"`
 	}
 
-	if err := c.Provide(func(deps tangledeps) protoresult {
-		engine, err := database.DatabaseEngine(deps.NodeConfig.String(databaseCore.CfgDatabaseEngine))
-		if err != nil {
-			CorePlugin.Panic(err)
-		}
+	if err := c.Provide(func(deps cfgDeps) cfgResult {
 
-		res := protoresult{
+		res := cfgResult{
 			NetworkID:               iotago.NetworkIDFromString(deps.NodeConfig.String(CfgProtocolNetworkIDName)),
 			NetworkIDName:           deps.NodeConfig.String(CfgProtocolNetworkIDName),
 			Bech32HRP:               iotago.NetworkPrefix(deps.NodeConfig.String(CfgProtocolBech32HRP)),
 			MinPoWScore:             deps.NodeConfig.Float64(CfgProtocolMinPoWScore),
 			MilestonePublicKeyCount: deps.NodeConfig.Int(CfgProtocolMilestonePublicKeyCount),
-			DatabaseEngine:          engine,
 		}
 
 		if *cooPubKeyRangesFlag != "" {

--- a/core/protocfg/params.go
+++ b/core/protocfg/params.go
@@ -1,0 +1,37 @@
+package protocfg
+
+import (
+	flag "github.com/spf13/pflag"
+
+	"github.com/gohornet/hornet/pkg/node"
+	iotago "github.com/iotaledger/iota.go/v2"
+)
+
+const (
+	// the network ID on which this node operates on.
+	CfgProtocolNetworkIDName = "protocol.networkID"
+	// the HRP which should be used for Bech32 addresses.
+	CfgProtocolBech32HRP = "protocol.bech32HRP"
+	// the minimum PoW score required by the network.
+	CfgProtocolMinPoWScore = "protocol.minPoWScore"
+	// the amount of public keys in a milestone.
+	CfgProtocolMilestonePublicKeyCount = "protocol.milestonePublicKeyCount"
+	// the ed25519 public key of the coordinator in hex representation.
+	CfgProtocolPublicKeyRanges = "protocol.publicKeyRanges"
+	// the ed25519 public key of the coordinator in hex representation.
+	CfgProtocolPublicKeyRangesJSON = "publicKeyRanges"
+)
+
+var params = &node.PluginParams{
+	Params: map[string]*flag.FlagSet{
+		"nodeConfig": func() *flag.FlagSet {
+			fs := flag.NewFlagSet("", flag.ContinueOnError)
+			fs.String(CfgProtocolNetworkIDName, "chrysalis-mainnet", "the network ID on which this node operates on.")
+			fs.String(CfgProtocolBech32HRP, string(iotago.PrefixMainnet), "the HRP which should be used for Bech32 addresses.")
+			fs.Float64(CfgProtocolMinPoWScore, 4000, "the minimum PoW score required by the network.")
+			fs.Int(CfgProtocolMilestonePublicKeyCount, 2, "the amount of public keys in a milestone")
+			return fs
+		}(),
+	},
+	Masked: nil,
+}

--- a/integration-tests/tester/framework/config.go
+++ b/integration-tests/tester/framework/config.go
@@ -56,7 +56,7 @@ const (
 
 var (
 	disabledPluginsPeer      = []string{}
-	disabledPluginsEntryNode = []string{"dashboard", "profiling", "gossip", "snapshot", "metrics", "tangle", "warpsync", "webapi"}
+	disabledPluginsEntryNode = []string{}
 	// The seed on which the total supply resides on per default.
 	GenesisSeed    ed25519.PrivateKey
 	GenesisAddress iotago.Ed25519Address

--- a/pkg/model/utxo/balances.go
+++ b/pkg/model/utxo/balances.go
@@ -44,10 +44,10 @@ func balanceFromBytes(value []byte) (balance uint64, dustAllowanceBalance uint64
 }
 
 func bytesFromBalance(balance uint64, dustAllowanceBalance uint64, outputCount int64) []byte {
-	marshalUtil := marshalutil.New(16)
-	marshalUtil.WriteUint64(balance)
-	marshalUtil.WriteUint64(dustAllowanceBalance)
-	marshalUtil.WriteInt64(outputCount)
+	marshalUtil := marshalutil.New(24)
+	marshalUtil.WriteUint64(balance)              // 8 bytes
+	marshalUtil.WriteUint64(dustAllowanceBalance) // 8 bytes
+	marshalUtil.WriteInt64(outputCount)           // 8 bytes
 	return marshalUtil.Bytes()
 }
 

--- a/pkg/model/utxo/output.go
+++ b/pkg/model/utxo/output.go
@@ -157,17 +157,17 @@ func NewOutput(messageID hornet.MessageID, transaction *iotago.Transaction, inde
 
 func (o *Output) kvStorableKey() (key []byte) {
 	ms := marshalutil.New(35)
-	ms.WriteByte(UTXOStoreKeyPrefixOutput)
-	ms.WriteBytes(o.outputID[:])
+	ms.WriteByte(UTXOStoreKeyPrefixOutput) // 1 byte
+	ms.WriteBytes(o.outputID[:])           // 34 bytes
 	return ms.Bytes()
 }
 
 func (o *Output) kvStorableValue() (value []byte) {
 	ms := marshalutil.New(74)
-	ms.WriteBytes(o.messageID)
-	ms.WriteByte(o.outputType)
-	ms.WriteBytes(o.addressBytes())
-	ms.WriteUint64(o.amount)
+	ms.WriteBytes(o.messageID)      // 32 bytes
+	ms.WriteByte(o.outputType)      // 1 byte
+	ms.WriteBytes(o.addressBytes()) // 33 bytes
+	ms.WriteUint64(o.amount)        // 8 bytes
 	return ms.Bytes()
 }
 

--- a/pkg/model/utxo/spent.go
+++ b/pkg/model/utxo/spent.go
@@ -67,10 +67,10 @@ func NewSpent(output *Output, targetTransactionID *iotago.TransactionID, confirm
 
 func (o *Output) spentDatabaseKey() []byte {
 	ms := marshalutil.New(69)
-	ms.WriteByte(UTXOStoreKeyPrefixSpent)
-	ms.WriteBytes(o.addressBytes())
-	ms.WriteByte(o.outputType)
-	ms.WriteBytes(o.outputID[:])
+	ms.WriteByte(UTXOStoreKeyPrefixSpent) // 1 byte
+	ms.WriteBytes(o.addressBytes())       // 33 bytes
+	ms.WriteByte(o.outputType)            // 1 byte
+	ms.WriteBytes(o.outputID[:])          // 34 bytes
 	return ms.Bytes()
 }
 
@@ -80,8 +80,8 @@ func (s *Spent) kvStorableKey() (key []byte) {
 
 func (s *Spent) kvStorableValue() (value []byte) {
 	ms := marshalutil.New(36)
-	ms.WriteBytes(s.targetTransactionID[:])
-	ms.WriteUint32(uint32(s.confirmationIndex))
+	ms.WriteBytes(s.targetTransactionID[:])     // 32 bytes
+	ms.WriteUint32(uint32(s.confirmationIndex)) // 4 bytes
 	return ms.Bytes()
 }
 

--- a/pkg/model/utxo/treasury_output.go
+++ b/pkg/model/utxo/treasury_output.go
@@ -36,15 +36,15 @@ type TreasuryOutput struct {
 
 func (t *TreasuryOutput) kvStorableKey() (key []byte) {
 	return marshalutil.New(34).
-		WriteByte(UTXOStoreKeyPrefixTreasuryOutput).
-		WriteBool(t.Spent).
-		WriteBytes(t.MilestoneID[:]).
+		WriteByte(UTXOStoreKeyPrefixTreasuryOutput). // 1 byte
+		WriteBool(t.Spent).                          // 1 byte
+		WriteBytes(t.MilestoneID[:]).                // 32 bytes
 		Bytes()
 }
 
 func (t *TreasuryOutput) kvStorableValue() (value []byte) {
 	return marshalutil.New(8).
-		WriteUint64(t.Amount).
+		WriteUint64(t.Amount). // 8 bytes
 		Bytes()
 }
 

--- a/pkg/model/utxo/unspent.go
+++ b/pkg/model/utxo/unspent.go
@@ -11,10 +11,10 @@ type OutputConsumer func(output *Output) bool
 
 func (o *Output) unspentDatabaseKey() []byte {
 	ms := marshalutil.New(69)
-	ms.WriteByte(UTXOStoreKeyPrefixUnspent)
-	ms.WriteBytes(o.addressBytes())
-	ms.WriteByte(o.outputType)
-	ms.WriteBytes(o.outputID[:])
+	ms.WriteByte(UTXOStoreKeyPrefixUnspent) // 1 byte
+	ms.WriteBytes(o.addressBytes())         // 33 bytes
+	ms.WriteByte(o.outputType)              // 1 byte
+	ms.WriteBytes(o.outputID[:])            // 34 bytes
 	return ms.Bytes()
 }
 

--- a/pkg/node/plugin.go
+++ b/pkg/node/plugin.go
@@ -36,6 +36,9 @@ type Pluggable struct {
 	Params *PluginParams
 	// The function to call to initialize the plugin dependencies.
 	DepsFunc interface{}
+	// PreProvide gets called before the provide stage of node initialization.
+	// This can be used to force disable other pluggables before they get initialized.
+	PreProvide PreProvideFunc
 	// Provide gets called in the provide stage of node initialization.
 	Provide ProvideFunc
 	// Configure gets called in the configure stage of node initialization.

--- a/pkg/node/plugin.go
+++ b/pkg/node/plugin.go
@@ -36,14 +36,17 @@ type Pluggable struct {
 	Params *PluginParams
 	// The function to call to initialize the plugin dependencies.
 	DepsFunc interface{}
+	// InitConfigPars gets called in the init stage of node initialization.
+	// This can be used to provide config parameters even if the pluggable is disabled.
+	InitConfigPars InitConfigParsFunc
 	// PreProvide gets called before the provide stage of node initialization.
 	// This can be used to force disable other pluggables before they get initialized.
 	PreProvide PreProvideFunc
-	// Provide gets called in the provide stage of node initialization.
+	// Provide gets called in the provide stage of node initialization (enabled pluggables only).
 	Provide ProvideFunc
-	// Configure gets called in the configure stage of node initialization.
+	// Configure gets called in the configure stage of node initialization (enabled pluggables only).
 	Configure Callback
-	// Run gets called in the run stage of node initialization.
+	// Run gets called in the run stage of node initialization (enabled pluggables only).
 	Run Callback
 
 	// The logger instance used in this plugin.

--- a/plugins/coordinator/plugin.go
+++ b/plugins/coordinator/plugin.go
@@ -99,12 +99,13 @@ type dependencies struct {
 }
 
 func provide(c *dig.Container) {
-	type selectordeps struct {
+
+	type selectorDeps struct {
 		dig.In
 		NodeConfig *configuration.Configuration `name:"nodeConfig"`
 	}
 
-	if err := c.Provide(func(deps selectordeps) *mselection.HeaviestSelector {
+	if err := c.Provide(func(deps selectorDeps) *mselection.HeaviestSelector {
 		// use the heaviest branch tip selection for the milestones
 		return mselection.New(
 			deps.NodeConfig.Int(CfgCoordinatorTipselectMinHeaviestBranchUnreferencedMessagesThreshold),
@@ -116,7 +117,7 @@ func provide(c *dig.Container) {
 		Plugin.Panic(err)
 	}
 
-	type coordinatordeps struct {
+	type coordinatorDeps struct {
 		dig.In
 		Storage                 *storage.Storage
 		Tangle                  *tangle.Tangle
@@ -128,7 +129,7 @@ func provide(c *dig.Container) {
 		MilestonePublicKeyCount int                          `name:"milestonePublicKeyCount"`
 	}
 
-	if err := c.Provide(func(deps coordinatordeps) *coordinator.Coordinator {
+	if err := c.Provide(func(deps coordinatorDeps) *coordinator.Coordinator {
 
 		initCoordinator := func() (*coordinator.Coordinator, error) {
 

--- a/plugins/dashboard/routes.go
+++ b/plugins/dashboard/routes.go
@@ -15,7 +15,6 @@ import (
 	"golang.org/x/time/rate"
 
 	"github.com/gohornet/hornet/pkg/jwt"
-	"github.com/gohornet/hornet/plugins/restapi"
 )
 
 const (
@@ -86,7 +85,7 @@ func apiMiddlewares() []echo.MiddlewareFunc {
 		return !deps.DashboardAllowedAPIRoute(context)
 	}
 
-	apiBindAddr := deps.NodeConfig.String(restapi.CfgRestAPIBindAddress)
+	apiBindAddr := deps.RestAPIBindAddress
 	_, apiBindPort, err := net.SplitHostPort(apiBindAddr)
 	if err != nil {
 		Plugin.LogFatalf("wrong REST API bind address: %s", err)

--- a/plugins/faucet/plugin.go
+++ b/plugins/faucet/plugin.go
@@ -86,7 +86,7 @@ func provide(c *dig.Container) {
 	faucetAddress := iotago.AddressFromEd25519PubKey(privateKey.Public().(ed25519.PublicKey))
 	faucetSigner := iotago.NewInMemoryAddressSigner(iotago.NewAddressKeysForEd25519Address(&faucetAddress, privateKey))
 
-	type faucetdeps struct {
+	type faucetDeps struct {
 		dig.In
 		Storage          *storage.Storage
 		PowHandler       *pow.Handler
@@ -99,7 +99,7 @@ func provide(c *dig.Container) {
 		MessageProcessor *gossip.MessageProcessor
 	}
 
-	if err := c.Provide(func(deps faucetdeps) *faucet.Faucet {
+	if err := c.Provide(func(deps faucetDeps) *faucet.Faucet {
 		return faucet.New(
 			deps.Storage,
 			deps.NetworkID,
@@ -126,6 +126,7 @@ func provide(c *dig.Container) {
 }
 
 func configure() {
+
 	routeGroup := deps.Echo.Group("/api/plugins/faucet")
 
 	allowedRoutes := map[string][]string{

--- a/plugins/migrator/plugin.go
+++ b/plugins/migrator/plugin.go
@@ -60,12 +60,14 @@ type dependencies struct {
 
 // provide provides the MigratorService as a singleton.
 func provide(c *dig.Container) {
-	type serviceDependencies struct {
+
+	type serviceDeps struct {
 		dig.In
 		NodeConfig *configuration.Configuration `name:"nodeConfig"`
 		Validator  *migrator.Validator
 	}
-	if err := c.Provide(func(deps serviceDependencies) (*migrator.MigratorService, error) {
+
+	if err := c.Provide(func(deps serviceDeps) *migrator.MigratorService {
 
 		maxReceiptEntries := deps.NodeConfig.Int(CfgMigratorReceiptMaxEntries)
 		switch {
@@ -79,13 +81,14 @@ func provide(c *dig.Container) {
 			deps.Validator,
 			deps.NodeConfig.String(CfgMigratorStateFilePath),
 			deps.NodeConfig.Int(CfgMigratorReceiptMaxEntries),
-		), nil
+		)
 	}); err != nil {
 		Plugin.Panic(err)
 	}
 }
 
 func configure() {
+
 	var msIndex *uint32
 	if *bootstrap {
 		msIndex = startIndex
@@ -97,6 +100,7 @@ func configure() {
 }
 
 func run() {
+
 	if err := Plugin.Node.Daemon().BackgroundWorker(Plugin.Name, func(shutdownSignal <-chan struct{}) {
 		Plugin.LogInfof("Starting %s ... done", Plugin.Name)
 		deps.MigratorService.Start(shutdownSignal, func(err error) bool {

--- a/plugins/mqtt/plugin.go
+++ b/plugins/mqtt/plugin.go
@@ -64,12 +64,14 @@ var (
 
 type dependencies struct {
 	dig.In
-	Storage       *storage.Storage
-	Tangle        *tangle.Tangle
-	NodeConfig    *configuration.Configuration `name:"nodeConfig"`
-	BelowMaxDepth int                          `name:"belowMaxDepth"`
-	Bech32HRP     iotago.NetworkPrefix         `name:"bech32HRP"`
-	Echo          *echo.Echo                   `optional:"true"`
+	Storage                               *storage.Storage
+	Tangle                                *tangle.Tangle
+	NodeConfig                            *configuration.Configuration `name:"nodeConfig"`
+	MaxDeltaMsgYoungestConeRootIndexToCMI int                          `name:"maxDeltaMsgYoungestConeRootIndexToCMI"`
+	MaxDeltaMsgOldestConeRootIndexToCMI   int                          `name:"maxDeltaMsgOldestConeRootIndexToCMI"`
+	BelowMaxDepth                         int                          `name:"belowMaxDepth"`
+	Bech32HRP                             iotago.NetworkPrefix         `name:"bech32HRP"`
+	Echo                                  *echo.Echo                   `optional:"true"`
 }
 
 func configure() {

--- a/plugins/mqtt/utils.go
+++ b/plugins/mqtt/utils.go
@@ -11,7 +11,6 @@ import (
 	"github.com/gohornet/hornet/pkg/model/milestone"
 	"github.com/gohornet/hornet/pkg/model/storage"
 	"github.com/gohornet/hornet/pkg/model/utxo"
-	"github.com/gohornet/hornet/plugins/urts"
 	iotago "github.com/iotaledger/iota.go/v2"
 )
 
@@ -139,11 +138,11 @@ func publishMessageMetadata(cachedMetadata *storage.CachedMetadata) {
 				// if the OCRI to CMI delta is over BelowMaxDepth/below-max-depth, then the tip is lazy and should be reattached
 				shouldPromote = false
 				shouldReattach = true
-			} else if (cmi - ycri) > milestone.Index(deps.NodeConfig.Int(urts.CfgTipSelMaxDeltaMsgYoungestConeRootIndexToCMI)) {
+			} else if (cmi - ycri) > milestone.Index(deps.MaxDeltaMsgYoungestConeRootIndexToCMI) {
 				// if the CMI to YCRI delta is over CfgTipSelMaxDeltaMsgYoungestConeRootIndexToCMI, then the tip is lazy and should be promoted
 				shouldPromote = true
 				shouldReattach = false
-			} else if (cmi - ocri) > milestone.Index(deps.NodeConfig.Int(urts.CfgTipSelMaxDeltaMsgOldestConeRootIndexToCMI)) {
+			} else if (cmi - ocri) > milestone.Index(deps.MaxDeltaMsgOldestConeRootIndexToCMI) {
 				// if the OCRI to CMI delta is over CfgTipSelMaxDeltaMsgOldestConeRootIndexToCMI, the tip is semi-lazy and should be promoted
 				shouldPromote = true
 				shouldReattach = false

--- a/plugins/prometheus/database.go
+++ b/plugins/prometheus/database.go
@@ -6,8 +6,6 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 
-	"github.com/gohornet/hornet/core/database"
-
 	"github.com/iotaledger/hive.go/events"
 )
 
@@ -84,7 +82,7 @@ func configureDatabase() {
 
 func collectDatabase() {
 	databaseSizeBytes.Set(0)
-	dbSize, err := directorySize(deps.NodeConfig.String(database.CfgDatabasePath))
+	dbSize, err := directorySize(deps.DatabasePath)
 	if err == nil {
 		databaseSizeBytes.Set(float64(dbSize))
 	}

--- a/plugins/prometheus/plugin.go
+++ b/plugins/prometheus/plugin.go
@@ -65,6 +65,7 @@ type dependencies struct {
 	AppInfo          *app.AppInfo
 	NodeConfig       *configuration.Configuration `name:"nodeConfig"`
 	Database         *database.Database
+	DatabasePath     string `name:"databasePath"`
 	Storage          *storage.Storage
 	ServerMetrics    *metrics.ServerMetrics
 	DatabaseMetrics  *metrics.DatabaseMetrics

--- a/plugins/restapi/v1/control.go
+++ b/plugins/restapi/v1/control.go
@@ -8,7 +8,6 @@ import (
 	"github.com/labstack/gommon/bytes"
 	"github.com/pkg/errors"
 
-	"github.com/gohornet/hornet/core/snapshot"
 	"github.com/gohornet/hornet/pkg/model/milestone"
 	"github.com/gohornet/hornet/pkg/restapi"
 )
@@ -85,7 +84,7 @@ func createSnapshots(c echo.Context) (*createSnapshotsResponse, error) {
 
 	if request.FullIndex != nil {
 		fullIndex = milestone.Index(*request.FullIndex)
-		fullSnapshotFilePath = filepath.Join(filepath.Dir(deps.NodeConfig.String(snapshot.CfgSnapshotsFullPath)), fmt.Sprintf("full_snapshot_%d.bin", fullIndex))
+		fullSnapshotFilePath = filepath.Join(filepath.Dir(deps.SnapshotsFullPath), fmt.Sprintf("full_snapshot_%d.bin", fullIndex))
 
 		// ToDo: abort signal?
 		if err := deps.Snapshot.CreateFullSnapshot(fullIndex, fullSnapshotFilePath, false, nil); err != nil {
@@ -95,7 +94,7 @@ func createSnapshots(c echo.Context) (*createSnapshotsResponse, error) {
 
 	if request.DeltaIndex != nil {
 		deltaIndex = milestone.Index(*request.DeltaIndex)
-		deltaSnapshotFilePath = filepath.Join(filepath.Dir(deps.NodeConfig.String(snapshot.CfgSnapshotsDeltaPath)), fmt.Sprintf("delta_snapshot_%d.bin", deltaIndex))
+		deltaSnapshotFilePath = filepath.Join(filepath.Dir(deps.SnapshotsDeltaPath), fmt.Sprintf("delta_snapshot_%d.bin", deltaIndex))
 
 		// ToDo: abort signal?
 		// if no full snapshot was created, the last existing full snapshot will be used

--- a/plugins/restapi/v1/messages.go
+++ b/plugins/restapi/v1/messages.go
@@ -20,8 +20,6 @@ import (
 	"github.com/gohornet/hornet/pkg/restapi"
 	"github.com/gohornet/hornet/pkg/tipselect"
 	"github.com/gohornet/hornet/pkg/utils"
-	restapiplugin "github.com/gohornet/hornet/plugins/restapi"
-	"github.com/gohornet/hornet/plugins/urts"
 	"github.com/iotaledger/hive.go/objectstorage"
 	iotago "github.com/iotaledger/iota.go/v2"
 )
@@ -94,11 +92,11 @@ func messageMetadataByID(c echo.Context) (*messageMetadataResponse, error) {
 			// if the OCRI to CMI delta is over BelowMaxDepth/below-max-depth, then the tip is lazy and should be reattached
 			shouldPromote = false
 			shouldReattach = true
-		} else if (cmi - ycri) > milestone.Index(deps.NodeConfig.Int(urts.CfgTipSelMaxDeltaMsgYoungestConeRootIndexToCMI)) {
+		} else if (cmi - ycri) > milestone.Index(deps.MaxDeltaMsgYoungestConeRootIndexToCMI) {
 			// if the CMI to YCRI delta is over CfgTipSelMaxDeltaMsgYoungestConeRootIndexToCMI, then the tip is lazy and should be promoted
 			shouldPromote = true
 			shouldReattach = false
-		} else if (cmi - ocri) > milestone.Index(deps.NodeConfig.Int(urts.CfgTipSelMaxDeltaMsgOldestConeRootIndexToCMI)) {
+		} else if (cmi - ocri) > milestone.Index(deps.MaxDeltaMsgOldestConeRootIndexToCMI) {
 			// if the OCRI to CMI delta is over CfgTipSelMaxDeltaMsgOldestConeRootIndexToCMI, the tip is semi-lazy and should be promoted
 			shouldPromote = true
 			shouldReattach = false
@@ -153,7 +151,7 @@ func childrenIDsByID(c echo.Context) (*childrenResponse, error) {
 		return nil, errors.WithMessagef(restapi.ErrInvalidParameter, "invalid message ID: %s, error: %s", messageIDHex, err)
 	}
 
-	maxResults := deps.NodeConfig.Int(restapiplugin.CfgRestAPILimitsMaxResults)
+	maxResults := deps.RestAPILimitsMaxResults
 	childrenMessageIDs := deps.Storage.ChildrenMessageIDs(messageID, objectstorage.WithIteratorMaxIterations(maxResults))
 
 	return &childrenResponse{
@@ -180,7 +178,7 @@ func messageIDsByIndex(c echo.Context) (*messageIDsByIndexResponse, error) {
 		return nil, errors.WithMessage(restapi.ErrInvalidParameter, fmt.Sprintf("query parameter index too long, max. %d bytes but is %d", storage.IndexationIndexLength, len(indexBytes)))
 	}
 
-	maxResults := deps.NodeConfig.Int(restapiplugin.CfgRestAPILimitsMaxResults)
+	maxResults := deps.RestAPILimitsMaxResults
 	indexMessageIDs := deps.Storage.IndexMessageIDs(indexBytes, objectstorage.WithIteratorMaxIterations(maxResults))
 
 	return &messageIDsByIndexResponse{

--- a/plugins/restapi/v1/plugin.go
+++ b/plugins/restapi/v1/plugin.go
@@ -167,24 +167,29 @@ var (
 
 type dependencies struct {
 	dig.In
-	Storage              *storage.Storage
-	Tangle               *tangle.Tangle
-	Manager              *p2p.Manager
-	Service              *gossip.Service
-	UTXO                 *utxo.Manager
-	PoWHandler           *pow.Handler
-	MessageProcessor     *gossip.MessageProcessor
-	Snapshot             *snapshot.Snapshot
-	AppInfo              *app.AppInfo
-	NodeConfig           *configuration.Configuration `name:"nodeConfig"`
-	PeeringConfigManager *p2p.ConfigManager
-	NetworkID            uint64                 `name:"networkId"`
-	NetworkIDName        string                 `name:"networkIdName"`
-	BelowMaxDepth        int                    `name:"belowMaxDepth"`
-	MinPoWScore          float64                `name:"minPoWScore"`
-	Bech32HRP            iotago.NetworkPrefix   `name:"bech32HRP"`
-	TipSelector          *tipselect.TipSelector `optional:"true"`
-	Echo                 *echo.Echo             `optional:"true"`
+	Storage                               *storage.Storage
+	Tangle                                *tangle.Tangle
+	Manager                               *p2p.Manager
+	Service                               *gossip.Service
+	UTXO                                  *utxo.Manager
+	PoWHandler                            *pow.Handler
+	MessageProcessor                      *gossip.MessageProcessor
+	Snapshot                              *snapshot.Snapshot
+	AppInfo                               *app.AppInfo
+	NodeConfig                            *configuration.Configuration `name:"nodeConfig"`
+	PeeringConfigManager                  *p2p.ConfigManager
+	NetworkID                             uint64                 `name:"networkId"`
+	NetworkIDName                         string                 `name:"networkIdName"`
+	MaxDeltaMsgYoungestConeRootIndexToCMI int                    `name:"maxDeltaMsgYoungestConeRootIndexToCMI"`
+	MaxDeltaMsgOldestConeRootIndexToCMI   int                    `name:"maxDeltaMsgOldestConeRootIndexToCMI"`
+	BelowMaxDepth                         int                    `name:"belowMaxDepth"`
+	MinPoWScore                           float64                `name:"minPoWScore"`
+	Bech32HRP                             iotago.NetworkPrefix   `name:"bech32HRP"`
+	RestAPILimitsMaxResults               int                    `name:"restAPILimitsMaxResults"`
+	SnapshotsFullPath                     string                 `name:"snapshotsFullPath"`
+	SnapshotsDeltaPath                    string                 `name:"snapshotsDeltaPath"`
+	TipSelector                           *tipselect.TipSelector `optional:"true"`
+	Echo                                  *echo.Echo             `optional:"true"`
 }
 
 func configure() {

--- a/plugins/restapi/v1/utxo.go
+++ b/plugins/restapi/v1/utxo.go
@@ -13,7 +13,6 @@ import (
 	"github.com/gohornet/hornet/pkg/model/milestone"
 	"github.com/gohornet/hornet/pkg/model/utxo"
 	"github.com/gohornet/hornet/pkg/restapi"
-	restapiplugin "github.com/gohornet/hornet/plugins/restapi"
 	"github.com/iotaledger/hive.go/kvstore"
 	iotago "github.com/iotaledger/iota.go/v2"
 )
@@ -154,7 +153,7 @@ func balanceByEd25519Address(c echo.Context) (*addressBalanceResponse, error) {
 }
 
 func outputsResponse(address iotago.Address, includeSpent bool, filterType *iotago.OutputType) (*addressOutputsResponse, error) {
-	maxResults := deps.NodeConfig.Int(restapiplugin.CfgRestAPILimitsMaxResults)
+	maxResults := deps.RestAPILimitsMaxResults
 
 	opts := []utxo.UTXOIterateOption{
 		utxo.FilterAddress(address),


### PR DESCRIPTION
This PR modifies the node initialization and adds a pre-provide stage, in which plugins can force disable other core modules or plugins.

This way the autopeering entry node can now run in standalone mode again.

It also adds a initConfigPars stage to provide global config parameters via dependency injection, even if the pluggables are disabled. This also further reduces the dependencies between the modules.